### PR TITLE
Secure SQL export escaping and add tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -441,20 +441,65 @@ class BJLG_Performance {
         foreach ($rows as $row) {
             $row_values = [];
             foreach ($row as $value) {
-                if (is_null($value)) {
-                    $row_values[] = 'NULL';
-                } else {
-                    global $wpdb;
-                    $row_values[] = "'" . $wpdb->_real_escape($value) . "'";
-                }
+                $row_values[] = $this->format_sql_value($value);
             }
             $values[] = '(' . implode(', ', $row_values) . ')';
         }
-        
+
         $insert = "INSERT INTO `{$table}` ({$columns_str}) VALUES\n";
         $insert .= implode(",\n", $values) . ";\n\n";
-        
+
         fwrite($handle, $insert);
+    }
+
+    /**
+     * Prépare une valeur pour une instruction SQL INSERT.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    private function format_sql_value($value) {
+        if (is_null($value)) {
+            return 'NULL';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_string($value)) {
+            if ($this->is_binary_string($value)) {
+                return '0x' . bin2hex($value);
+            }
+
+            return "'" . esc_sql($value) . "'";
+        }
+
+        $serialized = function_exists('maybe_serialize') ? maybe_serialize($value) : serialize($value);
+
+        return "'" . esc_sql($serialized) . "'";
+    }
+
+    /**
+     * Détermine si une chaîne contient des données binaires.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    private function is_binary_string($value) {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        if (strpos($value, "\0") !== false) {
+            return true;
+        }
+
+        return @preg_match('//u', $value) !== 1;
     }
     
     /**

--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+
+final class BJLG_BackupDatabaseTest extends TestCase
+{
+    public function test_create_insert_statement_escapes_special_and_binary_values(): void
+    {
+        $backup = new BJLG_Backup();
+
+        $method = new ReflectionMethod(BJLG_Backup::class, 'create_insert_statement');
+        $method->setAccessible(true);
+
+        $rows = [
+            [
+                'id' => 1,
+                'name' => "O'Reilly",
+                'payload' => "Binary\0Data",
+                'comment' => "'; DROP TABLE users; --",
+                'injection' => "' OR '1'='1",
+                'emoji' => "emoji 😃",
+                'nullable' => null,
+            ],
+        ];
+
+        $sql = $method->invoke($backup, 'wp_test', $rows);
+
+        $this->assertStringContainsString("INSERT INTO `wp_test` (`id`, `name`, `payload`, `comment`, `injection`, `emoji`, `nullable`) VALUES", $sql);
+        $this->assertStringContainsString("'O\\'Reilly'", $sql);
+        $this->assertStringContainsString('0x42696e6172790044617461', $sql);
+        $this->assertStringContainsString("'\\'; DROP TABLE users; --'", $sql);
+        $this->assertStringContainsString("'\\' OR \\'1\\'=\\'1'", $sql);
+        $this->assertStringContainsString("'emoji 😃'", $sql);
+        $this->assertStringContainsString(', NULL)', $sql);
+        $this->assertStringNotContainsString("' OR '1'='1", $sql);
+    }
+}

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -53,6 +53,22 @@ if (!function_exists('current_user_can')) {
     }
 }
 
+if (!function_exists('esc_sql')) {
+    /**
+     * Simplified esc_sql implementation for tests.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    function esc_sql($value) {
+        if (is_array($value)) {
+            return array_map('esc_sql', $value);
+        }
+
+        return addslashes((string) $value);
+    }
+}
+
 if (!function_exists('sanitize_file_name')) {
     function sanitize_file_name($filename) {
         return preg_replace('/[^A-Za-z0-9\\-_.]/', '', (string) $filename);


### PR DESCRIPTION
## Summary
- replace direct usage of `$wpdb->_real_escape` with a SQL value formatter relying on `esc_sql` and binary detection
- reuse the formatter for the performance exporter to keep database dumps safe for null and binary values
- add a unit test covering special characters, binary payloads, and injection attempts plus a bootstrap `esc_sql` helper

## Testing
- php -l backup-jlg/includes/class-bjlg-backup.php
- php -l backup-jlg/includes/class-bjlg-performance.php
- php -l backup-jlg/tests/bootstrap.php
- php -l backup-jlg/tests/BJLG_BackupDatabaseTest.php
- composer install *(fails: curl error 56, CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c8783177e4832ebe936cc3a94de519