### PR TITLE
Ensure GMT strings when formatting scheduled times

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -83,15 +83,15 @@ class BJLG_Health_Check {
             if ($cleanup_timestamp < time()) {
                 $messages[] = "Nettoyage en retard de " . human_time_diff($cleanup_timestamp, time());
             } else {
-                $messages[] = "Nettoyage : " . get_date_from_gmt(gmdate('Y-m-d H:i:s', $cleanup_timestamp), 'd/m/Y H:i');
+                $messages[] = "Nettoyage : " . get_date_from_gmt($this->format_gmt_datetime($cleanup_timestamp), 'd/m/Y H:i');
             }
         }
-        
+
         if ($backup_timestamp) {
             if ($backup_timestamp < time()) {
                 $messages[] = "Sauvegarde en retard de " . human_time_diff($backup_timestamp, time());
             } else {
-                $messages[] = "Sauvegarde : " . get_date_from_gmt(gmdate('Y-m-d H:i:s', $backup_timestamp), 'd/m/Y H:i');
+                $messages[] = "Sauvegarde : " . get_date_from_gmt($this->format_gmt_datetime($backup_timestamp), 'd/m/Y H:i');
             }
         }
         
@@ -108,6 +108,13 @@ class BJLG_Health_Check {
             'status' => $has_warning ? 'warning' : 'success',
             'message' => implode(' | ', $messages)
         ];
+    }
+
+    /**
+     * Retourne la date/heure GMT formatée attendue par get_date_from_gmt().
+     */
+    private function format_gmt_datetime($timestamp) {
+        return gmdate('Y-m-d H:i:s', $timestamp);
     }
 
     /**

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -145,7 +145,7 @@ class BJLG_Scheduler {
         
         // Obtenir la prochaine exécution
         $next_run = wp_next_scheduled(self::SCHEDULE_HOOK);
-        $next_run_formatted = $next_run ? get_date_from_gmt(gmdate('Y-m-d H:i:s', $next_run), 'd/m/Y H:i:s') : 'Non planifié';
+        $next_run_formatted = $next_run ? get_date_from_gmt($this->format_gmt_datetime($next_run), 'd/m/Y H:i:s') : 'Non planifié';
         
         wp_send_json_success([
             'message' => 'Planification enregistrée !',
@@ -175,11 +175,11 @@ class BJLG_Scheduler {
             BJLG_Debug::log(sprintf(
                 "Nouvelle sauvegarde planifiée (%s). Prochaine exécution : %s",
                 $settings['recurrence'],
-                get_date_from_gmt(gmdate('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
+                get_date_from_gmt($this->format_gmt_datetime($first_timestamp), 'd/m/Y H:i:s')
             ));
-            
-            BJLG_History::log('schedule_updated', 'success', 
-                'Prochaine sauvegarde planifiée pour le ' . get_date_from_gmt(gmdate('Y-m-d H:i:s', $first_timestamp), 'd/m/Y H:i:s')
+
+            BJLG_History::log('schedule_updated', 'success',
+                'Prochaine sauvegarde planifiée pour le ' . get_date_from_gmt($this->format_gmt_datetime($first_timestamp), 'd/m/Y H:i:s')
             );
         } else {
             BJLG_Debug::log("ERREUR : Impossible de calculer le timestamp pour la planification.");
@@ -283,7 +283,7 @@ class BJLG_Scheduler {
         if ($next_run) {
             $response['next_run'] = $next_run;
             $response['next_run_formatted'] = get_date_from_gmt(
-                gmdate('Y-m-d H:i:s', $next_run),
+                $this->format_gmt_datetime($next_run),
                 'd/m/Y H:i:s'
             );
             $response['next_run_relative'] = human_time_diff($next_run, current_time('timestamp'));
@@ -291,7 +291,14 @@ class BJLG_Scheduler {
         
         wp_send_json_success($response);
     }
-    
+
+    /**
+     * Retourne la date/heure GMT formatée attendue par get_date_from_gmt().
+     */
+    private function format_gmt_datetime($timestamp) {
+        return gmdate('Y-m-d H:i:s', $timestamp);
+    }
+
     /**
      * Exécute immédiatement une sauvegarde planifiée
      */


### PR DESCRIPTION
## Summary
- reuse a dedicated helper in the scheduler to consistently feed GMT strings into `get_date_from_gmt()` when reporting next runs
- ensure the health check cron status formatter also relies on GMT timestamps before localizing dates

## Testing
- `cd backup-jlg && composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d064743db8832ea9d00036b80bdfad