### PR TITLE
Add newline after plugin bootstrap call

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -146,3 +146,4 @@ final class BJLG_Plugin {
 
 // Lancement du plugin
 BJLG_Plugin::instance();
+


### PR DESCRIPTION
## Summary
- add a blank line after the BJLG_Plugin::instance() bootstrap call to ensure the file ends with an empty line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c878121d14832ea515c4d241986bb3