### PR TITLE
Secure API key user binding

### DIFF
--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -13,7 +13,7 @@ if (!function_exists('get_site_url')) {
     }
 }
 
-if (!class_exists('BJLG\\BJLG_Debug')) {
+if (!class_exists('BJLG\\BJLG_Debug') && !class_exists('BJLG_Debug')) {
     class BJLG_Debug
     {
         /** @var array<int, string> */

--- a/backup-jlg/tests/BJLG_BackupFilesystemTest.php
+++ b/backup-jlg/tests/BJLG_BackupFilesystemTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-if (!class_exists('BJLG\\BJLG_Debug')) {
+if (!class_exists('BJLG\\BJLG_Debug') && !class_exists('BJLG_Debug')) {
     class BJLG_Debug
     {
         /** @var array<int, string> */

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../includes/class-bjlg-debug.php';
+if (!class_exists('BJLG\\BJLG_Debug')) {
+    require_once __DIR__ . '/../includes/class-bjlg-debug.php';
+}
 require_once __DIR__ . '/../includes/class-bjlg-restore.php';
 require_once __DIR__ . '/../includes/class-bjlg-encryption.php';
 

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -361,6 +361,14 @@ if (!function_exists('get_user_by')) {
             }
         }
 
+        if ($field === 'email' || $field === 'user_email') {
+            foreach ($users as $user) {
+                if (isset($user->user_email) && $user->user_email === $value) {
+                    return $user;
+                }
+            }
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- return API key records with their assigned user when verifying and rely on that metadata during authentication
- sanitize stored API key options to enforce user binding, capture roles, and migrate existing entries
- extend the REST API test suite (and supporting fixtures) to cover the new user binding workflow and prevent class redeclarations in tests

## Testing
- `./vendor-bjlg/bin/phpunit --filter BJLG_REST_APITest`
- `./vendor-bjlg/bin/phpunit` *(fails: BJLG_ActionsTest::test_maybe_handle_public_download_uses_status_from_validation, BJLG_IncrementalManifestTest::test_full_backup_updates_incremental_manifest, BJLG_IncrementalManifestTest::test_manifest_updates_even_without_registered_hook, BJLG_REST_APITest::test_download_backup_accepts_ids_with_file_extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68cf353aac3c832e8f416ca8c387862f