### PR TITLE
Normalize backup directory glob result

### DIFF
--- a/backup-jlg/includes/class-bjlg-health-check.php
+++ b/backup-jlg/includes/class-bjlg-health-check.php
@@ -145,7 +145,7 @@ class BJLG_Health_Check {
         }
         
         // Compter les sauvegardes
-        $backups = glob(BJLG_BACKUP_DIR . '*.zip*');
+        $backups = glob(BJLG_BACKUP_DIR . '*.zip*') ?: [];
         $count = count($backups);
         $size = 0;
         foreach ($backups as $backup) {


### PR DESCRIPTION
## Summary
- ensure the backup directory glob result defaults to an empty array before counting and iterating

## Testing
- not run (environment only includes plugin source)


------
https://chatgpt.com/codex/tasks/task_e_68d1c972be30832e9f877ce3c9e28187