### PR TITLE
Allow backup routes to accept dotted filenames

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -119,7 +119,7 @@ class BJLG_REST_API {
         ]);
         
         // Routes : Opérations sur une sauvegarde spécifique
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[^/]+)', [
             [
                 'methods' => 'GET',
                 'callback' => [$this, 'get_backup'],
@@ -133,7 +133,7 @@ class BJLG_REST_API {
         ]);
         
         // Route : Télécharger une sauvegarde
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)/download', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[^/]+)/download', [
             'methods' => 'GET',
             'callback' => [$this, 'download_backup'],
             'permission_callback' => [$this, 'check_permissions'],
@@ -146,7 +146,7 @@ class BJLG_REST_API {
         ]);
         
         // Route : Restaurer une sauvegarde
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)/restore', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[^/]+)/restore', [
             'methods' => 'POST',
             'callback' => [$this, 'restore_backup'],
             'permission_callback' => [$this, 'check_permissions'],

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -184,6 +184,37 @@ final class BJLG_REST_APITest extends TestCase
         }
     }
 
+    public function test_resolve_backup_path_accepts_ids_with_extensions(): void
+    {
+        $api = new BJLG\BJLG_REST_API();
+
+        $reflection = new ReflectionClass(BJLG\BJLG_REST_API::class);
+        $method = $reflection->getMethod('resolve_backup_path');
+        $method->setAccessible(true);
+
+        $zipFilename = sprintf('bjlg-test-backup-%s.2024-01-01.zip', uniqid('', false));
+        $zipPath = BJLG_BACKUP_DIR . $zipFilename;
+
+        $encryptedFilename = sprintf('bjlg-test-backup-%s.zip.enc', uniqid('', false));
+        $encryptedPath = BJLG_BACKUP_DIR . $encryptedFilename;
+
+        file_put_contents($zipPath, 'zip');
+        file_put_contents($encryptedPath, 'enc');
+
+        try {
+            $this->assertSame(realpath($zipPath), $method->invoke($api, $zipFilename));
+            $this->assertSame(realpath($encryptedPath), $method->invoke($api, $encryptedFilename));
+        } finally {
+            if (file_exists($zipPath)) {
+                unlink($zipPath);
+            }
+
+            if (file_exists($encryptedPath)) {
+                unlink($encryptedPath);
+            }
+        }
+    }
+
     public function test_format_backup_data_generates_download_token(): void
     {
         $GLOBALS['bjlg_test_transients'] = [];


### PR DESCRIPTION
## Summary
- allow the backup REST routes to accept identifiers containing dots and file extensions
- cover resolve_backup_path with backups ending in .zip and .zip.enc to prevent regressions

## Testing
- composer test *(fails: phpunit not found in PATH)*
- composer install --no-interaction *(fails: network error 403 when reaching packagist)*

------
https://chatgpt.com/codex/tasks/task_e_68cb01851918832ea833cfccb9a54d94