### PR TITLE
Allow dots in backup REST identifiers

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -119,7 +119,7 @@ class BJLG_REST_API {
         ]);
         
         // Routes : Opérations sur une sauvegarde spécifique
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[A-Za-z0-9._-]+)', [
             [
                 'methods' => 'GET',
                 'callback' => [$this, 'get_backup'],
@@ -133,7 +133,7 @@ class BJLG_REST_API {
         ]);
         
         // Route : Télécharger une sauvegarde
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)/download', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[A-Za-z0-9._-]+)/download', [
             'methods' => 'GET',
             'callback' => [$this, 'download_backup'],
             'permission_callback' => [$this, 'check_permissions'],
@@ -146,7 +146,7 @@ class BJLG_REST_API {
         ]);
         
         // Route : Restaurer une sauvegarde
-        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[a-zA-Z0-9_-]+)/restore', [
+        register_rest_route(self::API_NAMESPACE, '/backups/(?P<id>[A-Za-z0-9._-]+)/restore', [
             'methods' => 'POST',
             'callback' => [$this, 'restore_backup'],
             'permission_callback' => [$this, 'check_permissions'],

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -217,6 +217,49 @@ namespace {
         }
     }
 
+    public function test_download_backup_accepts_ids_with_file_extensions(): void
+    {
+        $GLOBALS['bjlg_test_transients'] = [];
+
+        $api = new BJLG\BJLG_REST_API();
+
+        $filename = 'bjlg-test-backup-' . uniqid('', true) . '.zip';
+        $filepath = BJLG_BACKUP_DIR . $filename;
+
+        file_put_contents($filepath, 'backup-data');
+
+        $request = new class($filename) {
+            /** @var array<string, mixed> */
+            private $params;
+
+            public function __construct($id)
+            {
+                $this->params = [
+                    'id' => $id,
+                ];
+            }
+
+            public function get_param($key)
+            {
+                return $this->params[$key] ?? null;
+            }
+        };
+
+        try {
+            $response = $api->download_backup($request);
+
+            $this->assertIsArray($response);
+            $this->assertArrayHasKey('download_url', $response);
+            $this->assertSame($filename, $response['filename']);
+            $this->assertArrayHasKey('size', $response);
+            $this->assertGreaterThan(0, $response['size']);
+        } finally {
+            if (file_exists($filepath)) {
+                unlink($filepath);
+            }
+        }
+    }
+
         public function test_update_settings_rejects_empty_payload(): void
         {
             $api = new BJLG\BJLG_REST_API();

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+namespace {
+
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/../');
 }
@@ -474,6 +476,8 @@ if (!function_exists('rest_ensure_response')) {
     function rest_ensure_response($response) {
         return $response;
     }
+}
+
 }
 
 namespace BJLG {


### PR DESCRIPTION
## Summary
- allow dots in REST route identifiers for backup resources so filenames like `.zip` are accepted
- add a regression test that exercises downloading a backup whose identifier includes a file extension
- wrap the bootstrap helpers in an explicit global namespace block to keep later namespace declarations valid

## Testing
- composer test *(fails: existing syntax error in tests/BJLG_ActionsTest.php complaining about `use PHPUnit\Framework\TestCase;`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6c96ca58832eb7ebbee2993ee3d0