### PR TITLE
Validate JWT tokens against current user state

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -293,7 +293,7 @@ class BJLG_REST_API {
                 return $jwt_check;
             }
 
-            return (bool) $jwt_check;
+            return true;
         }
 
         // Vérifier l'authentification WordPress standard
@@ -542,16 +542,24 @@ class BJLG_REST_API {
             );
         }
 
-        $user_id = isset($payload_data['user_id']) ? (int) $payload_data['user_id'] : null;
-        $username = isset($payload_data['username']) ? $payload_data['username'] : null;
+        $user_id = isset($payload_data['user_id']) ? (int) $payload_data['user_id'] : 0;
+        $username = isset($payload_data['username']) ? (string) $payload_data['username'] : '';
+
+        if ($user_id <= 0 && $username === '') {
+            return new WP_Error(
+                'jwt_invalid_token',
+                __('Les informations utilisateur sont manquantes dans le token.', 'backup-jlg'),
+                ['status' => 401]
+            );
+        }
 
         $user = false;
 
-        if ($user_id) {
+        if ($user_id > 0) {
             $user = get_user_by('id', $user_id);
         }
 
-        if (!$user && $username) {
+        if (!$user && $username !== '') {
             $user = get_user_by('login', $username);
         }
 

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -195,6 +195,38 @@ namespace {
             $this->assertSame('jwt_insufficient_permissions', $result->get_error_code());
         }
 
+        public function test_check_permissions_rejects_token_when_user_deleted(): void
+        {
+            $api = new BJLG\BJLG_REST_API();
+
+            $token = $this->generateJwtToken([
+                'user_id' => 314,
+                'username' => 'deleted-user',
+            ]);
+
+            $request = new class($token) {
+                /** @var array<string, string> */
+                private $headers;
+
+                public function __construct(string $token)
+                {
+                    $this->headers = [
+                        'Authorization' => 'Bearer ' . $token,
+                    ];
+                }
+
+                public function get_header($key)
+                {
+                    return $this->headers[$key] ?? null;
+                }
+            };
+
+            $result = $api->check_permissions($request);
+
+            $this->assertInstanceOf(\WP_Error::class, $result);
+            $this->assertSame('jwt_user_not_found', $result->get_error_code());
+        }
+
     public function test_verify_api_key_updates_usage_statistics(): void
     {
         $GLOBALS['bjlg_test_options'] = [];


### PR DESCRIPTION
## Summary
- ensure JWT permission checks propagate detailed errors instead of booleans
- harden token validation by requiring a current user with the backup capability
- add coverage that revoked or deleted users cannot access REST endpoints via JWT

## Testing
- `composer install`
- `./vendor-bjlg/bin/phpunit --filter BJLG_REST_APITest`


------
https://chatgpt.com/codex/tasks/task_e_68cee37de370832ea4ddd3170cbe524c