### PR TITLE
Validate JWT tokens against current user state

### DIFF
--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -303,6 +303,48 @@ if (!function_exists('current_user_can')) {
     }
 }
 
+if (!function_exists('get_user_by')) {
+    function get_user_by($field, $value) {
+        $users = $GLOBALS['bjlg_test_users'] ?? [];
+
+        if ($field === 'id' || $field === 'ID') {
+            $id = (int) $value;
+
+            if (isset($users[$id])) {
+                return $users[$id];
+            }
+
+            return false;
+        }
+
+        if ($field === 'login' || $field === 'user_login') {
+            foreach ($users as $user) {
+                if (isset($user->user_login) && $user->user_login === $value) {
+                    return $user;
+                }
+            }
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('user_can')) {
+    function user_can($user, $capability) {
+        if (is_object($user)) {
+            if (isset($user->allcaps) && is_array($user->allcaps)) {
+                return !empty($user->allcaps[$capability]);
+            }
+
+            if (isset($user->caps) && is_array($user->caps)) {
+                return !empty($user->caps[$capability]);
+            }
+        }
+
+        return false;
+    }
+}
+
 if (!function_exists('get_option')) {
     function get_option($option, $default = false) {
         return $GLOBALS['bjlg_test_options'][$option] ?? $default;


### PR DESCRIPTION
## Summary
- validate JWT bearer tokens by decoding payloads, ensuring the signature is valid, and confirming the referenced user still has BJLG_CAPABILITY
- surface JWT validation errors from the permission callback so REST endpoints reject revoked tokens cleanly
- extend the REST API test suite with coverage for invalid signatures, missing users, and revoked capabilities, adding bootstrap helpers for user lookups

## Testing
- vendor-bjlg/bin/phpunit *(fails: existing ZipArchive test double signature mismatch)*
- vendor-bjlg/bin/phpunit tests/BJLG_REST_APITest.php *(fails: missing BJLG_Backup/BJLG_Debug classes in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9e13b6ac832ea72e7a708748de61