### PR TITLE
Handle secure backup download tokens on init

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -17,6 +17,7 @@ class BJLG_Actions {
         add_action('wp_ajax_bjlg_delete_backup', [$this, 'handle_delete_backup']);
         add_action('wp_ajax_bjlg_download', [$this, 'handle_download_request']);
         add_action('wp_ajax_nopriv_bjlg_download', [$this, 'handle_download_request']);
+        add_action('init', [$this, 'maybe_handle_public_download']);
         add_action('template_redirect', [$this, 'maybe_handle_public_download']);
     }
 


### PR DESCRIPTION
## Summary
- ensure the secure download handler also runs on `init` so the token logic can stream files immediately when the public query var is used

## Testing
- php -l backup-jlg/includes/class-bjlg-actions.php

------
https://chatgpt.com/codex/tasks/task_e_68cac459acb8832e8d5774b7dc462b9a