### PR TITLE
Centralize backup task TTL handling

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -193,7 +193,7 @@ class BJLG_Admin {
                         <?php foreach ($backups as $backup_file):
                             $filename = basename($backup_file);
                             $download_token = wp_generate_password(32, false);
-                            set_transient('bjlg_download_' . $download_token, $backup_file, BJLG_Backup::TASK_TTL);
+                            set_transient('bjlg_download_' . $download_token, $backup_file, BJLG_Backup::get_task_ttl());
                             $file_url = add_query_arg([
                                 'action' => 'bjlg_download',
                                 'token' => $download_token,

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -15,6 +15,15 @@ class BJLG_Backup {
 
     public const TASK_TTL = DAY_IN_SECONDS;
 
+    /**
+     * Récupère la durée de vie maximale d'une tâche stockée dans un transient.
+     *
+     * @return int
+     */
+    public static function get_task_ttl() {
+        return (int) apply_filters('bjlg_task_ttl', self::TASK_TTL);
+    }
+
     private $performance_optimizer;
     private $encryption_handler;
     
@@ -76,7 +85,7 @@ class BJLG_Backup {
         ];
         
         // Sauvegarder temporairement
-        set_transient($task_id, $task_data, self::TASK_TTL);
+        set_transient($task_id, $task_data, self::get_task_ttl());
         
         BJLG_Debug::log("Nouvelle tâche de sauvegarde créée : $task_id");
         BJLG_History::log('backup_started', 'info', 'Composants : ' . implode(', ', $components));
@@ -175,7 +184,7 @@ class BJLG_Backup {
             $components = array_values(array_unique(array_intersect($components, $allowed_components)));
 
             $task_data['components'] = $components;
-            set_transient($task_id, $task_data, self::TASK_TTL);
+            set_transient($task_id, $task_data, self::get_task_ttl());
 
             if (empty($components)) {
                 BJLG_Debug::log("ERREUR: Aucun composant valide pour la tâche $task_id.");
@@ -197,7 +206,7 @@ class BJLG_Backup {
                     BJLG_Debug::log("Pas de sauvegarde complète trouvée, bascule en mode complet.");
                     $backup_type = 'full';
                     $task_data['incremental'] = false;
-                    set_transient($task_id, $task_data, self::TASK_TTL);
+                    set_transient($task_id, $task_data, self::get_task_ttl());
                 }
             }
             
@@ -735,7 +744,7 @@ class BJLG_Backup {
             $task_data['progress'] = $progress;
             $task_data['status'] = $status;
             $task_data['status_text'] = $status_text;
-            set_transient($task_id, $task_data, self::TASK_TTL);
+            set_transient($task_id, $task_data, self::get_task_ttl());
         }
     }
 

--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -333,7 +333,7 @@ class BJLG_Performance {
                 'progress' => $progress,
                 'status' => 'running',
                 'status_text' => "Traitement de {$task['type']} (" . (isset($task['subtype']) ? $task['subtype'] : '') . ")..."
-            ], BJLG_Backup::TASK_TTL);
+            ], BJLG_Backup::get_task_ttl());
             
             try {
                 $result = $this->execute_single_task($task);

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -806,7 +806,7 @@ class BJLG_REST_API {
             'start_time' => time()
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);
@@ -1095,7 +1095,7 @@ class BJLG_REST_API {
 
         // Générer un lien de téléchargement temporaire
         $download_token = wp_generate_password(32, false);
-        set_transient('bjlg_download_' . $download_token, $filepath, BJLG_Backup::TASK_TTL);
+        set_transient('bjlg_download_' . $download_token, $filepath, BJLG_Backup::get_task_ttl());
 
         $download_url = add_query_arg([
             'action' => 'bjlg_download',
@@ -1104,7 +1104,7 @@ class BJLG_REST_API {
 
         return rest_ensure_response([
             'download_url' => $download_url,
-            'expires_in' => BJLG_Backup::TASK_TTL,
+            'expires_in' => BJLG_Backup::get_task_ttl(),
             'filename' => basename($filepath),
             'size' => filesize($filepath)
         ]);
@@ -1134,7 +1134,7 @@ class BJLG_REST_API {
             'create_restore_point' => $create_restore_point
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_restore_task', ['task_id' => $task_id]);
@@ -1470,7 +1470,7 @@ class BJLG_REST_API {
         $download_token = wp_generate_password(32, false);
         $transient_key = 'bjlg_download_' . $download_token;
 
-        set_transient($transient_key, $filepath, BJLG_Backup::TASK_TTL);
+        set_transient($transient_key, $filepath, BJLG_Backup::get_task_ttl());
 
         $download_url = add_query_arg([
             'action' => 'bjlg_download',
@@ -1499,7 +1499,7 @@ class BJLG_REST_API {
             'components' => $manifest['contains'] ?? [],
             'download_url' => $download_url,
             'download_token' => $download_token,
-            'download_expires_in' => BJLG_Backup::TASK_TTL,
+            'download_expires_in' => BJLG_Backup::get_task_ttl(),
             'download_rest_url' => $rest_download_url,
             'manifest' => $manifest
         ];

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -276,7 +276,7 @@ class BJLG_Restore {
             'password_encrypted' => $encrypted_password
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_restore_task', ['task_id' => $task_id]);
@@ -339,7 +339,7 @@ class BJLG_Restore {
                 'progress' => 10,
                 'status' => 'running',
                 'status_text' => 'Vérification du fichier de sauvegarde...'
-            ], BJLG_Backup::TASK_TTL);
+            ], BJLG_Backup::get_task_ttl());
 
             if (!file_exists($filepath)) {
                 throw new Exception("Le fichier de sauvegarde n'a pas été trouvé.");
@@ -351,7 +351,7 @@ class BJLG_Restore {
                     'progress' => 20,
                     'status' => 'running',
                     'status_text' => 'Déchiffrement de l\'archive...'
-                ], BJLG_Backup::TASK_TTL);
+                ], BJLG_Backup::get_task_ttl());
                 
                 $encryption = new BJLG_Encryption();
                 $filepath = $encryption->decrypt_backup_file($filepath, $password);
@@ -385,7 +385,7 @@ class BJLG_Restore {
                     'progress' => 30,
                     'status' => 'running',
                     'status_text' => 'Restauration de la base de données...'
-                ], BJLG_Backup::TASK_TTL);
+                ], BJLG_Backup::get_task_ttl());
 
                 if ($zip->locateName('database.sql') !== false) {
                     $allowed_entries = $this->build_allowed_zip_entries($zip, $temp_extract_dir);
@@ -404,7 +404,7 @@ class BJLG_Restore {
                         'progress' => 50,
                         'status' => 'running',
                         'status_text' => 'Base de données restaurée.'
-                    ], BJLG_Backup::TASK_TTL);
+                    ], BJLG_Backup::get_task_ttl());
                 }
             }
 
