### PR TITLE
Refactor restore pre-backup to use injected backup manager

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -100,7 +100,11 @@ final class BJLG_Plugin {
     }
     
     private function init_services() {
-        new BJLG_Admin(); new BJLG_Actions(); new BJLG_Backup(); new BJLG_Restore();
+        new BJLG_Admin();
+        new BJLG_Actions();
+
+        $backup_manager = new BJLG_Backup();
+        new BJLG_Restore($backup_manager);
         new BJLG_Scheduler(); new BJLG_Cleanup(); new BJLG_Encryption(); new BJLG_Health_Check();
         new BJLG_Diagnostics(); new BJLG_Webhooks(); new BJLG_Incremental(); new BJLG_Performance();
         new BJLG_REST_API(); new BJLG_Settings();

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -479,7 +479,7 @@ class BJLG_Backup {
     /**
      * Ajoute récursivement un dossier au ZIP
      */
-    private function add_folder_to_zip(&$zip, $folder, $zip_path, $exclude = [], $incremental = false, $modified_files = []) {
+    public function add_folder_to_zip(&$zip, $folder, $zip_path, $exclude = [], $incremental = false, $modified_files = []) {
         $handle = opendir($folder);
         
         while (($file = readdir($handle)) !== false) {
@@ -540,7 +540,7 @@ class BJLG_Backup {
     /**
      * Exporte la base de données (méthode publique pour la sauvegarde pré-restauration)
      */
-    private function dump_database($filepath) {
+    public function dump_database($filepath) {
         global $wpdb;
         
         $handle = fopen($filepath, 'w');


### PR DESCRIPTION
## Summary
- expose BJLG_Backup::dump_database and ::add_folder_to_zip for reuse
- inject a BJLG_Backup instance into BJLG_Restore to remove Reflection usage
- update plugin bootstrap to pass the backup manager to BJLG_Restore

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c8afe44832ea42ad2ffc510acfe