### PR TITLE
Corriger l'export CSV de l'historique de diagnostic

### DIFF
--- a/backup-jlg/includes/class-bjlg-diagnostics.php
+++ b/backup-jlg/includes/class-bjlg-diagnostics.php
@@ -268,15 +268,28 @@ private function get_php_info() {
     }
     
     private function format_history_as_csv($history) {
-        $csv = "Date,Type,Statut,Message\n";
-        foreach ($history as $entry) {
-            $csv .= sprintf("%s,%s,%s,%s\n",
-                $entry['timestamp'] ?? '',
-                $entry['type'] ?? '',
-                $entry['status'] ?? '',
-                str_replace(',', ';', $entry['message'] ?? '')
-            );
+        $handle = fopen('php://temp', 'r+');
+
+        if ($handle === false) {
+            return '';
         }
+
+        fputcsv($handle, ['Date', 'Action', 'Statut', 'Détails', 'Utilisateur'], ',', '"', '\\');
+
+        foreach ($history as $entry) {
+            fputcsv($handle, [
+                $entry['timestamp'] ?? '',
+                $entry['action_type'] ?? '',
+                $entry['status'] ?? '',
+                $entry['details'] ?? '',
+                $entry['user_name'] ?? '',
+            ], ',', '"', '\\');
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle) ?: '';
+        fclose($handle);
+
         return $csv;
     }
     


### PR DESCRIPTION
## Summary
- utilise fputcsv pour générer correctement le fichier CSV de l'historique récent
- aligne les colonnes exportées sur les champs renvoyés par BJLG_History::get_history et ajoute l'en-tête correspondant

## Testing
- `composer install` *(échoue : dépôt packagist inaccessible depuis l'environnement)*
- `php <<'PHP' ...` *(vérifie le contenu généré pour historique-recent.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4936cfa8832ebd0caeec7c1e7f12