### PR TITLE
Fix API key usage updates and add tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -282,22 +282,24 @@ class BJLG_REST_API {
     private function verify_api_key($api_key) {
         $stored_keys = get_option('bjlg_api_keys', []);
         
-        foreach ($stored_keys as $key_data) {
+        foreach ($stored_keys as &$key_data) {
             if (hash_equals($key_data['key'], $api_key)) {
                 // Vérifier l'expiration
                 if (isset($key_data['expires']) && $key_data['expires'] < time()) {
                     return false;
                 }
-                
+
                 // Mettre à jour l'utilisation
                 $key_data['last_used'] = time();
                 $key_data['usage_count'] = ($key_data['usage_count'] ?? 0) + 1;
                 update_option('bjlg_api_keys', $stored_keys);
-                
+
                 return true;
             }
         }
-        
+
+        unset($key_data);
+
         return false;
     }
     

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-rest-api.php';
+
+final class BJLG_REST_APITest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    public function test_verify_api_key_increments_usage_count(): void
+    {
+        update_option('bjlg_api_keys', [
+            [
+                'key' => 'test-key',
+                'usage_count' => 2,
+                'last_used' => 123,
+            ],
+        ]);
+
+        $api = new BJLG_REST_API();
+        $beforeTime = time();
+
+        $method = new ReflectionMethod(BJLG_REST_API::class, 'verify_api_key');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($api, 'test-key');
+
+        $this->assertTrue($result);
+
+        $storedKeys = get_option('bjlg_api_keys');
+
+        $this->assertSame(3, $storedKeys[0]['usage_count']);
+        $this->assertArrayHasKey('last_used', $storedKeys[0]);
+        $this->assertGreaterThanOrEqual($beforeTime, $storedKeys[0]['last_used']);
+    }
+}

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -53,6 +53,23 @@ if (!function_exists('current_user_can')) {
     }
 }
 
+if (!isset($GLOBALS['bjlg_test_options'])) {
+    $GLOBALS['bjlg_test_options'] = [];
+}
+
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        return $GLOBALS['bjlg_test_options'][$option] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($option, $value) {
+        $GLOBALS['bjlg_test_options'][$option] = $value;
+        return true;
+    }
+}
+
 if (!function_exists('sanitize_file_name')) {
     function sanitize_file_name($filename) {
         return preg_replace('/[^A-Za-z0-9\\-_.]/', '', (string) $filename);


### PR DESCRIPTION
## Summary
- iterate over stored API keys by reference so usage counters persist after verification
- provide test stubs for `get_option` and `update_option` to emulate WordPress storage
- cover API key verification usage counter updates with a new PHPUnit test

## Testing
- `composer test` *(fails: phpunit not found because dependencies could not be installed without external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c878165c9c832eb4031968702fb7c0