### PR TITLE
Improve autoloading, download tokens, and task locking

### DIFF
--- a/backup-jlg/composer.json
+++ b/backup-jlg/composer.json
@@ -19,9 +19,9 @@
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
-        "psr-4": {
-            "BJLG\\": "includes/"
-        }
+        "classmap": [
+            "includes/"
+        ]
     },
     "config": {
         "vendor-dir": "vendor-bjlg",

--- a/backup-jlg/includes/class-bjlg-rate-limiter.php
+++ b/backup-jlg/includes/class-bjlg-rate-limiter.php
@@ -87,14 +87,25 @@ class BJLG_Rate_Limiter {
 
                 $ip = trim($ip);
 
-                if (filter_var($ip, FILTER_VALIDATE_IP,
-                    FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false) {
-                    return $ip;
+                $validated_ip = filter_var($ip, FILTER_VALIDATE_IP);
+
+                if ($validated_ip !== false) {
+                    return $validated_ip;
                 }
             }
         }
 
-        return $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+        $fallback_ip = $_SERVER['REMOTE_ADDR'] ?? '';
+
+        if (is_string($fallback_ip) && $fallback_ip !== '') {
+            $validated_fallback = filter_var($fallback_ip, FILTER_VALIDATE_IP);
+
+            if ($validated_fallback !== false) {
+                return $validated_fallback;
+            }
+        }
+
+        return 'unknown';
     }
 
     /**


### PR DESCRIPTION
## Summary
- switch Composer autoloading to a classmap that matches the plugin class file layout
- harden task locking, history logging, and rate limiting fallbacks for non-WordPress runtimes
- allow REST download endpoints to reuse tokens and expand coverage with new PHPUnit cases while keeping debug logs accessible in tests

## Testing
- `composer install`
- `./vendor-bjlg/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68d4407750a0832ea7e75951b6a1f304