### PR TITLE
Use global ZipArchive in health check

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -352,18 +352,18 @@ class BJLG_Health_Check {
      * Vérifie l'extension ZIP
      */
     private function check_zip_extension() {
-        if (!class_exists('ZipArchive')) {
+        if (!class_exists(\ZipArchive::class)) {
             return [
                 'status' => 'error',
                 'message' => 'Extension PHP ZIP manquante ! Requise pour créer les sauvegardes.'
             ];
         }
-        
+
         // Tester la création d'une archive
         $test_file = BJLG_BACKUP_DIR . 'test_' . uniqid() . '.zip';
-        $zip = new ZipArchive();
-        
-        if ($zip->open($test_file, ZipArchive::CREATE) === TRUE) {
+        $zip = new \ZipArchive();
+
+        if ($zip->open($test_file, \ZipArchive::CREATE) === TRUE) {
             $zip->addFromString('test.txt', 'test');
             $zip->close();
             @unlink($test_file);


### PR DESCRIPTION
## Summary
- ensure the health check references ZipArchive via the global namespace
- update instantiation and constants to use the fully qualified ZipArchive class

## Testing
- php -l backup-jlg/includes/class-bjlg-health-check.php

------
https://chatgpt.com/codex/tasks/task_e_68d194f81e5c832eb1e66c311bc9e85f