### PR TITLE
Implement async restore upload workflow

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -115,6 +115,140 @@ jQuery(document).ready(function($) {
             }, 3000);
         }
     });
+
+    // --- GESTIONNAIRE DE RESTAURATION ---
+    $('#bjlg-restore-form').on('submit', function(e) {
+        e.preventDefault();
+
+        const $form = $(this);
+        const $button = $form.find('button[type="submit"]');
+        const $statusWrapper = $('#bjlg-restore-status');
+        const $statusText = $('#bjlg-restore-status-text');
+        const $progressBar = $('#bjlg-restore-progress-bar');
+        const fileInput = $form.find('input[name="restore_file"]')[0];
+
+        if (!fileInput || !fileInput.files || !fileInput.files.length) {
+            alert('Veuillez sélectionner un fichier de sauvegarde à restaurer.');
+            return;
+        }
+
+        const createBackupBeforeRestore = $form.find('input[name="create_backup_before_restore"]').is(':checked');
+
+        $button.prop('disabled', true);
+        $statusWrapper.show();
+        $statusText.text('Téléversement du fichier...');
+        $progressBar.css('width', '0%').text('0%');
+
+        const formData = new FormData();
+        formData.append('action', 'bjlg_upload_restore_file');
+        formData.append('nonce', bjlg_ajax.nonce);
+        formData.append('restore_file', fileInput.files[0]);
+
+        $.ajax({
+            url: bjlg_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false
+        })
+        .done(function(response) {
+            if (response.success && response.data && response.data.filename) {
+                $statusText.text('Fichier téléversé. Initialisation de la restauration...');
+                runRestoreTask(response.data.filename, createBackupBeforeRestore);
+            } else {
+                const message = response.data && response.data.message ? response.data.message : 'Réponse invalide lors du téléversement.';
+                $statusText.text('Erreur : ' + message);
+                $button.prop('disabled', false);
+            }
+        })
+        .fail(function(xhr) {
+            const errorMessage = xhr && xhr.status ? ' (' + xhr.status + ')' : '';
+            $statusText.text('Erreur lors du téléversement du fichier' + errorMessage + '.');
+            $button.prop('disabled', false);
+        });
+
+        function runRestoreTask(filename, createBackup) {
+            $.ajax({
+                url: bjlg_ajax.ajax_url,
+                type: 'POST',
+                data: {
+                    action: 'bjlg_run_restore',
+                    nonce: bjlg_ajax.nonce,
+                    filename: filename,
+                    create_backup_before_restore: createBackup ? '1' : '0'
+                }
+            })
+            .done(function(response) {
+                if (response.success && response.data && response.data.task_id) {
+                    $statusText.text('Restauration en cours...');
+                    pollRestoreProgress(response.data.task_id);
+                } else {
+                    const message = response.data && response.data.message ? response.data.message : 'Réponse invalide lors du lancement de la restauration.';
+                    $statusText.text('Erreur : ' + message);
+                    $button.prop('disabled', false);
+                }
+            })
+            .fail(function(xhr) {
+                const errorMessage = xhr && xhr.status ? ' (' + xhr.status + ')' : '';
+                $statusText.text('Erreur lors du lancement de la restauration' + errorMessage + '.');
+                $button.prop('disabled', false);
+            });
+        }
+
+        function pollRestoreProgress(taskId) {
+            const interval = setInterval(function() {
+                $.ajax({
+                    url: bjlg_ajax.ajax_url,
+                    type: 'POST',
+                    data: {
+                        action: 'bjlg_check_restore_progress',
+                        nonce: bjlg_ajax.nonce,
+                        task_id: taskId
+                    }
+                })
+                .done(function(response) {
+                    if (response.success && response.data) {
+                        const data = response.data;
+
+                        if (typeof data.status_text === 'string') {
+                            $statusText.text(data.status_text);
+                        }
+
+                        if (typeof data.progress !== 'undefined') {
+                            const progressValue = Number.parseFloat(data.progress);
+                            const hasNumericProgress = Number.isFinite(progressValue);
+                            const progressDisplay = hasNumericProgress ? progressValue.toFixed(1) : data.progress;
+                            $progressBar
+                                .css('width', progressDisplay + '%')
+                                .text(progressDisplay + '%');
+                        }
+
+                        if (data.status === 'complete') {
+                            clearInterval(interval);
+                            $statusText.html('✔️ Restauration terminée ! Rechargement de la page...');
+                            $progressBar.css('width', '100%').text('100%');
+                            setTimeout(function() { window.location.reload(); }, 2500);
+                        } else if (data.status === 'error') {
+                            clearInterval(interval);
+                            const errorText = data.status_text || 'Une erreur est survenue pendant la restauration.';
+                            $statusText.html('<span style="color:red;">❌ ' + errorText + '</span>');
+                            $button.prop('disabled', false);
+                        }
+                    } else {
+                        clearInterval(interval);
+                        const message = response.data && response.data.message ? response.data.message : 'La progression de la restauration est introuvable.';
+                        $statusText.text('Erreur : ' + message);
+                        $button.prop('disabled', false);
+                    }
+                })
+                .fail(function() {
+                    clearInterval(interval);
+                    $statusText.text('Erreur de communication lors du suivi de la restauration.');
+                    $button.prop('disabled', false);
+                });
+            }, 3000);
+        }
+    });
     
     // --- GESTIONNAIRE SAUVEGARDE DES RÉGLAGES ---
     $('.bjlg-settings-form').on('submit', function(e) {

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -246,7 +246,7 @@ class BJLG_Admin {
         <div class="bjlg-section">
             <h2>Restaurer depuis un fichier</h2>
             <p>Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration.</p>
-            <form id="bjlg-restore-form" enctype="multipart/form-data">
+            <form id="bjlg-restore-form" method="post" enctype="multipart/form-data">
                 <table class="form-table">
                     <tbody>
                         <tr>

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -320,13 +320,25 @@ class BJLG_Restore {
 
         // Créer une tâche de restauration
         $task_id = 'bjlg_restore_' . md5(uniqid('restore', true));
+        $create_backup_before_restore = true;
+        if (array_key_exists('create_backup_before_restore', $_POST)) {
+            $raw_create_backup = wp_unslash($_POST['create_backup_before_restore']);
+            $filtered_value = filter_var($raw_create_backup, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if ($filtered_value === null) {
+                $create_backup_before_restore = !empty($raw_create_backup);
+            } else {
+                $create_backup_before_restore = (bool) $filtered_value;
+            }
+        }
+
         $task_data = [
             'progress' => 0,
             'status' => 'pending',
             'status_text' => 'Initialisation de la restauration...',
             'filename' => $filename,
             'filepath' => $filepath,
-            'password_encrypted' => $encrypted_password
+            'password_encrypted' => $encrypted_password,
+            'create_restore_point' => (bool) $create_backup_before_restore
         ];
         
         set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());


### PR DESCRIPTION
## Summary
- add a JavaScript restore form handler that uploads the file via AJAX, launches the restore job and polls its progress
- persist the "create backup before restore" option when scheduling a restore task and clarify the restore form intent with an explicit POST method

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2bd057968832e9b8310452ac67643