### PR TITLE
Harden API key cleanup and validate restore files

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup-path-resolver.php
+++ b/backup-jlg/includes/class-bjlg-backup-path-resolver.php
@@ -1,0 +1,85 @@
+<?php
+namespace BJLG;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Fournit des méthodes utilitaires pour résoudre les chemins des sauvegardes.
+ */
+class BJLG_Backup_Path_Resolver {
+
+    /**
+     * Résout et valide le chemin d'une sauvegarde à partir d'un identifiant brut.
+     *
+     * @param mixed $raw_id
+     * @return string|WP_Error
+     */
+    public static function resolve($raw_id) {
+        $sanitized_id = sanitize_file_name(basename((string) $raw_id));
+
+        if ($sanitized_id === '') {
+            return new WP_Error(
+                'invalid_backup_id',
+                'Invalid backup ID',
+                ['status' => 400]
+            );
+        }
+
+        $canonical_backup_dir = realpath(BJLG_BACKUP_DIR);
+
+        if ($canonical_backup_dir === false) {
+            return new WP_Error(
+                'invalid_backup_id',
+                'Invalid backup ID',
+                ['status' => 400]
+            );
+        }
+
+        $canonical_backup_dir = rtrim($canonical_backup_dir, "/\\") . DIRECTORY_SEPARATOR;
+
+        $candidate_paths = [BJLG_BACKUP_DIR . $sanitized_id];
+
+        if (strtolower(substr($sanitized_id, -4)) !== '.zip') {
+            $candidate_paths[] = BJLG_BACKUP_DIR . $sanitized_id . '.zip';
+        }
+
+        $canonical_length = strlen($canonical_backup_dir);
+
+        foreach ($candidate_paths as $candidate_path) {
+            if (!file_exists($candidate_path)) {
+                continue;
+            }
+
+            $resolved_path = realpath($candidate_path);
+
+            if ($resolved_path === false) {
+                return new WP_Error(
+                    'invalid_backup_id',
+                    'Invalid backup ID',
+                    ['status' => 400]
+                );
+            }
+
+            if (strlen($resolved_path) < $canonical_length || strncmp($resolved_path, $canonical_backup_dir, $canonical_length) !== 0) {
+                return new WP_Error(
+                    'invalid_backup_id',
+                    'Invalid backup ID',
+                    ['status' => 400]
+                );
+            }
+
+            return $resolved_path;
+        }
+
+        return new WP_Error(
+            'backup_not_found',
+            'Backup not found',
+            ['status' => 404]
+        );
+    }
+}
+

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -11,6 +11,11 @@ require_once __DIR__ . '/../includes/class-bjlg-encryption.php';
 
 final class BJLG_RestoreSecurityTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    private $existingBackupPath;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -20,6 +25,22 @@ final class BJLG_RestoreSecurityTest extends TestCase
         $GLOBALS['bjlg_test_scheduled_events'] = [];
 
         $_POST = [];
+
+        if (!is_dir(BJLG_BACKUP_DIR)) {
+            mkdir(BJLG_BACKUP_DIR, 0777, true);
+        }
+
+        $this->existingBackupPath = BJLG_BACKUP_DIR . 'backup.zip';
+        file_put_contents($this->existingBackupPath, 'dummy-backup');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->existingBackupPath)) {
+            unlink($this->existingBackupPath);
+        }
+
+        parent::tearDown();
     }
 
     public function test_password_is_preserved_and_encrypted_before_storage(): void


### PR DESCRIPTION
## Summary
- ensure expired or invalid API keys are removed from storage immediately and share validation helpers across REST handlers
- centralize backup path resolution in a dedicated helper and reuse it for both REST and AJAX restore flows
- extend restore security tests to provision a dummy backup file before scheduling tasks

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3c50470f8832ea312d6a17c71efde