### PR TITLE
Improve backup deletion and restore safety

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -49,8 +49,8 @@ class BJLG_Actions {
                 throw new Exception("Nom de fichier invalide.");
             }
 
-            // Construire le chemin initial vers le fichier
-            $filepath = BJLG_BACKUP_DIR . $filename;
+            // Construire le chemin initial vers le fichier en utilisant le chemin canonique du répertoire
+            $filepath = $real_backup_dir . DIRECTORY_SEPARATOR . $filename;
 
             // Obtenir le chemin canonique du fichier pour la sécurité
             $real_filepath = realpath($filepath);


### PR DESCRIPTION
## Summary
- ensure backup deletion resolves the target file path inside the real backup directory before unlinking
- validate cron scheduling succeeds before storing new backup task state
- wrap SQL import in strict transaction handling and rollback on any query failure

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3e717a6c0832e94cf3d8058b619cd