### PR TITLE
Ensure encrypted restores clean up decrypted archives

### DIFF
--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -73,7 +73,7 @@ final class BJLG_BackupDatabaseTest extends TestCase
             /** @var array<string, string|false> */
             public $fileContents = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile($filepath, $entryname = "", $start = 0, $length = ZipArchive::LENGTH_TO_END, $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 $this->fileContents[$entryname] = @file_get_contents($filepath);
@@ -124,7 +124,7 @@ final class BJLG_BackupDatabaseTest extends TestCase
 
         $method = new ReflectionMethod(BJLG\BJLG_Backup::class, 'backup_database');
         $method->setAccessible(true);
-        $method->invoke($backup, $zip, false);
+        $method->invokeArgs($backup, [&$zip, false]);
 
         $this->assertNotEmpty($zip->addedFiles);
 

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -41,7 +41,7 @@ final class BJLG_BackupFilesystemTest extends TestCase
             /** @var array<int, array{0: string, 1: string}> */
             public $addedFiles = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile($filepath, $entryname = "", $start = 0, $length = ZipArchive::LENGTH_TO_END, $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 return true;
@@ -70,7 +70,7 @@ final class BJLG_BackupFilesystemTest extends TestCase
             /** @var array<int, array{0: string, 1: string}> */
             public $addedFiles = [];
 
-            public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+            public function addFile($filepath, $entryname = "", $start = 0, $length = ZipArchive::LENGTH_TO_END, $flags = ZipArchive::FL_OVERWRITE): bool
             {
                 $this->addedFiles[] = [$filepath, $entryname];
                 return true;
@@ -123,13 +123,13 @@ final class BJLG_BackupFilesystemTest extends TestCase
                 /** @var array<int, array{0: string, 1: string}> */
                 public $addedFiles = [];
 
-                public function addFile($filepath, $entryname, $start = 0, $length = 0, $flags = 0): bool
+                public function addFile($filepath, $entryname = "", $start = 0, $length = ZipArchive::LENGTH_TO_END, $flags = ZipArchive::FL_OVERWRITE): bool
                 {
                     $this->addedFiles[] = [$filepath, $entryname];
                     return true;
                 }
 
-                public function setCompressionName($name, $method)
+                public function setCompressionName($name, $method, $compflags = 0): bool
                 {
                     return true;
                 }

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -11,6 +11,30 @@ if (!defined('BJLG_CAPABILITY')) {
     define('BJLG_CAPABILITY', 'manage_options');
 }
 
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!defined('WP_CONTENT_DIR')) {
+    $wp_content_dir = sys_get_temp_dir() . '/bjlg-wp-content';
+    if (!is_dir($wp_content_dir)) {
+        mkdir($wp_content_dir, 0777, true);
+    }
+
+    define('WP_CONTENT_DIR', $wp_content_dir);
+}
+
+if (!defined('WP_PLUGIN_DIR')) {
+    $wp_plugin_dir = WP_CONTENT_DIR . '/plugins';
+    if (!is_dir($wp_plugin_dir)) {
+        mkdir($wp_plugin_dir, 0777, true);
+    }
+
+    define('WP_PLUGIN_DIR', $wp_plugin_dir);
+}
+
 if (!defined('BJLG_BACKUP_DIR')) {
     $test_backup_dir = sys_get_temp_dir() . '/bjlg-tests/';
     if (!is_dir($test_backup_dir)) {
@@ -55,6 +79,18 @@ $GLOBALS['bjlg_test_scheduled_events'] = [
 ];
 $GLOBALS['bjlg_test_options'] = [];
 $GLOBALS['bjlg_registered_routes'] = [];
+
+if (!isset($GLOBALS['wpdb'])) {
+    $GLOBALS['wpdb'] = new class {
+        /** @var string */
+        public $options = 'wp_options';
+
+        public function query($query)
+        {
+            return true;
+        }
+    };
+}
 
 if (!class_exists('WP_Error')) {
     class WP_Error
@@ -417,6 +453,42 @@ if (!function_exists('sanitize_text_field')) {
         $str = strip_tags($str);
         $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
         return trim($str);
+    }
+}
+
+if (!function_exists('wp_cache_flush')) {
+    function wp_cache_flush() {
+        return true;
+    }
+}
+
+if (!function_exists('wp_cache_delete')) {
+    function wp_cache_delete($key, $group = '') {
+        return true;
+    }
+}
+
+if (!function_exists('get_theme_root')) {
+    function get_theme_root() {
+        $root = WP_CONTENT_DIR . '/themes';
+        if (!is_dir($root)) {
+            mkdir($root, 0777, true);
+        }
+
+        return $root;
+    }
+}
+
+if (!function_exists('wp_get_upload_dir')) {
+    function wp_get_upload_dir() {
+        $basedir = WP_CONTENT_DIR . '/uploads';
+        if (!is_dir($basedir)) {
+            mkdir($basedir, 0777, true);
+        }
+
+        return [
+            'basedir' => $basedir,
+        ];
     }
 }
 


### PR DESCRIPTION
## Summary
- track original and decrypted archive paths during restores and remove any temporary decrypted file with logging
- extend the PHPUnit bootstrap with WordPress cache/directory stubs and load the debug class for restore tests
- add a regression test covering encrypted restores and update ZipArchive test doubles to match PHP 8 signatures

## Testing
- vendor-bjlg/bin/phpunit tests/BJLG_RestoreSecurityTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cf228100a0832e94056b2c9aede75b