### PR TITLE
Extend download transient TTL to match backup task lifetime

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -193,7 +193,7 @@ class BJLG_Admin {
                         <?php foreach ($backups as $backup_file):
                             $filename = basename($backup_file);
                             $download_token = wp_generate_password(32, false);
-                            set_transient('bjlg_download_' . $download_token, $backup_file, HOUR_IN_SECONDS);
+                            set_transient('bjlg_download_' . $download_token, $backup_file, BJLG_Backup::TASK_TTL);
                             $file_url = add_query_arg([
                                 'action' => 'bjlg_download',
                                 'token' => $download_token,

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1026,7 +1026,7 @@ class BJLG_REST_API {
 
         // Générer un lien de téléchargement temporaire
         $download_token = wp_generate_password(32, false);
-        set_transient('bjlg_download_' . $download_token, $filepath, HOUR_IN_SECONDS);
+        set_transient('bjlg_download_' . $download_token, $filepath, BJLG_Backup::TASK_TTL);
 
         $download_url = add_query_arg([
             'action' => 'bjlg_download',
@@ -1035,7 +1035,7 @@ class BJLG_REST_API {
 
         return rest_ensure_response([
             'download_url' => $download_url,
-            'expires_in' => HOUR_IN_SECONDS,
+            'expires_in' => BJLG_Backup::TASK_TTL,
             'filename' => basename($filepath),
             'size' => filesize($filepath)
         ]);
@@ -1401,7 +1401,7 @@ class BJLG_REST_API {
         $download_token = wp_generate_password(32, false);
         $transient_key = 'bjlg_download_' . $download_token;
 
-        set_transient($transient_key, $filepath, HOUR_IN_SECONDS);
+        set_transient($transient_key, $filepath, BJLG_Backup::TASK_TTL);
 
         $download_url = add_query_arg([
             'action' => 'bjlg_download',
@@ -1430,7 +1430,7 @@ class BJLG_REST_API {
             'components' => $manifest['contains'] ?? [],
             'download_url' => $download_url,
             'download_token' => $download_token,
-            'download_expires_in' => HOUR_IN_SECONDS,
+            'download_expires_in' => BJLG_Backup::TASK_TTL,
             'download_rest_url' => $rest_download_url,
             'manifest' => $manifest
         ];


### PR DESCRIPTION
## Summary
- reuse the BJLG_Backup::TASK_TTL constant for all download token transients
- propagate the longer TTL to the metadata returned by the REST API and the admin download list

## Testing
- composer install
- ./vendor-bjlg/bin/phpunit *(fails: ZipArchive mock signature mismatch in BJLG_BackupDatabaseTest)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9bea4b14832e8d10e0b410855634