### PR TITLE
Add start_time to manual scheduled backups

### DIFF
--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -312,9 +312,10 @@ class BJLG_Scheduler {
             'components' => $settings['components'] ?? ['db', 'plugins', 'themes', 'uploads'],
             'encrypt' => $settings['encrypt'] ?? false,
             'incremental' => $settings['incremental'] ?? false,
-            'source' => 'manual_scheduled'
+            'source' => 'manual_scheduled',
+            'start_time' => time()
         ];
-        
+
         set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         BJLG_Debug::log("Exécution manuelle de la sauvegarde planifiée - Task ID: $task_id");

--- a/backup-jlg/tests/BJLG_SchedulerTest.php
+++ b/backup-jlg/tests/BJLG_SchedulerTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('BJLG\\BJLG_Debug') && !class_exists('BJLG_Debug')) {
+    class BJLG_Debug
+    {
+        /** @var array<int, string> */
+        public static $logs = [];
+
+        /**
+         * @param mixed $message
+         */
+        public static function log($message): void
+        {
+            self::$logs[] = (string) $message;
+        }
+    }
+
+    class_alias('BJLG_Debug', 'BJLG\\BJLG_Debug');
+}
+
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+require_once __DIR__ . '/../includes/class-bjlg-scheduler.php';
+
+final class BJLG_SchedulerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = true;
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_scheduled_events'] = [
+            'recurring' => [],
+            'single' => [],
+        ];
+        $GLOBALS['bjlg_test_options'] = [];
+        $_POST = [];
+        $_REQUEST = [];
+    }
+
+    public function test_handle_run_scheduled_now_sets_start_time(): void
+    {
+        update_option('bjlg_schedule_settings', [
+            'components' => ['db', 'themes'],
+            'encrypt' => true,
+            'incremental' => true,
+        ]);
+
+        $_POST['nonce'] = 'test-nonce';
+
+        $scheduler = BJLG\BJLG_Scheduler::instance();
+
+        try {
+            $scheduler->handle_run_scheduled_now();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('task_id', $response->data);
+            $task_id = $response->data['task_id'];
+        }
+
+        $this->assertArrayHasKey($task_id, $GLOBALS['bjlg_test_transients']);
+        $task_data = $GLOBALS['bjlg_test_transients'][$task_id];
+
+        $this->assertArrayHasKey('start_time', $task_data);
+        $this->assertIsInt($task_data['start_time']);
+        $this->assertGreaterThan(0, $task_data['start_time']);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure manually-triggered scheduled backups record a start_time in their task payload
- add a PHPUnit test that exercises handle_run_scheduled_now and asserts the task has a start_time

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d054aa11e0832eaa4e726f38288ba3