### PR TITLE
Instancie le handler incrémental une seule fois

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -433,12 +433,20 @@ class BJLG_Backup {
             // Obtenir toutes les tables
             $tables = $wpdb->get_results("SHOW TABLES", ARRAY_N);
 
+            $incremental_handler = null;
+            if ($incremental && class_exists(BJLG_Incremental::class)) {
+                $incremental_handler = BJLG_Incremental::get_latest_instance();
+
+                if (!$incremental_handler) {
+                    $incremental_handler = new BJLG_Incremental();
+                }
+            }
+
             foreach ($tables as $table_array) {
                 $table = $table_array[0];
 
                 // Pour l'incrémental, vérifier si la table a changé
-                if ($incremental) {
-                    $incremental_handler = new BJLG_Incremental();
+                if ($incremental && $incremental_handler) {
                     if (!$incremental_handler->table_has_changed($table)) {
                         BJLG_Debug::log("Table $table ignorée (pas de changement)");
                         continue;


### PR DESCRIPTION
## Summary
- récupère l'instance incrémentale existante ou en crée une seule fois avant d'analyser les tables
- réutilise le même handler dans la boucle de vérification pour éviter les hooks dupliqués

## Testing
- php -l backup-jlg/includes/class-bjlg-backup.php

------
https://chatgpt.com/codex/tasks/task_e_68cf1831ba40832ea15007b77b3c273a