### PR TITLE
Ensure scheduler singleton reused

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -105,7 +105,7 @@ final class BJLG_Plugin {
 
         $backup_manager = new BJLG\BJLG_Backup();
         new BJLG\BJLG_Restore($backup_manager);
-        new BJLG\BJLG_Scheduler(); BJLG\BJLG_Cleanup::instance(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
+        BJLG\BJLG_Scheduler::instance(); BJLG\BJLG_Cleanup::instance(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
         new BJLG\BJLG_Diagnostics(); new BJLG\BJLG_Webhooks(); new BJLG\BJLG_Incremental(); new BJLG\BJLG_Performance();
         new BJLG\BJLG_REST_API(); new BJLG\BJLG_Settings();
     }

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1636,8 +1636,8 @@ class BJLG_REST_API {
 
         update_option('bjlg_schedule_settings', $validated_schedule);
 
-        // Réinitialiser la planification
-        $scheduler = new BJLG_Scheduler();
+        // Réinitialiser la planification sans multiplier les hooks
+        $scheduler = BJLG_Scheduler::instance();
         $scheduler->check_schedule();
 
         return rest_ensure_response([

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -12,7 +12,27 @@ class BJLG_Scheduler {
 
     const SCHEDULE_HOOK = 'bjlg_scheduled_backup_hook';
 
-    public function __construct() {
+    /**
+     * Instance unique du planificateur.
+     *
+     * @var BJLG_Scheduler|null
+     */
+    private static $instance = null;
+
+    /**
+     * Retourne l'instance unique du planificateur.
+     *
+     * @return BJLG_Scheduler
+     */
+    public static function instance() {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
         // Actions AJAX
         add_action('wp_ajax_bjlg_save_schedule_settings', [$this, 'handle_save_schedule']);
         add_action('wp_ajax_bjlg_get_next_scheduled', [$this, 'handle_get_next_scheduled']);
@@ -26,6 +46,12 @@ class BJLG_Scheduler {
         
         // Vérifier et appliquer la planification au chargement
         add_action('init', [$this, 'check_schedule']);
+    }
+
+    private function __clone() {}
+
+    public function __wakeup() {
+        throw new \Exception('Cannot unserialize singleton');
     }
     
     /**


### PR DESCRIPTION
## Summary
- add a singleton accessor to `BJLG_Scheduler` so the internal hooks are registered only once
- reuse the shared scheduler instance when bootstrapping services and when REST clients create a schedule

## Testing
- not run (WordPress test environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68d045e3564c832e898d9e916696a4dc