### PR TITLE
Add rate limiting to auth endpoint

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -47,7 +47,7 @@ class BJLG_REST_API {
         register_rest_route(self::API_NAMESPACE, '/auth', [
             'methods' => 'POST',
             'callback' => [$this, 'authenticate'],
-            'permission_callback' => '__return_true',
+            'permission_callback' => [$this, 'check_auth_permissions'],
             'args' => [
                 'username' => [
                     'required' => true,
@@ -180,7 +180,7 @@ class BJLG_REST_API {
                 ]
             ]
         ]);
-        
+
         // Routes : Statut et monitoring
         register_rest_route(self::API_NAMESPACE, '/status', [
             'methods' => 'GET',
@@ -263,7 +263,22 @@ class BJLG_REST_API {
             'permission_callback' => [$this, 'check_permissions'],
         ]);
     }
-    
+
+    /**
+     * Vérification des permissions pour l'authentification
+     */
+    public function check_auth_permissions($request) {
+        if ($this->rate_limiter && !$this->rate_limiter->check($request)) {
+            return new WP_Error(
+                'rate_limit_exceeded',
+                __('Trop de requêtes. Veuillez patienter.', 'backup-jlg'),
+                ['status' => 429]
+            );
+        }
+
+        return true;
+    }
+
     /**
      * Vérification des permissions de base
      */


### PR DESCRIPTION
## Summary
- route /auth through a dedicated permission callback that enforces the REST rate limiter and 429 errors
- keep authentication reachable when rate limits allow and extend the REST API test suite with rate limiting coverage

## Testing
- ./vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d26bbc4410832e864ee49188aaf340