### PR TITLE
Handle inaccessible directories when adding to ZIP

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -480,8 +480,12 @@ class BJLG_Backup {
      * Ajoute récursivement un dossier au ZIP
      */
     public function add_folder_to_zip(&$zip, $folder, $zip_path, $exclude = [], $incremental = false, $modified_files = []) {
-        $handle = opendir($folder);
-        
+        $handle = @opendir($folder);
+        if ($handle === false) {
+            BJLG_Debug::log("Impossible d'ouvrir le répertoire : $folder");
+            return;
+        }
+
         while (($file = readdir($handle)) !== false) {
             if ($file == '.' || $file == '..') continue;
             

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('BJLG_Debug')) {
+    class BJLG_Debug
+    {
+        /** @var array<int, string> */
+        public static $logs = [];
+
+        /**
+         * @param mixed $message
+         */
+        public static function log($message): void
+        {
+            self::$logs[] = (string) $message;
+        }
+    }
+}
+
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+
+final class BJLG_BackupFilesystemTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (class_exists('BJLG_Debug')) {
+            BJLG_Debug::$logs = [];
+        }
+    }
+
+    public function test_add_folder_to_zip_logs_and_returns_when_directory_cannot_be_opened(): void
+    {
+        $backup = new BJLG_Backup();
+
+        $zip = new class extends ZipArchive {
+            /** @var array<int, array{0: string, 1: string}> */
+            public $addedFiles = [];
+
+            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            {
+                $this->addedFiles[] = [$filepath, $entryname];
+                return true;
+            }
+        };
+
+        $nonexistentFolder = sys_get_temp_dir() . '/bjlg-missing-' . uniqid('', true);
+
+        $backup->add_folder_to_zip($zip, $nonexistentFolder, 'wp-content/plugins/');
+
+        $this->assertSame([], $zip->addedFiles);
+        $this->assertNotEmpty(BJLG_Debug::$logs);
+        $this->assertStringContainsString($nonexistentFolder, BJLG_Debug::$logs[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- log and stop when add_folder_to_zip cannot open a directory before iterating
- add a unit test covering the inaccessible directory scenario to ensure logging occurs

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*
- ./vendor-bjlg/bin/phpunit *(not run: file not found because dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c966efe328832eb8fcb6a74b77b375