### PR TITLE
Align backup type filter with manifest components

### DIFF
--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -186,6 +186,17 @@ namespace {
             $this->assertContains(basename($databaseBackup), $databaseFilenames);
             $this->assertNotContains(basename($uploadsBackup), $databaseFilenames);
 
+            $databaseEntry = null;
+            foreach ($databaseResponse['backups'] as $backup) {
+                if (($backup['filename'] ?? '') === basename($databaseBackup)) {
+                    $databaseEntry = $backup;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($databaseEntry);
+            $this->assertContains('db', $databaseEntry['components'] ?? []);
+
             $filesResponse = $api->get_backups($makeRequest('files'));
             $this->assertIsArray($filesResponse);
             $this->assertArrayHasKey('backups', $filesResponse);
@@ -196,6 +207,17 @@ namespace {
 
             $this->assertContains(basename($uploadsBackup), $filesFilenames);
             $this->assertNotContains(basename($databaseBackup), $filesFilenames);
+
+            $filesEntry = null;
+            foreach ($filesResponse['backups'] as $backup) {
+                if (($backup['filename'] ?? '') === basename($uploadsBackup)) {
+                    $filesEntry = $backup;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($filesEntry);
+            $this->assertNotEmpty(array_intersect(['plugins', 'themes', 'uploads'], $filesEntry['components'] ?? []));
 
             $this->deleteBackupIfExists($databaseBackup);
             $this->deleteBackupIfExists($uploadsBackup);


### PR DESCRIPTION
## Summary
- ensure the backups collection endpoint maps the database/files filters to the manifest component names and historic filename aliases
- extend the REST API test to assert the filtered database and files entries expose the expected components

## Testing
- vendor-bjlg/bin/phpunit *(fails: existing failures in BJLG_ActionsTest::test_maybe_handle_public_download_uses_status_from_validation, BJLG_IncrementalManifestTest::test_full_backup_updates_incremental_manifest, BJLG_IncrementalManifestTest::test_manifest_updates_even_without_registered_hook, BJLG_REST_APITest::test_download_backup_accepts_ids_with_file_extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68cfef0e6328832eb7cdda52c57b3cf5