### PR TITLE
Prevent REST stats endpoint from re-registering cleanup hooks

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -105,7 +105,7 @@ final class BJLG_Plugin {
 
         $backup_manager = new BJLG\BJLG_Backup();
         new BJLG\BJLG_Restore($backup_manager);
-        new BJLG\BJLG_Scheduler(); new BJLG\BJLG_Cleanup(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
+        new BJLG\BJLG_Scheduler(); BJLG\BJLG_Cleanup::instance(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
         new BJLG\BJLG_Diagnostics(); new BJLG\BJLG_Webhooks(); new BJLG\BJLG_Incremental(); new BJLG\BJLG_Performance();
         new BJLG\BJLG_REST_API(); new BJLG\BJLG_Settings();
     }

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1175,8 +1175,7 @@ class BJLG_REST_API {
         $period = $request->get_param('period');
         
         $history_stats = BJLG_History::get_stats($period);
-        $cleanup = new BJLG_Cleanup();
-        $storage_stats = $cleanup->get_storage_stats();
+        $storage_stats = BJLG_Cleanup::get_storage_stats_snapshot();
         
         $disk_total = $storage_stats['disk_total'];
         $disk_free = $storage_stats['disk_free'];

--- a/backup-jlg/tests/BJLG_ActionsTest.php
+++ b/backup-jlg/tests/BJLG_ActionsTest.php
@@ -16,7 +16,7 @@ namespace BJLG {
 
 namespace {
 
-use PHPUnit\\Framework\\TestCase;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../includes/class-bjlg-actions.php';
 
@@ -37,7 +37,7 @@ final class BJLG_ActionsTest extends TestCase
     {
         $GLOBALS['bjlg_test_current_user_can'] = false;
 
-        $actions = new BJLG\\BJLG_Actions();
+        $actions = new BJLG\BJLG_Actions();
 
         try {
             $actions->handle_delete_backup();
@@ -65,7 +65,7 @@ final class BJLG_ActionsTest extends TestCase
      */
     public function test_handle_download_request_uses_status_from_validation(?string $token, int $expected_status): void
     {
-        $actions = new BJLG\\BJLG_Actions();
+        $actions = new BJLG\BJLG_Actions();
 
         if ($token !== null) {
             $_REQUEST['token'] = $token;
@@ -95,7 +95,7 @@ final class BJLG_ActionsTest extends TestCase
      */
     public function test_maybe_handle_public_download_uses_status_from_validation(string $token, int $expected_status): void
     {
-        $actions = new BJLG\\BJLG_Actions();
+        $actions = new BJLG\BJLG_Actions();
 
         $_GET['bjlg_download'] = $token;
 
@@ -110,7 +110,7 @@ final class BJLG_ActionsTest extends TestCase
 
     public function test_handle_delete_backup_returns_error_when_backup_directory_is_missing(): void
     {
-        $actions = new BJLG\\BJLG_Actions();
+        $actions = new BJLG\BJLG_Actions();
 
         $_POST['filename'] = 'missing-backup.zip';
 


### PR DESCRIPTION
## Summary
- add a singleton accessor and static snapshot helper on BJLG_Cleanup so storage stats can be queried without re-instantiation
- switch the REST API stats endpoint and plugin bootstrap to use the shared cleanup instance
- extend the test harness with has_action/scheduling stubs, normalise namespace usage in BJLG_ActionsTest, and add a regression test that ensures repeated /stats calls do not register extra cleanup callbacks

## Testing
- `vendor-bjlg/bin/phpunit` *(fails: existing ZipArchive test double signature mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8a124728832ea42f24392afe5176