### PR TITLE
Preserve decimal precision in backup progress reporting

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -82,7 +82,14 @@ jQuery(document).ready(function($) {
                     if (response.success && response.data) {
                         const data = response.data;
                         $statusText.text(data.status_text || 'Progression...');
-                        $progressBar.css('width', data.progress + '%').text(data.progress + '%');
+
+                        const progressValue = Number.parseFloat(data.progress);
+                        const hasNumericProgress = Number.isFinite(progressValue);
+                        const progressDisplay = hasNumericProgress ? progressValue.toFixed(1) : data.progress;
+
+                        $progressBar
+                            .css('width', progressDisplay + '%')
+                            .text(progressDisplay + '%');
                         
                         if (data.progress >= 100) {
                             clearInterval(interval);

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -277,7 +277,7 @@ class BJLG_Backup {
                 }
                 
                 $progress += $progress_per_component;
-                $this->update_task_progress($task_id, round($progress), 'running', "Composant $component terminé");
+                $this->update_task_progress($task_id, round($progress, 1), 'running', "Composant $component terminé");
             }
             
             // Fermer l'archive
@@ -825,6 +825,14 @@ class BJLG_Backup {
     private function update_task_progress($task_id, $progress, $status, $status_text) {
         $task_data = get_transient($task_id);
         if ($task_data) {
+            if (is_numeric($progress)) {
+                $progress = round((float) $progress, 1);
+
+                if (abs($progress - round($progress)) < 0.0001) {
+                    $progress = (int) round($progress);
+                }
+            }
+
             $task_data['progress'] = $progress;
             $task_data['status'] = $status;
             $task_data['status_text'] = $status_text;

--- a/backup-jlg/tests/BJLG_BackupProgressTest.php
+++ b/backup-jlg/tests/BJLG_BackupProgressTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class BJLG_BackupProgressTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_transients'] = [];
+    }
+
+    public function test_update_task_progress_stores_decimal_progress(): void
+    {
+        $task_id = 'bjlg_backup_' . uniqid('test', true);
+
+        set_transient($task_id, [
+            'progress' => 0,
+            'status' => 'pending',
+            'status_text' => 'Initialisation',
+        ], HOUR_IN_SECONDS);
+
+        $backup = new BJLG\BJLG_Backup();
+
+        $method = new ReflectionMethod($backup, 'update_task_progress');
+        $method->setAccessible(true);
+        $method->invoke($backup, $task_id, 42.65, 'running', 'Test progress');
+
+        $task_data = get_transient($task_id);
+
+        $this->assertIsArray($task_data);
+        $this->assertArrayHasKey('progress', $task_data);
+        $this->assertSame(42.7, $task_data['progress']);
+        $this->assertSame('running', $task_data['status']);
+        $this->assertSame('Test progress', $task_data['status_text']);
+    }
+
+    public function test_update_task_progress_preserves_integer_progress(): void
+    {
+        $task_id = 'bjlg_backup_' . uniqid('test', true);
+
+        set_transient($task_id, [
+            'progress' => 10,
+            'status' => 'running',
+            'status_text' => 'En cours',
+        ], HOUR_IN_SECONDS);
+
+        $backup = new BJLG\BJLG_Backup();
+
+        $method = new ReflectionMethod($backup, 'update_task_progress');
+        $method->setAccessible(true);
+        $method->invoke($backup, $task_id, 50, 'running', 'Toujours en cours');
+
+        $task_data = get_transient($task_id);
+
+        $this->assertIsArray($task_data);
+        $this->assertArrayHasKey('progress', $task_data);
+        $this->assertSame(50, $task_data['progress']);
+        $this->assertSame('running', $task_data['status']);
+        $this->assertSame('Toujours en cours', $task_data['status_text']);
+    }
+}


### PR DESCRIPTION
## Summary
- keep backup progress updates at decimal precision and normalize stored values
- ensure the admin progress bar renders percentages with one decimal place
- cover decimal progress handling with new unit tests

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1b932a900832ea8ac162db942bdb0