### PR TITLE
Hook restore task into WP-Cron

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -33,6 +33,7 @@ class BJLG_Restore {
         add_action('wp_ajax_bjlg_run_restore', [$this, 'handle_run_restore']);
         add_action('wp_ajax_bjlg_upload_restore_file', [$this, 'handle_upload_restore_file']);
         add_action('wp_ajax_bjlg_check_restore_progress', [$this, 'handle_check_restore_progress']);
+        add_action('bjlg_run_restore_task', [$this, 'run_restore_task'], 10, 1);
     }
 
     /**


### PR DESCRIPTION
## Summary
- register the `bjlg_run_restore_task` action in the restore service so WP-Cron can invoke the background task handler

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca83d9653c832ea2efedff9fc54244