### PR TITLE
Renforce la fiabilité du dossier de sauvegarde et unifie le chiffrement

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -103,11 +103,20 @@ final class BJLG_Plugin {
         new BJLG\BJLG_Admin();
         new BJLG\BJLG_Actions();
 
-        $backup_manager = new BJLG\BJLG_Backup();
-        new BJLG\BJLG_Restore($backup_manager);
-        BJLG\BJLG_Scheduler::instance(); BJLG\BJLG_Cleanup::instance(); new BJLG\BJLG_Encryption(); new BJLG\BJLG_Health_Check();
-        new BJLG\BJLG_Diagnostics(); new BJLG\BJLG_Webhooks(); new BJLG\BJLG_Incremental(); new BJLG\BJLG_Performance();
-        new BJLG\BJLG_REST_API(); new BJLG\BJLG_Settings();
+        $encryption_service = new BJLG\BJLG_Encryption();
+        $performance_service = new BJLG\BJLG_Performance();
+
+        $backup_manager = new BJLG\BJLG_Backup($performance_service, $encryption_service);
+        new BJLG\BJLG_Restore($backup_manager, $encryption_service);
+
+        BJLG\BJLG_Scheduler::instance();
+        BJLG\BJLG_Cleanup::instance();
+        new BJLG\BJLG_Health_Check();
+        new BJLG\BJLG_Diagnostics();
+        new BJLG\BJLG_Webhooks();
+        new BJLG\BJLG_Incremental();
+        new BJLG\BJLG_REST_API();
+        new BJLG\BJLG_Settings();
     }
     
     public function enqueue_admin_assets($hook) {

--- a/backup-jlg/includes/class-bjlg-history.php
+++ b/backup-jlg/includes/class-bjlg-history.php
@@ -64,28 +64,37 @@ class BJLG_History {
         if ($user_id === null) {
             $user_id = get_current_user_id();
         }
-        
+
+        if (!is_numeric($user_id) || (int) $user_id === 0) {
+            $user_id = null;
+        } else {
+            $user_id = (int) $user_id;
+        }
+
         // Obtenir l'adresse IP
         $ip_address = self::get_client_ip();
-        
+
+        $data = [
+            'timestamp'   => current_time('mysql'),
+            'action_type' => $action,
+            'status'      => $status,
+            'details'     => $details,
+        ];
+
+        $formats = ['%s', '%s', '%s', '%s'];
+
+        if ($user_id !== null) {
+            $data['user_id'] = $user_id;
+            $formats[] = '%d';
+        }
+
+        $data['ip_address'] = $ip_address;
+        $formats[] = '%s';
+
         $result = $wpdb->insert(
             $table_name,
-            [
-                'timestamp'   => current_time('mysql'),
-                'action_type' => $action,
-                'status'      => $status,
-                'details'     => $details,
-                'user_id'     => $user_id ?: null,
-                'ip_address'  => $ip_address
-            ],
-            [
-                '%s', // format pour timestamp
-                '%s', // format pour action_type
-                '%s', // format pour status
-                '%s', // format pour details
-                '%d', // format pour user_id
-                '%s', // format pour ip_address
-            ]
+            $data,
+            $formats
         );
         
         if ($result === false) {


### PR DESCRIPTION
## Summary
- évite l'enregistrement d'un identifiant utilisateur fantôme dans l'historique lorsque l'action provient du système
- vérifie et recrée le dossier bjlg-backups avant chaque archive en exposant les erreurs ZipArchive
- partage une instance unique du service de chiffrement entre les gestionnaires de sauvegarde et de restauration

## Testing
- composer test *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d42f30cff0832e8269ec8276f4512a