### PR TITLE
Namespace plugin classes and update references

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -100,14 +100,14 @@ final class BJLG_Plugin {
     }
     
     private function init_services() {
-        new BJLG_Admin();
-        new BJLG_Actions();
+        new BJLG\BJLG_Admin();
+        new BJLG\BJLG_Actions();
 
-        $backup_manager = new BJLG_Backup();
-        new BJLG_Restore($backup_manager);
-        new BJLG_Scheduler(); new BJLG_Cleanup(); new BJLG_Encryption(); new BJLG_Health_Check();
-        new BJLG_Diagnostics(); new BJLG_Webhooks(); new BJLG_Incremental(); new BJLG_Performance();
-        new BJLG_REST_API(); new BJLG_Settings();
+        $backup_manager = new BJLG\BJLG_Backup();
+        new BJLG\BJLG_Restore($backup_manager);
+        new BJLG\BJLG_Scheduler(); new BJLG\BJLG_Cleanup(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
+        new BJLG\BJLG_Diagnostics(); new BJLG\BJLG_Webhooks(); new BJLG\BJLG_Incremental(); new BJLG\BJLG_Performance();
+        new BJLG\BJLG_REST_API(); new BJLG\BJLG_Settings();
     }
     
     public function enqueue_admin_assets($hook) {
@@ -129,7 +129,7 @@ final class BJLG_Plugin {
     public function activate() {
         require_once BJLG_INCLUDES_DIR . 'class-bjlg-debug.php';
         require_once BJLG_INCLUDES_DIR . 'class-bjlg-history.php';
-        BJLG_History::create_table();
+        BJLG\BJLG_History::create_table();
 
         if (!is_dir(BJLG_BACKUP_DIR)) {
             wp_mkdir_p(BJLG_BACKUP_DIR);

--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -1,5 +1,11 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Actions AJAX (suppression de sauvegarde, etc.)
@@ -68,14 +74,14 @@ class BJLG_Actions {
                 throw new Exception("Impossible de supprimer le fichier.");
             }
 
-            if (class_exists('BJLG_History')) {
+            if (class_exists(BJLG_History::class)) {
                 BJLG_History::log('backup_deleted', 'success', 'Fichier : ' . $filename);
             }
 
             wp_send_json_success(['message' => 'Fichier supprimé avec succès.']);
 
         } catch (Exception $e) {
-            if (class_exists('BJLG_History')) {
+            if (class_exists(BJLG_History::class)) {
                 BJLG_History::log('backup_deleted', 'failure', 'Fichier : ' . $filename . ' - Erreur : ' . $e->getMessage());
             }
             wp_send_json_error(['message' => $e->getMessage()]);

--- a/backup-jlg/includes/class-bjlg-admin-advanced.php
+++ b/backup-jlg/includes/class-bjlg-admin-advanced.php
@@ -1,12 +1,16 @@
 <?php
+namespace BJLG;
+
 /**
  * Advanced Admin Features for Backup JLG
- * 
+ *
  * @package Backup_JLG
  * @since 2.0.0
  */
 
-if (!defined('ABSPATH')) exit;
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Advanced admin functionality (placeholder for future features)

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la création et l'affichage de l'interface d'administration du plugin.
@@ -18,7 +22,7 @@ class BJLG_Admin {
      * Charge les classes de destination disponibles.
      */
     private function load_destinations() {
-        if (class_exists('BJLG_Google_Drive')) {
+        if (class_exists(BJLG_Google_Drive::class)) {
             $this->destinations['google_drive'] = new BJLG_Google_Drive();
         }
     }
@@ -270,7 +274,7 @@ class BJLG_Admin {
      * Section : Historique
      */
     private function render_history_section() {
-        $history = class_exists('BJLG_History') ? BJLG_History::get_history(50) : [];
+        $history = class_exists(BJLG_History::class) ? BJLG_History::get_history(50) : [];
         ?>
         <div class="bjlg-section">
             <h2>Historique des 50 dernières actions</h2>
@@ -349,7 +353,7 @@ class BJLG_Admin {
         $cleanup_settings = get_option('bjlg_cleanup_settings', ['by_number' => 3, 'by_age' => 0]);
         $schedule_settings = get_option('bjlg_schedule_settings', ['recurrence' => 'weekly', 'day' => 'sunday', 'time' => '23:59']);
         $wl_settings = get_option('bjlg_whitelabel_settings', ['plugin_name' => '', 'hide_from_non_admins' => false]);
-        $webhook_key = class_exists('BJLG_Webhooks') ? BJLG_Webhooks::get_webhook_key() : '';
+        $webhook_key = class_exists(BJLG_Webhooks::class) ? BJLG_Webhooks::get_webhook_key() : '';
         ?>
         <div class="bjlg-section">
             <h2>Configuration du Plugin</h2>
@@ -473,13 +477,13 @@ class BJLG_Admin {
             <p class="description">
                 Pour activer : ajoutez <code>define('BJLG_DEBUG', true);</code> dans votre <code>wp-config.php</code>
             </p>
-            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists('BJLG_Debug') ? BJLG_Debug::get_plugin_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
+            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_plugin_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
 
             <h3>Journal d'erreurs PHP de WordPress</h3>
             <p class="description">
                 Pour activer : ajoutez <code>define('WP_DEBUG_LOG', true);</code> dans votre <code>wp-config.php</code>
             </p>
-            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists('BJLG_Debug') ? BJLG_Debug::get_wp_error_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
+            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_wp_error_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
             
             <h3>Outils de Support</h3>
             <p>Générez un pack de support contenant les journaux et les informations système pour faciliter le diagnostic.</p>

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -1,5 +1,12 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+use ZipArchive;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère le processus complet de création de sauvegardes
@@ -25,10 +32,10 @@ class BJLG_Backup {
      * Initialise les handlers
      */
     public function init_handlers() {
-        if (class_exists('BJLG_Performance')) {
+        if (class_exists(BJLG_Performance::class)) {
             $this->performance_optimizer = new BJLG_Performance();
         }
-        if (class_exists('BJLG_Encryption')) {
+        if (class_exists(BJLG_Encryption::class)) {
             $this->encryption_handler = new BJLG_Encryption();
         }
     }

--- a/backup-jlg/includes/class-bjlg-cleanup.php
+++ b/backup-jlg/includes/class-bjlg-cleanup.php
@@ -1,5 +1,11 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la tâche cron quotidienne de nettoyage des sauvegardes et des logs.

--- a/backup-jlg/includes/class-bjlg-debug.php
+++ b/backup-jlg/includes/class-bjlg-debug.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Classe statique pour la gestion des logs de débogage.

--- a/backup-jlg/includes/class-bjlg-diagnostics.php
+++ b/backup-jlg/includes/class-bjlg-diagnostics.php
@@ -1,5 +1,12 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+use ZipArchive;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la création d'un pack de support pour le diagnostic.

--- a/backup-jlg/includes/class-bjlg-encryption.php
+++ b/backup-jlg/includes/class-bjlg-encryption.php
@@ -1,10 +1,16 @@
 <?php
+namespace BJLG;
+
 /**
  * Classe de chiffrement AES-256 pour sécuriser les sauvegardes
  * Fichier : includes/class-bjlg-encryption.php
  */
 
-if (!defined('ABSPATH')) exit;
+use Exception;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 class BJLG_Encryption {
     

--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère les diagnostics et le bilan de santé du système et du plugin.

--- a/backup-jlg/includes/class-bjlg-history.php
+++ b/backup-jlg/includes/class-bjlg-history.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la table d'historique (audit trail) pour toutes les actions du plugin.

--- a/backup-jlg/includes/class-bjlg-incremental.php
+++ b/backup-jlg/includes/class-bjlg-incremental.php
@@ -1,10 +1,17 @@
 <?php
+namespace BJLG;
+
 /**
  * Classe pour gérer les sauvegardes incrémentales
  * Fichier : includes/class-bjlg-incremental.php
  */
 
-if (!defined('ABSPATH')) exit;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 class BJLG_Incremental {
     

--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -1,10 +1,19 @@
 <?php
+namespace BJLG;
+
 /**
  * Optimisation des performances avec multi-threading et traitement parallèle
  * Fichier : includes/class-bjlg-performance.php
  */
 
-if (!defined('ABSPATH')) exit;
+use Exception;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ZipArchive;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 class BJLG_Performance {
     

--- a/backup-jlg/includes/class-bjlg-rate-limiter.php
+++ b/backup-jlg/includes/class-bjlg-rate-limiter.php
@@ -1,10 +1,14 @@
 <?php
+namespace BJLG;
+
 /**
  * Gère la limitation de taux pour l'API REST
  * Fichier : includes/class-bjlg-rate-limiter.php
  */
 
-if (!defined('ABSPATH')) exit;
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 class BJLG_Rate_Limiter {
 

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1,10 +1,17 @@
 <?php
+namespace BJLG;
+
 /**
  * API REST pour Backup JLG
  * Fichier : includes/class-bjlg-rest-api.php
  */
 
-if (!defined('ABSPATH')) exit;
+use WP_Error;
+use ZipArchive;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 class BJLG_REST_API {
     
@@ -19,7 +26,7 @@ class BJLG_REST_API {
         add_action('add_option_bjlg_api_keys', [$this, 'handle_api_keys_added'], 10, 2);
 
         // Initialiser le rate limiter
-        if (class_exists('BJLG_Rate_Limiter')) {
+        if (class_exists(BJLG_Rate_Limiter::class)) {
             $this->rate_limiter = new BJLG_Rate_Limiter();
         }
     }

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -1,5 +1,12 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+use ZipArchive;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 require_once __DIR__ . '/class-bjlg-backup.php';
 
@@ -16,7 +23,7 @@ class BJLG_Restore {
     private $backup_manager;
 
     public function __construct($backup_manager = null) {
-        if ($backup_manager === null && class_exists('BJLG_Backup')) {
+        if ($backup_manager === null && class_exists(BJLG_Backup::class)) {
             $backup_manager = new BJLG_Backup();
         }
 
@@ -162,7 +169,7 @@ class BJLG_Restore {
         try {
             $encrypted_password = $this->encrypt_password_for_transient($password);
         } catch (Exception $exception) {
-            if (class_exists('BJLG_Debug')) {
+            if (class_exists(BJLG_Debug::class)) {
                 BJLG_Debug::log('Échec du chiffrement du mot de passe de restauration : ' . $exception->getMessage(), 'error');
             }
             wp_send_json_error(['message' => 'Impossible de sécuriser le mot de passe fourni.']);
@@ -224,7 +231,7 @@ class BJLG_Restore {
             try {
                 $password = $this->decrypt_password_from_transient($encrypted_password);
             } catch (Exception $exception) {
-                if (class_exists('BJLG_Debug')) {
+                if (class_exists(BJLG_Debug::class)) {
                     BJLG_Debug::log("ERREUR: Échec du déchiffrement du mot de passe pour la tâche {$task_id} : " . $exception->getMessage(), 'error');
                 }
             }

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la planification avancée des sauvegardes automatiques.

--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -1,5 +1,11 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+use Exception;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la sauvegarde de tous les réglages du plugin via une seule action AJAX.

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Gère la création et l'écoute du webhook pour déclencher les sauvegardes à distance.

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -1,10 +1,14 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Intégration Google Drive (future version).
  */
-if (interface_exists('BJLG_Destination_Interface')) {
+if (interface_exists(BJLG_Destination_Interface::class)) {
 
     class BJLG_Google_Drive implements BJLG_Destination_Interface {
 

--- a/backup-jlg/includes/destinations/interface-bjlg-destination.php
+++ b/backup-jlg/includes/destinations/interface-bjlg-destination.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) exit;
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /**
  * Contrat pour toutes les destinations de sauvegarde.

--- a/backup-jlg/tests/BJLG_ActionsTest.php
+++ b/backup-jlg/tests/BJLG_ActionsTest.php
@@ -17,7 +17,7 @@ final class BJLG_ActionsTest extends TestCase
     {
         $GLOBALS['bjlg_test_current_user_can'] = false;
 
-        $actions = new BJLG_Actions();
+        $actions = new BJLG\BJLG_Actions();
 
         try {
             $actions->handle_delete_backup();

--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -13,7 +13,7 @@ if (!function_exists('get_site_url')) {
     }
 }
 
-if (!class_exists('BJLG_Debug')) {
+if (!class_exists('BJLG\\BJLG_Debug')) {
     class BJLG_Debug
     {
         /** @var array<int, string> */
@@ -23,6 +23,8 @@ if (!class_exists('BJLG_Debug')) {
             self::$logs[] = (string) $message;
         }
     }
+
+    class_alias('BJLG_Debug', 'BJLG\\BJLG_Debug');
 }
 
 require_once __DIR__ . '/../includes/class-bjlg-backup.php';
@@ -31,9 +33,9 @@ final class BJLG_BackupDatabaseTest extends TestCase
 {
     public function test_create_insert_statement_escapes_special_and_binary_values(): void
     {
-        $backup = new BJLG_Backup();
+        $backup = new BJLG\BJLG_Backup();
 
-        $method = new ReflectionMethod(BJLG_Backup::class, 'create_insert_statement');
+        $method = new ReflectionMethod(BJLG\BJLG_Backup::class, 'create_insert_statement');
         $method->setAccessible(true);
 
         $rows = [
@@ -62,7 +64,7 @@ final class BJLG_BackupDatabaseTest extends TestCase
 
     public function test_backup_database_streams_content_into_zip_via_temp_file(): void
     {
-        $backup = new BJLG_Backup();
+        $backup = new BJLG\BJLG_Backup();
 
         $zip = new class extends ZipArchive {
             /** @var array<int, array{0: string, 1: string}> */
@@ -120,7 +122,7 @@ final class BJLG_BackupDatabaseTest extends TestCase
             }
         };
 
-        $method = new ReflectionMethod(BJLG_Backup::class, 'backup_database');
+        $method = new ReflectionMethod(BJLG\BJLG_Backup::class, 'backup_database');
         $method->setAccessible(true);
         $method->invoke($backup, $zip, false);
 

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-if (!class_exists('BJLG_Debug')) {
+if (!class_exists('BJLG\\BJLG_Debug')) {
     class BJLG_Debug
     {
         /** @var array<int, string> */
@@ -17,6 +17,8 @@ if (!class_exists('BJLG_Debug')) {
             self::$logs[] = (string) $message;
         }
     }
+
+    class_alias('BJLG_Debug', 'BJLG\\BJLG_Debug');
 }
 
 require_once __DIR__ . '/../includes/class-bjlg-backup.php';
@@ -25,14 +27,14 @@ final class BJLG_BackupFilesystemTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (class_exists('BJLG_Debug')) {
+        if (class_exists('BJLG\\BJLG_Debug')) {
             BJLG_Debug::$logs = [];
         }
     }
 
     public function test_add_folder_to_zip_logs_and_returns_when_directory_cannot_be_opened(): void
     {
-        $backup = new BJLG_Backup();
+        $backup = new BJLG\BJLG_Backup();
 
         $zip = new class extends ZipArchive {
             /** @var array<int, array{0: string, 1: string}> */

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -13,7 +13,7 @@ final class BJLG_REST_APITest extends TestCase
 {
     public function test_verify_jwt_token_returns_false_for_invalid_signature(): void
     {
-        $api = new BJLG_REST_API();
+        $api = new BJLG\BJLG_REST_API();
 
         $header = ['typ' => 'JWT', 'alg' => 'HS256'];
         $payload = [
@@ -41,7 +41,7 @@ final class BJLG_REST_APITest extends TestCase
 
         $token = $base64Header . '.' . $base64Payload . '.' . $invalidSignature;
 
-        $reflection = new ReflectionClass(BJLG_REST_API::class);
+        $reflection = new ReflectionClass(BJLG\BJLG_REST_API::class);
         $method = $reflection->getMethod('verify_jwt_token');
         $method->setAccessible(true);
 
@@ -52,7 +52,7 @@ final class BJLG_REST_APITest extends TestCase
     {
         $GLOBALS['bjlg_test_options'] = [];
 
-        $api = new BJLG_REST_API();
+        $api = new BJLG\BJLG_REST_API();
 
         $api_key = 'test-api-key';
         $hashed_key = wp_hash_password($api_key);
@@ -65,7 +65,7 @@ final class BJLG_REST_APITest extends TestCase
             'last_used' => $initial_last_used,
         ]]);
 
-        $reflection = new ReflectionClass(BJLG_REST_API::class);
+        $reflection = new ReflectionClass(BJLG\BJLG_REST_API::class);
         $method = $reflection->getMethod('verify_api_key');
         $method->setAccessible(true);
 
@@ -85,7 +85,7 @@ final class BJLG_REST_APITest extends TestCase
     {
         $GLOBALS['bjlg_test_options'] = [];
 
-        $api = new BJLG_REST_API();
+        $api = new BJLG\BJLG_REST_API();
 
         $api_key = 'legacy-api-key';
 
@@ -94,7 +94,7 @@ final class BJLG_REST_APITest extends TestCase
             'usage_count' => 0,
         ]]);
 
-        $reflection = new ReflectionClass(BJLG_REST_API::class);
+        $reflection = new ReflectionClass(BJLG\BJLG_REST_API::class);
         $method = $reflection->getMethod('verify_api_key');
         $method->setAccessible(true);
 
@@ -108,7 +108,7 @@ final class BJLG_REST_APITest extends TestCase
 
     public function test_filter_api_keys_before_save_hashes_plain_keys(): void
     {
-        $api = new BJLG_REST_API();
+        $api = new BJLG\BJLG_REST_API();
 
         $plain_key = 'plain-key';
 

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -24,7 +24,7 @@ final class BJLG_RestoreSecurityTest extends TestCase
         $_POST['filename'] = 'backup.zip';
         $_POST['password'] = "  pa\nss\tword  ";
 
-        $restore = new BJLG_Restore();
+        $restore = new BJLG\BJLG_Restore();
 
         try {
             $restore->handle_run_restore();
@@ -45,7 +45,7 @@ final class BJLG_RestoreSecurityTest extends TestCase
         $this->assertNotSame($expected_sanitized, $encrypted_password);
         $this->assertStringNotContainsString($expected_sanitized, $encrypted_password);
 
-        $reflection = new ReflectionClass(BJLG_Restore::class);
+        $reflection = new ReflectionClass(BJLG\BJLG_Restore::class);
         $method = $reflection->getMethod('decrypt_password_from_transient');
         $method->setAccessible(true);
         $decrypted_password = $method->invoke($restore, $encrypted_password);


### PR DESCRIPTION
## Summary
- add a BJLG namespace to every class file under `includes/` and adjust internal references to use namespaced class constants and required global imports
- update the plugin bootstrap to instantiate the new namespaced classes and keep activation logic aligned
- refresh the PHPUnit fixtures to reference the namespaced classes while providing compatibility aliases for debugging stubs

## Testing
- composer dump-autoload
- composer test *(fails: phpunit not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b29df72c832eacbd1872ba5e08f8