### PR TITLE
feat: add async restore upload workflow

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -246,7 +246,7 @@ class BJLG_Admin {
         <div class="bjlg-section">
             <h2>Restaurer depuis un fichier</h2>
             <p>Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration.</p>
-            <form id="bjlg-restore-form" enctype="multipart/form-data">
+            <form id="bjlg-restore-form" method="post" enctype="multipart/form-data">
                 <table class="form-table">
                     <tbody>
                         <tr>


### PR DESCRIPTION
## Summary
- add a JavaScript handler that uploads restore files via AJAX, starts the restore task, and polls for progress updates
- add an explicit POST method to the restore form for graceful non-JS submission

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2cb118c80832e971553b6230964b1