### PR TITLE
Implement secure backup download endpoint

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -2,6 +2,7 @@
 namespace BJLG;
 
 use Exception;
+use WP_Error;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -14,6 +15,9 @@ class BJLG_Actions {
 
     public function __construct() {
         add_action('wp_ajax_bjlg_delete_backup', [$this, 'handle_delete_backup']);
+        add_action('wp_ajax_bjlg_download', [$this, 'handle_download_request']);
+        add_action('wp_ajax_nopriv_bjlg_download', [$this, 'handle_download_request']);
+        add_action('template_redirect', [$this, 'maybe_handle_public_download']);
     }
 
     /**
@@ -86,5 +90,144 @@ class BJLG_Actions {
             }
             wp_send_json_error(['message' => $e->getMessage()]);
         }
+    }
+
+    /**
+     * Gère la diffusion d'une sauvegarde via AJAX (authentifié ou non).
+     */
+    public function handle_download_request() {
+        $token = isset($_REQUEST['token']) ? sanitize_text_field(wp_unslash($_REQUEST['token'])) : '';
+
+        $validation = $this->validate_download_token($token);
+        if (is_wp_error($validation)) {
+            $status = (int) ($validation->get_error_data('status') ?? 403);
+            wp_send_json_error(['message' => $validation->get_error_message()], $status);
+        }
+
+        list($filepath, $transient_key) = $validation;
+
+        delete_transient($transient_key);
+
+        $this->stream_backup_file($filepath);
+    }
+
+    /**
+     * Intercepte les requêtes publiques (API REST) pour diffuser une sauvegarde.
+     */
+    public function maybe_handle_public_download() {
+        if (empty($_GET['bjlg_download'])) {
+            return;
+        }
+
+        $token = sanitize_text_field(wp_unslash($_GET['bjlg_download']));
+
+        $validation = $this->validate_download_token($token);
+        if (is_wp_error($validation)) {
+            $status = (int) ($validation->get_error_data('status') ?? 403);
+            status_header($status);
+            wp_die(esc_html($validation->get_error_message()), '', ['response' => $status]);
+        }
+
+        list($filepath, $transient_key) = $validation;
+
+        delete_transient($transient_key);
+
+        $this->stream_backup_file($filepath);
+    }
+
+    /**
+     * Valide un token de téléchargement et renvoie le chemin sécurisé.
+     *
+     * @param string $token
+     * @return array{0: string, 1: string}|WP_Error
+     */
+    private function validate_download_token($token) {
+        if (empty($token)) {
+            return new WP_Error('bjlg_missing_token', 'Token de téléchargement manquant.', ['status' => 400]);
+        }
+
+        $transient_key = 'bjlg_download_' . $token;
+        $filepath = get_transient($transient_key);
+
+        if (empty($filepath)) {
+            return new WP_Error('bjlg_invalid_token', 'Lien de téléchargement invalide ou expiré.', ['status' => 403]);
+        }
+
+        $real_backup_dir = realpath(BJLG_BACKUP_DIR);
+        $real_filepath = realpath($filepath);
+
+        if ($real_backup_dir === false || $real_filepath === false) {
+            return new WP_Error('bjlg_invalid_path', 'Chemin de sauvegarde invalide.', ['status' => 404]);
+        }
+
+        $normalized_dir = rtrim(str_replace('\\', '/', $real_backup_dir), '/') . '/';
+        $normalized_path = str_replace('\\', '/', $real_filepath);
+
+        if (strpos($normalized_path, $normalized_dir) !== 0) {
+            return new WP_Error('bjlg_invalid_path', 'Accès à la sauvegarde refusé.', ['status' => 403]);
+        }
+
+        if (!file_exists($real_filepath)) {
+            delete_transient($transient_key);
+            return new WP_Error('bjlg_missing_file', 'Le fichier de sauvegarde est introuvable.', ['status' => 404]);
+        }
+
+        if (!is_readable($real_filepath)) {
+            return new WP_Error('bjlg_unreadable_file', 'Le fichier de sauvegarde est inaccessible.', ['status' => 500]);
+        }
+
+        return [$real_filepath, $transient_key];
+    }
+
+    /**
+     * Diffuse un fichier de sauvegarde avec les bons en-têtes HTTP et arrête l'exécution.
+     *
+     * @param string $filepath
+     */
+    private function stream_backup_file($filepath) {
+        if (!file_exists($filepath) || !is_readable($filepath)) {
+            status_header(404);
+            wp_die('Fichier de sauvegarde introuvable.', '', ['response' => 404]);
+        }
+
+        if (function_exists('ignore_user_abort')) {
+            ignore_user_abort(true);
+        }
+
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(0);
+        }
+
+        nocache_headers();
+        status_header(200);
+        header('Content-Type: application/octet-stream');
+        header('Content-Disposition: attachment; filename="' . basename($filepath) . '"');
+        header('Content-Length: ' . filesize($filepath));
+        header('Content-Transfer-Encoding: binary');
+        header('Connection: close');
+
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
+
+        $handle = fopen($filepath, 'rb');
+        if ($handle === false) {
+            status_header(500);
+            wp_die('Impossible de lire le fichier de sauvegarde.', '', ['response' => 500]);
+        }
+
+        while (!feof($handle)) {
+            echo fread($handle, 8192);
+            flush();
+        }
+
+        fclose($handle);
+
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        } else {
+            flush();
+        }
+        exit;
     }
 }

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -192,7 +192,12 @@ class BJLG_Admin {
                     <tbody>
                         <?php foreach ($backups as $backup_file):
                             $filename = basename($backup_file);
-                            $file_url = content_url(str_replace(WP_CONTENT_DIR, '', $backup_file));
+                            $download_token = wp_generate_password(32, false);
+                            set_transient('bjlg_download_' . $download_token, $backup_file, HOUR_IN_SECONDS);
+                            $file_url = add_query_arg([
+                                'action' => 'bjlg_download',
+                                'token' => $download_token,
+                            ], admin_url('admin-ajax.php'));
                             $is_encrypted = (substr($filename, -4) === '.enc');
                             ?>
                             <tr>
@@ -211,7 +216,7 @@ class BJLG_Admin {
                                 <td><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), filemtime($backup_file)); ?></td>
                                 <td>
                                     <button class="button button-primary bjlg-restore-button" data-filename="<?php echo esc_attr($filename); ?>">Restaurer</button>
