### PR TITLE
Handle WP_Error in check_admin_permissions

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -279,9 +279,16 @@ class BJLG_REST_API {
      * Vérification des permissions admin
      */
     public function check_admin_permissions($request) {
-        if (!$this->check_permissions($request)) {
+        $permissions_check = $this->check_permissions($request);
+
+        if (is_wp_error($permissions_check)) {
+            return $permissions_check;
+        }
+
+        if (!$permissions_check) {
             return false;
         }
+
         return current_user_can('manage_options');
     }
     


### PR DESCRIPTION
## Summary
- capture the result of `check_permissions` inside `check_admin_permissions`
- return early when the permission check yields a `WP_Error`
- maintain the existing false return while requiring truthy permissions before checking for admin capability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9cf86b9f0832eb4680caa94287fe6