### PR TITLE
Fix REST settings option mapping for notifications and webhooks

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1593,8 +1593,13 @@ class BJLG_REST_API {
             return $validated_settings;
         }
 
+        $option_name_map = [
+            'notifications' => 'bjlg_notification_settings',
+            'webhooks' => 'bjlg_webhook_settings',
+        ];
+
         foreach ($validated_settings as $key => $value) {
-            $option_name = 'bjlg_' . $key . '_settings';
+            $option_name = $option_name_map[$key] ?? 'bjlg_' . $key . '_settings';
             update_option($option_name, $value);
         }
 

--- a/backup-jlg/readme.md
+++ b/backup-jlg/readme.md
@@ -309,6 +309,7 @@ header('X-XSS-Protection: 1; mode=block');
 - ✨ Sauvegardes incrémentales
 - ✨ Interface moderne
 - ✨ Système de notifications avancé
+- 🛠️ Correction : l'API REST met à jour correctement les réglages de notifications et de webhooks
 - 🐛 Correction du bug d'export SQL
 - 🔧 Optimisations générales
 

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -791,6 +791,40 @@ namespace {
             $this->assertSame($original_cleanup, get_option('bjlg_cleanup_settings'));
         }
 
+        public function test_update_settings_saves_notifications_and_webhooks(): void
+        {
+            $api = new BJLG\BJLG_REST_API();
+
+            $payload = [
+                'notifications' => ['email' => ['enabled' => true]],
+                'webhooks' => ['endpoints' => ['https://example.com/hook']],
+            ];
+
+            $request = new class($payload) {
+                /** @var array<string, mixed> */
+                private $payload;
+
+                /**
+                 * @param array<string, mixed> $payload
+                 */
+                public function __construct(array $payload)
+                {
+                    $this->payload = $payload;
+                }
+
+                public function get_json_params()
+                {
+                    return $this->payload;
+                }
+            };
+
+            $response = $api->update_settings($request);
+
+            $this->assertIsArray($response);
+            $this->assertSame($payload['notifications'], get_option('bjlg_notification_settings'));
+            $this->assertSame($payload['webhooks'], get_option('bjlg_webhook_settings'));
+        }
+
         public function test_create_schedule_rejects_incomplete_payload(): void
         {
             $api = new BJLG\BJLG_REST_API();


### PR DESCRIPTION
## Summary
- update the REST settings endpoint to map notifications and webhooks to their canonical option names
- add a PHPUnit test covering PUT /settings requests with notifications and webhook data
- document the fix in the changelog

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d14ca38660832e81e0e163a57a12c1