@@ -434,7 +434,7 @@ class BJLG_Restore {
                         'progress' => round($progress),
                         'status' => 'running',
                         'status_text' => "Restauration des {$type}..."
-                    ], BJLG_Backup::TASK_TTL);
+                    ], BJLG_Backup::get_task_ttl());
 
                     $source_folder = "wp-content/{$type}";
 
@@ -476,7 +476,7 @@ class BJLG_Restore {
                 'progress' => 95,
                 'status' => 'running',
                 'status_text' => 'Nettoyage...'
-            ], BJLG_Backup::TASK_TTL);
+            ], BJLG_Backup::get_task_ttl());
             
             $this->recursive_delete($temp_extract_dir);
             
@@ -489,7 +489,7 @@ class BJLG_Restore {
                 'progress' => 100,
                 'status' => 'complete',
                 'status_text' => 'Restauration terminée avec succès !'
-            ], BJLG_Backup::TASK_TTL);
+            ], BJLG_Backup::get_task_ttl());
 
         } catch (Exception $e) {
             BJLG_History::log('restore_run', 'failure', "Erreur : " . $e->getMessage());
@@ -503,7 +503,7 @@ class BJLG_Restore {
                 'progress' => 100,
                 'status' => 'error',
                 'status_text' => 'Erreur : ' . $e->getMessage()
-            ], BJLG_Backup::TASK_TTL);
+            ], BJLG_Backup::get_task_ttl());
         }
     }
 

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -289,7 +289,7 @@ class BJLG_Scheduler {
             'source' => 'manual_scheduled'
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         BJLG_Debug::log("Exécution manuelle de la sauvegarde planifiée - Task ID: $task_id");
         BJLG_History::log('scheduled_backup', 'info', 'Exécution manuelle de la sauvegarde planifiée');
@@ -326,7 +326,7 @@ class BJLG_Scheduler {
             'start_time' => time()
         ];
 
-        $transient_set = set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        $transient_set = set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
 
         if (!$transient_set) {
             BJLG_Debug::log("ERREUR : Impossible d'initialiser la tâche de sauvegarde planifiée $task_id.");

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -122,7 +122,7 @@ class BJLG_Webhooks {
             'source' => 'webhook'
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::TASK_TTL);
+        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         // Planifier l'exécution immédiate
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);


### PR DESCRIPTION
## Summary
- add a reusable `BJLG_Backup::get_task_ttl()` helper that exposes a filterable transient lifetime
- use the shared helper across backup, restore, REST, scheduler, webhook, admin, and performance flows so task progress refreshes extend TTL
- align download metadata to report the filtered task TTL consistently

## Testing
- `composer test` *(fails: test suite defines a ZipArchive stub with a signature incompatible with the native extension on PHP 8.2)*

------
https://chatgpt.com/codex/tasks/task_e_68cea908ea28832ea3c579ba80427941