### PR TITLE
Refine backup exclusion patterns and add coverage

### DIFF
--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -60,4 +60,41 @@ final class BJLG_BackupFilesystemTest extends TestCase
         $this->assertNotEmpty(BJLG_Debug::$logs);
         $this->assertStringContainsString($nonexistentFolder, BJLG_Debug::$logs[0]);
     }
+
+    public function test_backup_migration_plugin_is_not_excluded_by_default(): void
+    {
+        $backup = new BJLG\BJLG_Backup();
+
+        $zip = new class extends ZipArchive {
+            /** @var array<int, array{0: string, 1: string}> */
+            public $addedFiles = [];
+
+            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            {
+                $this->addedFiles[] = [$filepath, $entryname];
+                return true;
+            }
+        };
+
+        $root = sys_get_temp_dir() . '/bjlg-plugins-' . uniqid('', true);
+        $plugins_dir = $root . '/wp-content/plugins';
+        $backup_migration_dir = $plugins_dir . '/backup-migration';
+
+        if (!is_dir($backup_migration_dir) && !mkdir($backup_migration_dir, 0777, true) && !is_dir($backup_migration_dir)) {
+            $this->fail('Unable to create the backup-migration plugin directory for the test.');
+        }
+
+        $plugin_file = $backup_migration_dir . '/plugin.php';
+        file_put_contents($plugin_file, "<?php\n// backup-migration test plugin\n");
+
+        $reflection = new ReflectionMethod(BJLG\BJLG_Backup::class, 'get_exclude_patterns');
+        $reflection->setAccessible(true);
+        /** @var array<int, string> $exclude_patterns */
+        $exclude_patterns = $reflection->invoke($backup, $plugins_dir, 'wp-content/plugins/');
+
+        $backup->add_folder_to_zip($zip, $plugins_dir, 'wp-content/plugins/', $exclude_patterns);
+
+        $added_files = array_map(static fn($entry) => $entry[0], $zip->addedFiles);
+        $this->assertContains($plugin_file, $added_files, 'The backup-migration plugin should be included in the archive by default.');
+    }
 }


### PR DESCRIPTION
## Summary
- replace the generic backup directory exclusion with a configurable helper that supports stored options and a WordPress filter
- keep excluding the plugin's own backup directory while letting legitimate plugins such as backup-migration be archived
- add a filesystem unit test that proves backup-migration files are included by default

## Testing
- composer test *(fails: phpunit executable not available in the environment)*
- composer install *(fails: network access to packagist blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c44bc10832e8e03d05db90f5687