-                                    <a href="<?php echo esc_url($file_url); ?>" class="button" download>Télécharger</a>
+                                    <a href="<?php echo esc_url($file_url); ?>" class="button">Télécharger</a>
                                     <button class="button button-link-delete bjlg-delete-button" data-filename="<?php echo esc_attr($filename); ?>">Supprimer</button>
                                 </td>
                             </tr>

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -762,11 +762,14 @@ class BJLG_REST_API {
         $download_token = wp_generate_password(32, false);
         set_transient('bjlg_download_' . $download_token, $filepath, HOUR_IN_SECONDS);
 
+        $download_url = add_query_arg([
+            'action' => 'bjlg_download',
+            'token' => $download_token,
+        ], admin_url('admin-ajax.php'));
+
         return rest_ensure_response([
-            'download_url' => add_query_arg([
-                'bjlg_download' => $download_token
-            ], site_url()),
-            'expires_in' => 3600,
+            'download_url' => $download_url,
+            'expires_in' => HOUR_IN_SECONDS,
             'filename' => basename($filepath),
             'size' => filesize($filepath)
         ]);


### PR DESCRIPTION
## Summary
- add secure download handlers to serve backups via transient tokens and admin-ajax
- intercept public bjlg_download query var to reuse the same validation/streaming logic
- return secured URLs from REST/API and admin UI when generating download links

## Testing
- composer test *(fails: phpunit missing in environment)*
- composer install *(fails: unable to reach packagist over network)*

------
https://chatgpt.com/codex/tasks/task_e_68cac02055a8832eb8c2f9d18ba469a2