### PR TITLE
Validate JWT users before granting REST access

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -474,6 +474,10 @@ class BJLG_REST_API {
             return false;
         }
 
+        if (empty($payload_data['user_id'])) {
+            return false;
+        }
+
         if (!defined('AUTH_KEY')) {
             return false;
         }
@@ -483,6 +487,24 @@ class BJLG_REST_API {
 
         if (!hash_equals($expected_signature, $signature)) {
             return false;
+        }
+
+        $user_id = (int) $payload_data['user_id'];
+        if ($user_id <= 0) {
+            return false;
+        }
+
+        $user = get_user_by('id', $user_id);
+        if (!$user instanceof \WP_User) {
+            return false;
+        }
+
+        if (!user_can($user, BJLG_CAPABILITY)) {
+            return false;
+        }
+
+        if (function_exists('wp_set_current_user')) {
+            wp_set_current_user($user_id);
         }
 
         return true;


### PR DESCRIPTION
## Summary
- require JWT verification to resolve the associated user, ensure the BJLG capability is still granted, and set the current user context
- extend the PHPUnit bootstrap with simple WP_User helpers so permission checks can exercise real capability logic
- add REST API tests covering missing or deprivileged users and successful admin access via JWT tokens

## Testing
- composer test *(fails: ZipArchive test double signature mismatch in BJLG_BackupDatabaseTest)*
- vendor-bjlg/bin/phpunit --filter test_verify_jwt_token_returns_false_when_user_is_missing
- vendor-bjlg/bin/phpunit --filter test_verify_jwt_token_returns_false_when_user_loses_capability
- vendor-bjlg/bin/phpunit --filter test_check_admin_permissions_accepts_valid_jwt_user
- vendor-bjlg/bin/phpunit --filter test_verify_jwt_token_returns_false_for_invalid_signature

------
https://chatgpt.com/codex/tasks/task_e_68ce905e81f0832eb4d290414d5f6a5c