### PR TITLE
Handle ZipArchive close failures in backup task

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -283,7 +283,7 @@ class BJLG_Backup {
             // Fermer l'archive
             $close_result = @$zip->close();
 
-            if ($close_result === false && !file_exists($backup_filepath)) {
+            if ($close_result !== true) {
                 throw new Exception("Impossible de finaliser l'archive ZIP.");
             }
             


### PR DESCRIPTION
## Summary
- throw an exception whenever `ZipArchive::close()` fails so the backup task goes through the error path

## Testing
- ./vendor-bjlg/bin/phpunit


------
https://chatgpt.com/codex/tasks/task_e_68d07de71abc832e97f4d34ff3e539aa