### PR TITLE
Fix GMT formatting for scheduled timestamps

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -83,7 +83,7 @@ class BJLG_Health_Check {
             if ($cleanup_timestamp < time()) {
                 $messages[] = "Nettoyage en retard de " . human_time_diff($cleanup_timestamp, time());
             } else {
-                $messages[] = "Nettoyage : " . get_date_from_gmt(date('Y-m-d H:i:s', $cleanup_timestamp), 'd/m/Y H:i');
+                $messages[] = "Nettoyage : " . get_date_from_gmt(gmdate('Y-m-d H:i:s', $cleanup_timestamp), 'd/m/Y H:i');
             }
         }
         
@@ -91,7 +91,7 @@ class BJLG_Health_Check {
             if ($backup_timestamp < time()) {
                 $messages[] = "Sauvegarde en retard de " . human_time_diff($backup_timestamp, time());
             } else {
-                $messages[] = "Sauvegarde : " . get_date_from_gmt(date('Y-m-d H:i:s', $backup_timestamp), 'd/m/Y H:i');
+                $messages[] = "Sauvegarde : " . get_date_from_gmt(gmdate('Y-m-d H:i:s', $backup_timestamp), 'd/m/Y H:i');
             }
         }
         

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -145,7 +145,7 @@ class BJLG_Scheduler {
         
         // Obtenir la prochaine exécution
         $next_run = wp_next_scheduled(self::SCHEDULE_HOOK);
-        $next_run_formatted = $next_run ? get_date_from_gmt(date('Y-m-d H:i:s', $next_run), 'd/m/Y H:i:s') : 'Non planifié';
+        $next_run_formatted = $next_run ? get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'd/m/Y H:i:s') : 'Non planifié';
         
         wp_send_json_success([
             'message' => 'Planification enregistrée !',
@@ -175,11 +175,11 @@ class BJLG_Scheduler {
             BJLG_Debug::log(sprintf(
                 "Nouvelle sauvegarde planifiée (%s). Prochaine exécution : %s",
                 $settings['recurrence'],
-                get_date_from_gmt(date('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
+                get_date_from_gmt(gmdate('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
             ));
             
             BJLG_History::log('schedule_updated', 'success', 
-                'Prochaine sauvegarde planifiée pour le ' . get_date_from_gmt(date('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
+                'Prochaine sauvegarde planifiée pour le ' . get_date_from_gmt(gmdate('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
             );
         } else {
             BJLG_Debug::log("ERREUR : Impossible de calculer le timestamp pour la planification.");
@@ -283,7 +283,7 @@ class BJLG_Scheduler {
         if ($next_run) {
             $response['next_run'] = $next_run;
             $response['next_run_formatted'] = get_date_from_gmt(
-                date('Y-m-d H:i:s', $next_run),
+                gmdate('Y-m-d H:i:s', $next_run),
                 'd/m/Y H:i:s'
             );
             $response['next_run_relative'] = human_time_diff($next_run, current_time('timestamp'));


### PR DESCRIPTION
## Summary
- ensure scheduler formatting uses gmdate before get_date_from_gmt so dates are truly GMT
- align health check cron status output to use GMT strings as well

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d060e69904832e9647bd3177a3f7a9