### PR TITLE
Import RuntimeException in restore class

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -2,6 +2,7 @@
 namespace BJLG;
 
 use Exception;
+use RuntimeException;
 use ZipArchive;
 
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
## Summary
- import RuntimeException alongside existing use statements in the restore class to avoid fatal errors when throwing the exception

## Testing
- php -l backup-jlg/includes/class-bjlg-restore.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0d61ce10832e8bce9012dc4b1247