### PR TITLE
Use public debug helper for support package

### DIFF
--- a/backup-jlg/includes/class-bjlg-diagnostics.php
+++ b/backup-jlg/includes/class-bjlg-diagnostics.php
@@ -56,11 +56,8 @@ class BJLG_Diagnostics {
             }
 
             // 2. Ajouter le log d'erreurs WP (limité aux 1000 dernières lignes)
-            $wp_log_path = WP_CONTENT_DIR . '/debug.log';
-            if (file_exists($wp_log_path)) {
-                $wp_log_content = BJLG_Debug::read_tail($wp_log_path, 1000);
-                $zip->addFromString('wp-debug.log', $wp_log_content);
-            }
+            $wp_log_content = BJLG_Debug::get_wp_error_log_content(1000);
+            $zip->addFromString('wp-debug.log', $wp_log_content);
 
             // 3. Ajouter le bilan de santé
             $health_checker = new BJLG_Health_Check();


### PR DESCRIPTION
## Summary
- switch the support package generator to rely on BJLG_Debug::get_wp_error_log_content when collecting the WordPress error log
- ensure the returned log content (including potential informational messages) continues to be embedded in the generated archive

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc632c1e44832ebace95ee40008f9c