### PR TITLE
Update API key tracking and add tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -282,22 +282,26 @@ class BJLG_REST_API {
     private function verify_api_key($api_key) {
         $stored_keys = get_option('bjlg_api_keys', []);
         
-        foreach ($stored_keys as $key_data) {
+        foreach ($stored_keys as $index => &$key_data) {
             if (hash_equals($key_data['key'], $api_key)) {
                 // Vérifier l'expiration
                 if (isset($key_data['expires']) && $key_data['expires'] < time()) {
+                    unset($key_data);
                     return false;
                 }
-                
+
                 // Mettre à jour l'utilisation
                 $key_data['last_used'] = time();
                 $key_data['usage_count'] = ($key_data['usage_count'] ?? 0) + 1;
+                $stored_keys[$index] = $key_data;
                 update_option('bjlg_api_keys', $stored_keys);
-                
+
+                unset($key_data);
                 return true;
             }
         }
-        
+
+        unset($key_data);
         return false;
     }
     

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -16,6 +16,7 @@ if (!defined('BJLG_BACKUP_DIR')) {
 $GLOBALS['bjlg_test_current_user_can'] = true;
 $GLOBALS['bjlg_test_transients'] = [];
 $GLOBALS['bjlg_test_scheduled_events'] = [];
+$GLOBALS['bjlg_test_options'] = [];
 
 if (!class_exists('BJLG_Test_JSON_Response')) {
     class BJLG_Test_JSON_Response extends RuntimeException {
@@ -52,6 +53,19 @@ if (!function_exists('check_ajax_referer')) {
 if (!function_exists('current_user_can')) {
     function current_user_can($capability) {
         return $GLOBALS['bjlg_test_current_user_can'] ?? false;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        return $GLOBALS['bjlg_test_options'][$option] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($option, $value) {
+        $GLOBALS['bjlg_test_options'][$option] = $value;
+        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure API key verification iterates stored keys by reference so usage metadata persists
- persist updated key data back to the stored options when usage is recorded
- add stubs for WordPress option helpers in the test bootstrap and cover API key usage updates with PHPUnit

## Testing
- php -l backup-jlg/includes/class-bjlg-rest-api.php
- php -l backup-jlg/tests/BJLG_REST_APITest.php
- php -l backup-jlg/tests/bootstrap.php


------
https://chatgpt.com/codex/tasks/task_e_68c930ba6f1c832eae51ba8816565673