### PR TITLE
Ensure webhook backup tasks track start time and duration

### DIFF
--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -119,9 +119,10 @@ class BJLG_Webhooks {
             'components' => $components,
             'encrypt' => $encrypt,
             'incremental' => $incremental,
-            'source' => 'webhook'
+            'source' => 'webhook',
+            'start_time' => time()
         ];
-        
+
         set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
         
         // Planifier l'exécution immédiate


### PR DESCRIPTION
## Summary
- ensure webhook-triggered backup tasks store a start time before scheduling
- add a REST API test that asserts webhook backup durations are positive and bounded

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d25d972b4c832e9c67a72d1a45943e