### PR TITLE
Handle directory opening failures

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -71,9 +71,42 @@ class BJLG_Restore {
 
             // Ajout des dossiers
             $upload_dir_info = wp_get_upload_dir();
-            $backup_manager->add_folder_to_zip($zip, WP_PLUGIN_DIR, 'wp-content/plugins/', []);
-            $backup_manager->add_folder_to_zip($zip, get_theme_root(), 'wp-content/themes/', []);
-            $backup_manager->add_folder_to_zip($zip, $upload_dir_info['basedir'], 'wp-content/uploads/', []);
+            $directories = [
+                [
+                    'path' => WP_PLUGIN_DIR,
+                    'zip' => 'wp-content/plugins/',
+                    'label' => 'plugins',
+                ],
+                [
+                    'path' => get_theme_root(),
+                    'zip' => 'wp-content/themes/',
+                    'label' => 'thèmes',
+                ],
+                [
+                    'path' => $upload_dir_info['basedir'],
+                    'zip' => 'wp-content/uploads/',
+                    'label' => 'uploads',
+                ],
+            ];
+
+            foreach ($directories as $directory) {
+                try {
+                    $backup_manager->add_folder_to_zip($zip, $directory['path'], $directory['zip'], []);
+                } catch (Exception $exception) {
+                    $message = sprintf(
+                        "Impossible d'ajouter le répertoire %s (%s) à la sauvegarde de sécurité : %s",
+                        $directory['label'],
+                        $directory['path'],
+                        $exception->getMessage()
+                    );
+
+                    if (class_exists('BJLG_Debug')) {
+                        BJLG_Debug::log($message);
+                    }
+
+                    throw new Exception($message, 0, $exception);
+                }
+            }
 
             $zip->close();
             

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -30,7 +30,7 @@ final class BJLG_BackupFilesystemTest extends TestCase
         }
     }
 
-    public function test_add_folder_to_zip_logs_and_returns_when_directory_cannot_be_opened(): void
+    public function test_add_folder_to_zip_throws_exception_when_directory_cannot_be_opened(): void
     {
         $backup = new BJLG_Backup();
 
@@ -47,7 +47,12 @@ final class BJLG_BackupFilesystemTest extends TestCase
 
         $nonexistentFolder = sys_get_temp_dir() . '/bjlg-missing-' . uniqid('', true);
 
-        $backup->add_folder_to_zip($zip, $nonexistentFolder, 'wp-content/plugins/');
+        try {
+            $backup->add_folder_to_zip($zip, $nonexistentFolder, 'wp-content/plugins/');
+            $this->fail('Une exception aurait dû être levée lorsque le répertoire est introuvable.');
+        } catch (Exception $exception) {
+            $this->assertStringContainsString($nonexistentFolder, $exception->getMessage());
+        }
 
         $this->assertSame([], $zip->addedFiles);
         $this->assertNotEmpty(BJLG_Debug::$logs);


### PR DESCRIPTION
## Summary
- throw explicit exceptions when directories cannot be opened during zipping instead of silencing errors
- propagate directory-related failures to backup and restore flows with detailed logging
- adjust filesystem unit test to reflect the new exception-based behavior

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*
- ./vendor-bjlg/bin/phpunit *(not run: binary not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68c9b2a750d4832ea26c2e900d9ad645