### PR TITLE
Add RuntimeException import to restore class

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -2,6 +2,7 @@
 namespace BJLG;
 
 use Exception;
+use RuntimeException;
 use ZipArchive;
 
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
## Summary
- import the RuntimeException class in the restore handler so runtime errors use the global class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb08573304832ebeab43a835d8c415