### PR TITLE
Harden JWT verification for removed users

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -293,7 +293,7 @@ class BJLG_REST_API {
                 return $jwt_check;
             }
 
-            return (bool) $jwt_check;
+            return $jwt_check;
         }
 
         // Vérifier l'authentification WordPress standard
@@ -523,6 +523,9 @@ class BJLG_REST_API {
             );
         }
 
+        $user_id = isset($payload_data['user_id']) ? (int) $payload_data['user_id'] : 0;
+        $username = isset($payload_data['username']) ? (string) $payload_data['username'] : '';
+
         if (!defined('AUTH_KEY')) {
             return new WP_Error(
                 'jwt_signature_error',
@@ -542,16 +545,21 @@ class BJLG_REST_API {
             );
         }
 
-        $user_id = isset($payload_data['user_id']) ? (int) $payload_data['user_id'] : null;
-        $username = isset($payload_data['username']) ? $payload_data['username'] : null;
+        if ($user_id <= 0 && $username === '') {
+            return new WP_Error(
+                'jwt_invalid_user',
+                __('Le token JWT ne contient pas d’utilisateur valide.', 'backup-jlg'),
+                ['status' => 401]
+            );
+        }
 
         $user = false;
 
-        if ($user_id) {
+        if ($user_id > 0) {
             $user = get_user_by('id', $user_id);
         }
 
-        if (!$user && $username) {
+        if (!$user && $username !== '') {
             $user = get_user_by('login', $username);
         }
 

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -195,6 +195,38 @@ namespace {
             $this->assertSame('jwt_insufficient_permissions', $result->get_error_code());
         }
 
+        public function test_check_permissions_rejects_token_when_user_deleted(): void
+        {
+            $api = new BJLG\BJLG_REST_API();
+
+            $token = $this->generateJwtToken([
+                'user_id' => 314,
+                'username' => 'deleted-user',
+            ]);
+
+            $request = new class($token) {
+                /** @var array<string, string> */
+                private $headers;
+
+                public function __construct(string $token)
+                {
+                    $this->headers = [
+                        'Authorization' => 'Bearer ' . $token,
+                    ];
+                }
+
+                public function get_header($key)
+                {
+                    return $this->headers[$key] ?? null;
+                }
+            };
+
+            $result = $api->check_permissions($request);
+
+            $this->assertInstanceOf(\WP_Error::class, $result);
+            $this->assertSame('jwt_user_not_found', $result->get_error_code());
+        }
+
     public function test_verify_api_key_updates_usage_statistics(): void
     {
         $GLOBALS['bjlg_test_options'] = [];


### PR DESCRIPTION
## Summary
- ensure JWT verification decodes payload, looks up the referenced user, and rejects missing or unauthorized accounts with WP_Error responses
- allow the REST permission callback to propagate detailed JWT verification errors instead of coercing the result to a boolean
- add a regression test that confirms tokens belonging to deleted users are denied

## Testing
- ❌ `vendor-bjlg/bin/phpunit tests/BJLG_REST_APITest.php` *(fails: BJLG_Backup class is not available in the test environment)*
- ✅ `vendor-bjlg/bin/phpunit --filter test_check_permissions_rejects_token_when_user_deleted tests/BJLG_REST_APITest.php`


------
https://chatgpt.com/codex/tasks/task_e_68cee678808c832e8de8c8e4d38c52cd