### PR TITLE
Extend transient TTL for backup tasks

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH')) {
  */
 class BJLG_Backup {
 
+    public const TASK_TTL = DAY_IN_SECONDS;
+
     private $performance_optimizer;
     private $encryption_handler;
     
@@ -74,7 +76,7 @@ class BJLG_Backup {
         ];
         
         // Sauvegarder temporairement
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, self::TASK_TTL);
         
         BJLG_Debug::log("Nouvelle tâche de sauvegarde créée : $task_id");
         BJLG_History::log('backup_started', 'info', 'Composants : ' . implode(', ', $components));
@@ -173,7 +175,7 @@ class BJLG_Backup {
             $components = array_values(array_unique(array_intersect($components, $allowed_components)));
 
             $task_data['components'] = $components;
-            set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+            set_transient($task_id, $task_data, self::TASK_TTL);
 
             if (empty($components)) {
                 BJLG_Debug::log("ERREUR: Aucun composant valide pour la tâche $task_id.");
@@ -195,7 +197,7 @@ class BJLG_Backup {
                     BJLG_Debug::log("Pas de sauvegarde complète trouvée, bascule en mode complet.");
                     $backup_type = 'full';
                     $task_data['incremental'] = false;
-                    set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+                    set_transient($task_id, $task_data, self::TASK_TTL);
                 }
             }
             
@@ -733,7 +735,7 @@ class BJLG_Backup {
             $task_data['progress'] = $progress;
             $task_data['status'] = $status;
             $task_data['status_text'] = $status_text;
-            set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+            set_transient($task_id, $task_data, self::TASK_TTL);
         }
     }
 

--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -333,7 +333,7 @@ class BJLG_Performance {
                 'progress' => $progress,
                 'status' => 'running',
                 'status_text' => "Traitement de {$task['type']} (" . (isset($task['subtype']) ? $task['subtype'] : '') . ")..."
-            ], HOUR_IN_SECONDS);
+            ], BJLG_Backup::TASK_TTL);
             
             try {
                 $result = $this->execute_single_task($task);

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -737,7 +737,7 @@ class BJLG_REST_API {
             'start_time' => time()
         ];
         
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);
@@ -1065,7 +1065,7 @@ class BJLG_REST_API {
             'create_restore_point' => $create_restore_point
         ];
         
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_restore_task', ['task_id' => $task_id]);

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -276,7 +276,7 @@ class BJLG_Restore {
             'password_encrypted' => $encrypted_password
         ];
         
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_restore_task', ['task_id' => $task_id]);
@@ -339,7 +339,7 @@ class BJLG_Restore {
                 'progress' => 10,
                 'status' => 'running',
                 'status_text' => 'Vérification du fichier de sauvegarde...'
-            ], HOUR_IN_SECONDS);
+            ], BJLG_Backup::TASK_TTL);
 
             if (!file_exists($filepath)) {
                 throw new Exception("Le fichier de sauvegarde n'a pas été trouvé.");
@@ -351,7 +351,7 @@ class BJLG_Restore {
                     'progress' => 20,
                     'status' => 'running',
                     'status_text' => 'Déchiffrement de l\'archive...'
-                ], HOUR_IN_SECONDS);
+                ], BJLG_Backup::TASK_TTL);
                 
                 $encryption = new BJLG_Encryption();
                 $filepath = $encryption->decrypt_backup_file($filepath, $password);
@@ -385,7 +385,7 @@ class BJLG_Restore {
                     'progress' => 30,
                     'status' => 'running',
                     'status_text' => 'Restauration de la base de données...'
-                ], HOUR_IN_SECONDS);
+                ], BJLG_Backup::TASK_TTL);
 
                 if ($zip->locateName('database.sql') !== false) {
                     $allowed_entries = $this->build_allowed_zip_entries($zip, $temp_extract_dir);
@@ -404,7 +404,7 @@ class BJLG_Restore {
                         'progress' => 50,
                         'status' => 'running',
                         'status_text' => 'Base de données restaurée.'
-                    ], HOUR_IN_SECONDS);
+                    ], BJLG_Backup::TASK_TTL);
                 }
             }
 
@@ -434,7 +434,7 @@ class BJLG_Restore {
                         'progress' => round($progress),
                         'status' => 'running',
                         'status_text' => "Restauration des {$type}..."
-                    ], HOUR_IN_SECONDS);
+                    ], BJLG_Backup::TASK_TTL);
 
                     $source_folder = "wp-content/{$type}";
 
@@ -476,7 +476,7 @@ class BJLG_Restore {
                 'progress' => 95,
                 'status' => 'running',
                 'status_text' => 'Nettoyage...'
-            ], HOUR_IN_SECONDS);
+            ], BJLG_Backup::TASK_TTL);
             
             $this->recursive_delete($temp_extract_dir);
             
@@ -489,7 +489,7 @@ class BJLG_Restore {
                 'progress' => 100,
                 'status' => 'complete',
                 'status_text' => 'Restauration terminée avec succès !'
-            ], HOUR_IN_SECONDS);
+            ], BJLG_Backup::TASK_TTL);
 
         } catch (Exception $e) {
             BJLG_History::log('restore_run', 'failure', "Erreur : " . $e->getMessage());
@@ -503,7 +503,7 @@ class BJLG_Restore {
                 'progress' => 100,
                 'status' => 'error',
                 'status_text' => 'Erreur : ' . $e->getMessage()
-            ], HOUR_IN_SECONDS);
+            ], BJLG_Backup::TASK_TTL);
         }
     }
 

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -289,7 +289,7 @@ class BJLG_Scheduler {
             'source' => 'manual_scheduled'
         ];
         
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
         
         BJLG_Debug::log("Exécution manuelle de la sauvegarde planifiée - Task ID: $task_id");
         BJLG_History::log('scheduled_backup', 'info', 'Exécution manuelle de la sauvegarde planifiée');
@@ -326,7 +326,7 @@ class BJLG_Scheduler {
             'start_time' => time()
         ];
 
-        $transient_set = set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        $transient_set = set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
 
         if (!$transient_set) {
             BJLG_Debug::log("ERREUR : Impossible d'initialiser la tâche de sauvegarde planifiée $task_id.");

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -122,7 +122,7 @@ class BJLG_Webhooks {
             'source' => 'webhook'
         ];
         
-        set_transient($task_id, $task_data, HOUR_IN_SECONDS);
+        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
         
         // Planifier l'exécution immédiate
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);


### PR DESCRIPTION
## Summary
- add a BJLG_Backup::TASK_TTL constant to centralize the expected lifetime of task transients
- use the shared TTL when creating or updating backup and restore task state across backup, scheduler, REST API, webhook, restore, and performance flows

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce94e6e644832e96a8bd5c57f0c6f1