### PR TITLE
Use fully qualified ZipArchive in health check

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -352,7 +352,7 @@ class BJLG_Health_Check {
      * Vérifie l'extension ZIP
      */
     private function check_zip_extension() {
-        if (!class_exists(\ZipArchive::class)) {
+        if (!class_exists('\\ZipArchive')) {
             return [
                 'status' => 'error',
                 'message' => 'Extension PHP ZIP manquante ! Requise pour créer les sauvegardes.'


### PR DESCRIPTION
## Summary
- ensure the health check ZipArchive existence check uses the global class name string
- leave instantiation and constants using the global ZipArchive reference

## Testing
- php -l backup-jlg/includes/class-bjlg-health-check.php

------
https://chatgpt.com/codex/tasks/task_e_68d19ef462f4832eb2053e732eefc79a