### PR TITLE
Centralize task transient TTL handling

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -21,7 +21,22 @@ class BJLG_Backup {
      * @return int
      */
     public static function get_task_ttl() {
-        return (int) apply_filters('bjlg_task_ttl', self::TASK_TTL);
+        return max(0, (int) apply_filters('bjlg_task_ttl', self::TASK_TTL));
+    }
+
+    /**
+     * Persists the state of a task transient while ensuring its expiration is refreshed.
+     *
+     * @param string                $task_id
+     * @param array<string, mixed>  $task_data
+     * @param int|null              $expiration
+     * @return bool
+     */
+    public static function store_task_state($task_id, array $task_data, $expiration = null) {
+        $task_id = (string) $task_id;
+        $expiration = is_null($expiration) ? self::get_task_ttl() : max(0, (int) $expiration);
+
+        return set_transient($task_id, $task_data, $expiration);
     }
 
     private $performance_optimizer;
@@ -85,7 +100,7 @@ class BJLG_Backup {
         ];
         
         // Sauvegarder temporairement
-        set_transient($task_id, $task_data, self::get_task_ttl());
+        self::store_task_state($task_id, $task_data);
         
         BJLG_Debug::log("Nouvelle tâche de sauvegarde créée : $task_id");
         BJLG_History::log('backup_started', 'info', 'Composants : ' . implode(', ', $components));
@@ -184,7 +199,7 @@ class BJLG_Backup {
             $components = array_values(array_unique(array_intersect($components, $allowed_components)));
 
             $task_data['components'] = $components;
-            set_transient($task_id, $task_data, self::get_task_ttl());
+            self::store_task_state($task_id, $task_data);
 
             if (empty($components)) {
                 BJLG_Debug::log("ERREUR: Aucun composant valide pour la tâche $task_id.");
@@ -206,7 +221,7 @@ class BJLG_Backup {
                     BJLG_Debug::log("Pas de sauvegarde complète trouvée, bascule en mode complet.");
                     $backup_type = 'full';
                     $task_data['incremental'] = false;
-                    set_transient($task_id, $task_data, self::get_task_ttl());
+                    self::store_task_state($task_id, $task_data);
                 }
             }
             
@@ -744,7 +759,7 @@ class BJLG_Backup {
             $task_data['progress'] = $progress;
             $task_data['status'] = $status;
             $task_data['status_text'] = $status_text;
-            set_transient($task_id, $task_data, self::get_task_ttl());
+            self::store_task_state($task_id, $task_data);
         }
     }
 

--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -329,11 +329,11 @@ class BJLG_Performance {
         foreach ($tasks as $index => $task) {
             $progress = round((($index + 1) / $total_tasks) * 100);
             
-            set_transient($task_id, [
+            BJLG_Backup::store_task_state($task_id, [
                 'progress' => $progress,
                 'status' => 'running',
                 'status_text' => "Traitement de {$task['type']} (" . (isset($task['subtype']) ? $task['subtype'] : '') . ")..."
-            ], BJLG_Backup::get_task_ttl());
+            ]);
             
             try {
                 $result = $this->execute_single_task($task);

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -806,7 +806,7 @@ class BJLG_REST_API {
             'start_time' => time()
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        BJLG_Backup::store_task_state($task_id, $task_data);
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);
@@ -1134,7 +1134,7 @@ class BJLG_REST_API {
             'create_restore_point' => $create_restore_point
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        BJLG_Backup::store_task_state($task_id, $task_data);
         
         // Planifier l'exécution
         wp_schedule_single_event(time(), 'bjlg_run_restore_task', ['task_id' => $task_id]);

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -289,7 +289,7 @@ class BJLG_Scheduler {
             'source' => 'manual_scheduled'
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        BJLG_Backup::store_task_state($task_id, $task_data);
         
         BJLG_Debug::log("Exécution manuelle de la sauvegarde planifiée - Task ID: $task_id");
         BJLG_History::log('scheduled_backup', 'info', 'Exécution manuelle de la sauvegarde planifiée');
@@ -326,7 +326,7 @@ class BJLG_Scheduler {
             'start_time' => time()
         ];
 
-        $transient_set = set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        $transient_set = BJLG_Backup::store_task_state($task_id, $task_data);
 
         if (!$transient_set) {
             BJLG_Debug::log("ERREUR : Impossible d'initialiser la tâche de sauvegarde planifiée $task_id.");

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -122,7 +122,7 @@ class BJLG_Webhooks {
             'source' => 'webhook'
         ];
         
-        set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        BJLG_Backup::store_task_state($task_id, $task_data);
         
         // Planifier l'exécution immédiate
         wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);

--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -73,7 +73,7 @@ final class BJLG_BackupDatabaseTest extends TestCase
             /** @var array<string, string|false> */
             public $fileContents = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 $this->fileContents[$entryname] = @file_get_contents($filepath);

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -41,7 +41,7 @@ final class BJLG_BackupFilesystemTest extends TestCase
             /** @var array<int, array{0: string, 1: string}> */
             public $addedFiles = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 return true;
@@ -70,7 +70,7 @@ final class BJLG_BackupFilesystemTest extends TestCase
             /** @var array<int, array{0: string, 1: string}> */
             public $addedFiles = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 return true;
@@ -123,13 +123,13 @@ final class BJLG_BackupFilesystemTest extends TestCase
                 /** @var array<int, array{0: string, 1: string}> */
                 public $addedFiles = [];
 
-                public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+                public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = ZipArchive::FL_OVERWRITE): bool
                 {
                     $this->addedFiles[] = [$filepath, $entryname];
                     return true;
                 }
 
-                public function setCompressionName($name, $method)
+                public function setCompressionName(string $name, int $method, int $compflags = 0): bool
                 {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- add a reusable helper in `BJLG_Backup` to centralize task transient TTL handling and clamp the value to non-negative
- update backup, restore, scheduler, webhook, REST, and performance flows to persist task state through the helper so progress refreshes the TTL consistently
- adjust the ZipArchive test doubles to match the PHP 8 signature so task-related tests can exercise the new helper

## Testing
- composer test *(fails: several WordPress functions such as `esc_html`/`wp_cache_flush` are unavailable in the isolated test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee676bcfc832eaf2c9d392012b951