### PR TITLE
Support backup option flags from admin UI

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -18,6 +18,9 @@ jQuery(document).ready(function($) {
             components.push($(this).val());
         });
 
+        const encrypt = $form.find('input[name="encrypt_backup"]').is(':checked');
+        const incremental = $form.find('input[name="incremental_backup"]').is(':checked');
+
         if (components.length === 0) {
             alert('Veuillez sélectionner au moins un composant à sauvegarder.');
             return;
@@ -29,7 +32,13 @@ jQuery(document).ready(function($) {
         $statusText.text('Initialisation...');
         $progressBar.css('width', '5%').text('5%');
 
-        const data = { action: 'bjlg_start_backup_task', nonce: bjlg_ajax.nonce, components: components };
+        const data = {
+            action: 'bjlg_start_backup_task',
+            nonce: bjlg_ajax.nonce,
+            components: components,
+            encrypt: encrypt,
+            incremental: incremental
+        };
         let debugReport = "--- 1. REQUÊTE DE LANCEMENT ---\nDonnées envoyées:\n" + JSON.stringify(data, null, 2);
         if ($debugOutput.length) $debugOutput.text(debugReport);
 


### PR DESCRIPTION
## Summary
- include the encrypt and incremental checkbox states when launching a manual backup via AJAX
- accept both the legacy encrypt/incremental keys and the admin form encrypt_backup/incremental_backup flags on the PHP side
- centralize boolean parsing for incoming request values so the task payload is normalized

## Testing
- ⚠️ `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cb085756a4832e9aeb44d1bd8f2b25