### PR TITLE
Fix download error status propagation

### DIFF
--- a/backup-jlg/tests/BJLG_ActionsTest.php
+++ b/backup-jlg/tests/BJLG_ActionsTest.php
@@ -10,7 +10,11 @@ final class BJLG_ActionsTest extends TestCase
     protected function setUp(): void
     {
         $GLOBALS['bjlg_test_current_user_can'] = true;
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_last_status_header'] = null;
         $_POST = [];
+        $_REQUEST = [];
+        $_GET = [];
     }
 
     public function test_handle_delete_backup_denies_user_without_capability(): void
@@ -25,6 +29,66 @@ final class BJLG_ActionsTest extends TestCase
         } catch (BJLG_Test_JSON_Response $exception) {
             $this->assertSame(['message' => 'Permission refusée.'], $exception->data);
             $this->assertSame(403, $exception->status_code);
+        }
+    }
+
+    /**
+     * @return array<string, array{0: ?string, 1: int}>
+     */
+    public function provide_invalid_tokens_for_download(): array
+    {
+        return [
+            'missing token' => [null, 400],
+            'empty token' => ['', 400],
+            'expired token' => ['expired', 403],
+        ];
+    }
+
+    /**
+     * @dataProvider provide_invalid_tokens_for_download
+     */
+    public function test_handle_download_request_uses_status_from_validation(?string $token, int $expected_status): void
+    {
+        $actions = new BJLG\BJLG_Actions();
+
+        if ($token !== null) {
+            $_REQUEST['token'] = $token;
+        }
+
+        try {
+            $actions->handle_download_request();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $exception) {
+            $this->assertSame($expected_status, $exception->status_code);
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public function provide_public_download_tokens(): array
+    {
+        return [
+            'missing token' => ['', 400],
+            'expired token' => ['expired', 403],
+        ];
+    }
+
+    /**
+     * @dataProvider provide_public_download_tokens
+     */
+    public function test_maybe_handle_public_download_uses_status_from_validation(string $token, int $expected_status): void
+    {
+        $actions = new BJLG\BJLG_Actions();
+
+        $_GET['bjlg_download'] = $token;
+
+        try {
+            $actions->maybe_handle_public_download();
+            $this->fail('Expected BJLG_Test_WP_Die to be thrown.');
+        } catch (BJLG_Test_WP_Die $exception) {
+            $this->assertSame($expected_status, $exception->status_code);
+            $this->assertSame($expected_status, $GLOBALS['bjlg_test_last_status_header']);
         }
     }
 }

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -122,6 +122,22 @@ if (!class_exists('BJLG_Test_JSON_Response')) {
     }
 }
 
+if (!class_exists('BJLG_Test_WP_Die')) {
+    class BJLG_Test_WP_Die extends RuntimeException {
+        /** @var int|null */
+        public $status_code;
+
+        /**
+         * @param string   $message
+         * @param int|null $status_code
+         */
+        public function __construct($message = '', $status_code = null) {
+            $this->status_code = $status_code;
+            parent::__construct((string) $message);
+        }
+    }
+}
+
 if (!function_exists('add_action')) {
     function add_action($hook, $callback) {
         // No-op for tests.
@@ -241,6 +257,26 @@ if (!function_exists('wp_send_json_error')) {
 if (!function_exists('wp_send_json_success')) {
     function wp_send_json_success($data = null, $status_code = null) {
         throw new BJLG_Test_JSON_Response($data, $status_code);
+    }
+}
+
+if (!function_exists('status_header')) {
+    function status_header($code) {
+        $GLOBALS['bjlg_test_last_status_header'] = $code;
+    }
+}
+
+if (!function_exists('wp_die')) {
+    function wp_die($message = '', $title = '', $args = []) {
+        $response_code = null;
+
+        if (is_array($args) && isset($args['response'])) {
+            $response_code = $args['response'];
+        } elseif (!is_array($args) && $args !== null) {
+            $response_code = (int) $args;
+        }
+
+        throw new BJLG_Test_WP_Die($message, $response_code);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure download handlers reuse the WP_Error status codes returned by `validate_download_token()`
- centralize status extraction in a dedicated helper
- expand the unit test suite and bootstrap stubs to cover missing or expired tokens

## Testing
- composer test *(fails: phpunit executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf8e7129c832eacde0a22a0d6c8d6