### PR TITLE
Use fully qualified ZipArchive reference in health check

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -352,7 +352,7 @@ class BJLG_Health_Check {
      * Vérifie l'extension ZIP
      */
     private function check_zip_extension() {
-        if (!class_exists('\\ZipArchive')) {
+        if (!class_exists(\ZipArchive::class)) {
             return [
                 'status' => 'error',
                 'message' => 'Extension PHP ZIP manquante ! Requise pour créer les sauvegardes.'


### PR DESCRIPTION
## Summary
- update the health check's ZipArchive availability test to reference the global class explicitly

## Testing
- php -l includes/class-bjlg-health-check.php

------
https://chatgpt.com/codex/tasks/task_e_68d1b2d55740832e8bc1c3c07f0655bf