### PR TITLE
Add capability guard for backup deletion and add tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -14,6 +14,10 @@ class BJLG_Actions {
      * Supprime un fichier de sauvegarde via AJAX.
      */
     public function handle_delete_backup() {
+        if (!current_user_can(BJLG_CAPABILITY)) {
+            wp_send_json_error(['message' => 'Permission refusée.'], 403);
+        }
+
         check_ajax_referer('bjlg_nonce', 'nonce');
 
         if (empty($_POST['filename'])) {

--- a/backup-jlg/phpunit.xml
+++ b/backup-jlg/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="BJLG Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/backup-jlg/tests/BJLG_ActionsTest.php
+++ b/backup-jlg/tests/BJLG_ActionsTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-actions.php';
+
+final class BJLG_ActionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = true;
+        $_POST = [];
+    }
+
+    public function test_handle_delete_backup_denies_user_without_capability(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = false;
+
+        $actions = new BJLG_Actions();
+
+        try {
+            $actions->handle_delete_backup();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $exception) {
+            $this->assertSame(['message' => 'Permission refusée.'], $exception->data);
+            $this->assertSame(403, $exception->status_code);
+        }
+    }
+}

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+
+if (!defined('BJLG_CAPABILITY')) {
+    define('BJLG_CAPABILITY', 'manage_options');
+}
+
+if (!defined('BJLG_BACKUP_DIR')) {
+    define('BJLG_BACKUP_DIR', sys_get_temp_dir() . '/');
+}
+
+$GLOBALS['bjlg_test_current_user_can'] = true;
+
+if (!class_exists('BJLG_Test_JSON_Response')) {
+    class BJLG_Test_JSON_Response extends RuntimeException {
+        /** @var mixed */
+        public $data;
+
+        /** @var int|null */
+        public $status_code;
+
+        /**
+         * @param mixed     $data
+         * @param int|null  $status_code
+         */
+        public function __construct($data = null, $status_code = null) {
+            $this->data = $data;
+            $this->status_code = $status_code;
+            parent::__construct('JSON response');
+        }
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback) {
+        // No-op for tests.
+    }
+}
+
+if (!function_exists('check_ajax_referer')) {
+    function check_ajax_referer($action = -1, $query_arg = false, $die = true) {
+        return true;
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($capability) {
+        return $GLOBALS['bjlg_test_current_user_can'] ?? false;
+    }
+}
+
+if (!function_exists('sanitize_file_name')) {
+    function sanitize_file_name($filename) {
+        return preg_replace('/[^A-Za-z0-9\\-_.]/', '', (string) $filename);
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        return $value;
+    }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null, $status_code = null) {
+        throw new BJLG_Test_JSON_Response($data, $status_code);
+    }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null, $status_code = null) {
+        throw new BJLG_Test_JSON_Response($data, $status_code);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the delete-backup AJAX handler verifies the BJLG capability and returns a JSON error when missing
- introduce a PHPUnit configuration and bootstrap stubbing WordPress helpers for isolated tests
- cover the unauthorized deletion path with a dedicated unit test

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*
- ./vendor-bjlg/bin/phpunit *(not run: missing after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c874905684832ea12401b2f9c2093c