### PR TITLE
Harden download token handling and settings import sanitization

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -272,6 +272,53 @@ jQuery(document).ready(function($) {
         // ... (Code complet fourni précédemment) ...
     });
 
+    // --- DEMANDE DE TÉLÉCHARGEMENT SÉCURISÉ ---
+    $('body').on('click', '.bjlg-download-button', function(e) {
+        e.preventDefault();
+
+        const $button = $(this);
+        const filename = $button.data('filename');
+
+        if (!filename) {
+            return;
+        }
+
+        const originalText = $button.data('original-text') || $button.text();
+        $button.data('original-text', originalText);
+
+        $button.prop('disabled', true).text('Préparation...');
+
+        $.ajax({
+            url: bjlg_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'bjlg_prepare_download',
+                nonce: bjlg_ajax.nonce,
+                filename: filename
+            }
+        })
+        .done(function(response) {
+            if (response && response.success && response.data && response.data.download_url) {
+                window.location.href = response.data.download_url;
+            } else {
+                const message = response && response.data && response.data.message
+                    ? response.data.message
+                    : 'Impossible de préparer le téléchargement.';
+                alert(message);
+            }
+        })
+        .fail(function(xhr) {
+            let message = 'Une erreur est survenue lors de la préparation du téléchargement.';
+            if (xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message) {
+                message += '\n' + xhr.responseJSON.data.message;
+            }
+            alert(message);
+        })
+        .always(function() {
+            $button.prop('disabled', false).text(originalText);
+        });
+    });
+
     // --- GESTIONNAIRE SUPPRESSION DE SAUVEGARDE ---
     $('body').on('click', '.bjlg-delete-button', function(e) {
         e.preventDefault();

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -192,12 +192,6 @@ class BJLG_Admin {
                     <tbody>
                         <?php foreach ($backups as $backup_file):
                             $filename = basename($backup_file);
-                            $download_token = wp_generate_password(32, false);
-                            set_transient('bjlg_download_' . $download_token, $backup_file, BJLG_Backup::get_task_ttl());
-                            $file_url = add_query_arg([
-                                'action' => 'bjlg_download',
-                                'token' => $download_token,
-                            ], admin_url('admin-ajax.php'));
                             $is_encrypted = (substr($filename, -4) === '.enc');
                             ?>
                             <tr>
@@ -216,7 +210,7 @@ class BJLG_Admin {
                                 <td><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), filemtime($backup_file)); ?></td>
                                 <td>
                                     <button class="button button-primary bjlg-restore-button" data-filename="<?php echo esc_attr($filename); ?>">Restaurer</button>
-                                    <a href="<?php echo esc_url($file_url); ?>" class="button">Télécharger</a>
+                                    <button type="button" class="button bjlg-download-button" data-filename="<?php echo esc_attr($filename); ?>">Télécharger</button>
                                     <button class="button button-link-delete bjlg-delete-button" data-filename="<?php echo esc_attr($filename); ?>">Supprimer</button>
                                 </td>
                             </tr>

--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -90,8 +90,8 @@ class BJLG_Settings {
             // --- Réglages de la Rétention ---
             if (isset($_POST['by_number']) || isset($_POST['by_age'])) {
                 $cleanup_settings = [
-                    'by_number' => isset($_POST['by_number']) ? intval($_POST['by_number']) : 3,
-                    'by_age'    => isset($_POST['by_age']) ? intval($_POST['by_age']) : 0,
+                    'by_number' => isset($_POST['by_number']) ? max(0, intval(wp_unslash($_POST['by_number']))) : 3,
+                    'by_age'    => isset($_POST['by_age']) ? max(0, intval(wp_unslash($_POST['by_age']))) : 0,
                 ];
                 update_option('bjlg_cleanup_settings', $cleanup_settings);
                 $saved_settings['cleanup'] = $cleanup_settings;
@@ -101,62 +101,62 @@ class BJLG_Settings {
             // --- Réglages de la Marque Blanche ---
             if (isset($_POST['plugin_name']) || isset($_POST['hide_from_non_admins'])) {
                 $wl_settings = [
-                    'plugin_name'          => isset($_POST['plugin_name']) ? sanitize_text_field($_POST['plugin_name']) : '',
-                    'hide_from_non_admins' => isset($_POST['hide_from_non_admins']) && $_POST['hide_from_non_admins'] === 'true',
+                    'plugin_name'          => isset($_POST['plugin_name']) ? sanitize_text_field(wp_unslash($_POST['plugin_name'])) : '',
+                    'hide_from_non_admins' => isset($_POST['hide_from_non_admins']) && wp_unslash($_POST['hide_from_non_admins']) === 'true',
                 ];
                 update_option('bjlg_whitelabel_settings', $wl_settings);
                 $saved_settings['whitelabel'] = $wl_settings;
                 BJLG_Debug::log("Réglages de marque blanche sauvegardés : " . print_r($wl_settings, true));
             }
-            
+
             // --- Réglages de Chiffrement ---
             if (isset($_POST['encryption_enabled'])) {
                 $encryption_settings = [
-                    'enabled' => $_POST['encryption_enabled'] === 'true',
-                    'auto_encrypt' => isset($_POST['auto_encrypt']) && $_POST['auto_encrypt'] === 'true',
-                    'password_protect' => isset($_POST['password_protect']) && $_POST['password_protect'] === 'true',
-                    'compression_level' => isset($_POST['compression_level']) ? intval($_POST['compression_level']) : 6
+                    'enabled' => wp_unslash($_POST['encryption_enabled']) === 'true',
+                    'auto_encrypt' => isset($_POST['auto_encrypt']) && wp_unslash($_POST['auto_encrypt']) === 'true',
+                    'password_protect' => isset($_POST['password_protect']) && wp_unslash($_POST['password_protect']) === 'true',
+                    'compression_level' => isset($_POST['compression_level']) ? max(0, intval(wp_unslash($_POST['compression_level']))) : 6
                 ];
                 update_option('bjlg_encryption_settings', $encryption_settings);
                 $saved_settings['encryption'] = $encryption_settings;
                 BJLG_Debug::log("Réglages de chiffrement sauvegardés.");
             }
-            
+
             // --- Réglages Google Drive ---
             if (isset($_POST['gdrive_client_id']) && isset($_POST['gdrive_client_secret'])) {
                 $gdrive_settings = [
-                    'client_id'     => sanitize_text_field($_POST['gdrive_client_id']),
-                    'client_secret' => sanitize_text_field($_POST['gdrive_client_secret']),
-                    'folder_id'     => sanitize_text_field($_POST['gdrive_folder_id'] ?? ''),
-                    'enabled'       => isset($_POST['gdrive_enabled']) && $_POST['gdrive_enabled'] === 'true'
+                    'client_id'     => sanitize_text_field(wp_unslash($_POST['gdrive_client_id'])),
+                    'client_secret' => sanitize_text_field(wp_unslash($_POST['gdrive_client_secret'])),
+                    'folder_id'     => isset($_POST['gdrive_folder_id']) ? sanitize_text_field(wp_unslash($_POST['gdrive_folder_id'])) : '',
+                    'enabled'       => isset($_POST['gdrive_enabled']) && wp_unslash($_POST['gdrive_enabled']) === 'true'
                 ];
                 update_option('bjlg_gdrive_settings', $gdrive_settings);
                 $saved_settings['gdrive'] = $gdrive_settings;
                 BJLG_Debug::log("Identifiants Google Drive sauvegardés.");
             }
-            
+
             // --- Réglages de Notifications ---
             if (isset($_POST['notifications_enabled'])) {
                 $notifications_settings = [
-                    'enabled' => $_POST['notifications_enabled'] === 'true',
-                    'email_recipients' => sanitize_text_field($_POST['email_recipients'] ?? ''),
+                    'enabled' => wp_unslash($_POST['notifications_enabled']) === 'true',
+                    'email_recipients' => isset($_POST['email_recipients']) ? sanitize_text_field(wp_unslash($_POST['email_recipients'])) : '',
                     'events' => [
-                        'backup_complete' => isset($_POST['notify_backup_complete']) && $_POST['notify_backup_complete'] === 'true',
-                        'backup_failed' => isset($_POST['notify_backup_failed']) && $_POST['notify_backup_failed'] === 'true',
-                        'cleanup_complete' => isset($_POST['notify_cleanup_complete']) && $_POST['notify_cleanup_complete'] === 'true',
-                        'storage_warning' => isset($_POST['notify_storage_warning']) && $_POST['notify_storage_warning'] === 'true'
+                        'backup_complete' => isset($_POST['notify_backup_complete']) && wp_unslash($_POST['notify_backup_complete']) === 'true',
+                        'backup_failed' => isset($_POST['notify_backup_failed']) && wp_unslash($_POST['notify_backup_failed']) === 'true',
+                        'cleanup_complete' => isset($_POST['notify_cleanup_complete']) && wp_unslash($_POST['notify_cleanup_complete']) === 'true',
+                        'storage_warning' => isset($_POST['notify_storage_warning']) && wp_unslash($_POST['notify_storage_warning']) === 'true'
                     ],
                     'channels' => [
                         'email' => [
-                            'enabled' => isset($_POST['channel_email']) && $_POST['channel_email'] === 'true'
+                            'enabled' => isset($_POST['channel_email']) && wp_unslash($_POST['channel_email']) === 'true'
                         ],
                         'slack' => [
-                            'enabled' => isset($_POST['channel_slack']) && $_POST['channel_slack'] === 'true',
-                            'webhook_url' => sanitize_url($_POST['slack_webhook_url'] ?? '')
+                            'enabled' => isset($_POST['channel_slack']) && wp_unslash($_POST['channel_slack']) === 'true',
+                            'webhook_url' => isset($_POST['slack_webhook_url']) ? esc_url_raw(wp_unslash($_POST['slack_webhook_url'])) : ''
                         ],
                         'discord' => [
-                            'enabled' => isset($_POST['channel_discord']) && $_POST['channel_discord'] === 'true',
-                            'webhook_url' => sanitize_url($_POST['discord_webhook_url'] ?? '')
+                            'enabled' => isset($_POST['channel_discord']) && wp_unslash($_POST['channel_discord']) === 'true',
+                            'webhook_url' => isset($_POST['discord_webhook_url']) ? esc_url_raw(wp_unslash($_POST['discord_webhook_url'])) : ''
                         ]
                     ]
                 ];
@@ -164,38 +164,38 @@ class BJLG_Settings {
                 $saved_settings['notifications'] = $notifications_settings;
                 BJLG_Debug::log("Réglages de notifications sauvegardés.");
             }
-            
+
             // --- Réglages de Performance ---
             if (isset($_POST['multi_threading'])) {
                 $performance_settings = [
-                    'multi_threading' => $_POST['multi_threading'] === 'true',
-                    'max_workers' => isset($_POST['max_workers']) ? intval($_POST['max_workers']) : 2,
-                    'chunk_size' => isset($_POST['chunk_size']) ? intval($_POST['chunk_size']) : 50
+                    'multi_threading' => wp_unslash($_POST['multi_threading']) === 'true',
+                    'max_workers' => isset($_POST['max_workers']) ? max(1, intval(wp_unslash($_POST['max_workers']))) : 2,
+                    'chunk_size' => isset($_POST['chunk_size']) ? max(1, intval(wp_unslash($_POST['chunk_size']))) : 50
                 ];
                 update_option('bjlg_performance_settings', $performance_settings);
                 $saved_settings['performance'] = $performance_settings;
                 BJLG_Debug::log("Réglages de performance sauvegardés.");
             }
-            
+
             // --- Réglages Webhooks ---
             if (isset($_POST['webhook_enabled'])) {
                 $webhook_settings = [
-                    'enabled' => $_POST['webhook_enabled'] === 'true',
+                    'enabled' => wp_unslash($_POST['webhook_enabled']) === 'true',
                     'urls' => [
-                        'backup_complete' => sanitize_url($_POST['webhook_backup_complete'] ?? ''),
-                        'backup_failed' => sanitize_url($_POST['webhook_backup_failed'] ?? ''),
-                        'cleanup_complete' => sanitize_url($_POST['webhook_cleanup_complete'] ?? '')
+                        'backup_complete' => isset($_POST['webhook_backup_complete']) ? esc_url_raw(wp_unslash($_POST['webhook_backup_complete'])) : '',
+                        'backup_failed' => isset($_POST['webhook_backup_failed']) ? esc_url_raw(wp_unslash($_POST['webhook_backup_failed'])) : '',
+                        'cleanup_complete' => isset($_POST['webhook_cleanup_complete']) ? esc_url_raw(wp_unslash($_POST['webhook_cleanup_complete'])) : ''
                     ],
-                    'secret' => sanitize_text_field($_POST['webhook_secret'] ?? '')
+                    'secret' => isset($_POST['webhook_secret']) ? sanitize_text_field(wp_unslash($_POST['webhook_secret'])) : ''
                 ];
                 update_option('bjlg_webhook_settings', $webhook_settings);
                 $saved_settings['webhooks'] = $webhook_settings;
                 BJLG_Debug::log("Réglages de webhooks sauvegardés.");
             }
-            
+
             // --- Réglage du débogueur AJAX ---
             if (isset($_POST['ajax_debug_enabled'])) {
-                $ajax_debug_enabled = $_POST['ajax_debug_enabled'] === 'true';
+                $ajax_debug_enabled = wp_unslash($_POST['ajax_debug_enabled']) === 'true';
                 update_option('bjlg_ajax_debug_enabled', $ajax_debug_enabled);
                 $saved_settings['ajax_debug'] = $ajax_debug_enabled;
                 BJLG_Debug::log("Réglage du débogueur AJAX mis à jour.");
@@ -248,7 +248,9 @@ class BJLG_Settings {
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
         
-        $section = sanitize_text_field($_POST['section'] ?? 'all');
+        $section = isset($_POST['section'])
+            ? sanitize_text_field(wp_unslash($_POST['section']))
+            : 'all';
         
         try {
             if ($section === 'all') {
@@ -331,14 +333,15 @@ class BJLG_Settings {
         if (empty($_POST['import_data'])) {
             wp_send_json_error(['message' => 'Aucune donnée à importer.']);
         }
-        
+
         try {
-            $import_data = json_decode(base64_decode($_POST['import_data']), true);
-            
+            $raw_import = wp_unslash($_POST['import_data']);
+            $import_data = json_decode(base64_decode($raw_import), true);
+
             if (empty($import_data) || !isset($import_data['settings'])) {
                 throw new Exception("Format de données invalide.");
             }
-            
+
             // Vérifier la compatibilité de version
             if (isset($import_data['version'])) {
                 $import_version = $import_data['version'];
@@ -348,11 +351,14 @@ class BJLG_Settings {
             }
             
             // Importer les paramètres
-            foreach ($import_data['settings'] as $key => $value) {
-                // Valider que c'est bien une option du plugin
-                if (strpos($key, 'bjlg_') === 0) {
-                    update_option($key, $value);
-                }
+            $sanitized_settings = $this->sanitize_imported_settings((array) $import_data['settings']);
+
+            if (empty($sanitized_settings)) {
+                throw new Exception("Aucun réglage valide à importer.");
+            }
+
+            foreach ($sanitized_settings as $key => $value) {
+                update_option($key, $value);
             }
             
             BJLG_History::log('settings_imported', 'success', 'Paramètres importés depuis ' . ($import_data['site_url'] ?? 'inconnu'));
@@ -366,21 +372,294 @@ class BJLG_Settings {
     }
     
     /**
-     * Valide une adresse email ou une liste d'adresses
+     * Nettoie et valide les paramètres importés.
+     *
+     * @param array $settings
+     * @return array
      */
-public function validate_email_list($emails) {
-    $email_list = explode(',', $emails);
-    $valid_emails = [];
-    
-    foreach ($email_list as $email) {
-        $email = trim($email);
-        if (is_email($email)) {
-            $valid_emails[] = $email;
+    private function sanitize_imported_settings(array $settings) {
+        $sanitized = [];
+
+        foreach ($settings as $option => $value) {
+            $clean_value = $this->sanitize_imported_option($option, $value);
+            if ($clean_value !== null) {
+                $sanitized[$option] = $clean_value;
+            }
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Nettoie une option importée spécifique.
+     *
+     * @param string $option
+     * @param mixed  $value
+     * @return array|bool|null
+     */
+    private function sanitize_imported_option($option, $value) {
+        switch ($option) {
+            case 'bjlg_cleanup_settings':
+                $defaults = $this->default_settings['cleanup'];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['by_number'])) {
+                        $sanitized['by_number'] = max(0, intval($value['by_number']));
+                    }
+                    if (isset($value['by_age'])) {
+                        $sanitized['by_age'] = max(0, intval($value['by_age']));
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_whitelabel_settings':
+                $defaults = $this->default_settings['whitelabel'];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['plugin_name'])) {
+                        $sanitized['plugin_name'] = sanitize_text_field($value['plugin_name']);
+                    }
+                    if (isset($value['hide_from_non_admins'])) {
+                        $sanitized['hide_from_non_admins'] = $this->to_bool($value['hide_from_non_admins']);
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_encryption_settings':
+                $defaults = $this->default_settings['encryption'];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['enabled'])) {
+                        $sanitized['enabled'] = $this->to_bool($value['enabled']);
+                    }
+                    if (isset($value['auto_encrypt'])) {
+                        $sanitized['auto_encrypt'] = $this->to_bool($value['auto_encrypt']);
+                    }
+                    if (isset($value['password_protect'])) {
+                        $sanitized['password_protect'] = $this->to_bool($value['password_protect']);
+                    }
+                    if (isset($value['compression_level'])) {
+                        $sanitized['compression_level'] = max(0, intval($value['compression_level']));
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_notification_settings':
+                $defaults = [
+                    'enabled' => false,
+                    'email_recipients' => '',
+                    'events' => $this->default_settings['notifications']['events'],
+                    'channels' => [
+                        'email' => ['enabled' => false],
+                        'slack' => ['enabled' => false, 'webhook_url' => ''],
+                        'discord' => ['enabled' => false, 'webhook_url' => ''],
+                    ],
+                ];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['enabled'])) {
+                        $sanitized['enabled'] = $this->to_bool($value['enabled']);
+                    }
+                    if (isset($value['email_recipients'])) {
+                        $sanitized['email_recipients'] = sanitize_text_field($value['email_recipients']);
+                    }
+                    if (isset($value['events']) && is_array($value['events'])) {
+                        foreach ($sanitized['events'] as $event_key => $default_value) {
+                            if (isset($value['events'][$event_key])) {
+                                $sanitized['events'][$event_key] = $this->to_bool($value['events'][$event_key]);
+                            }
+                        }
+                    }
+                    if (isset($value['channels']) && is_array($value['channels'])) {
+                        foreach ($sanitized['channels'] as $channel_key => $channel_defaults) {
+                            if (!isset($value['channels'][$channel_key]) || !is_array($value['channels'][$channel_key])) {
+                                continue;
+                            }
+                            $channel_value = $value['channels'][$channel_key];
+
+                            if (isset($channel_value['enabled'])) {
+                                $sanitized['channels'][$channel_key]['enabled'] = $this->to_bool($channel_value['enabled']);
+                            }
+
+                            if (isset($channel_defaults['webhook_url'])) {
+                                $sanitized['channels'][$channel_key]['webhook_url'] = isset($channel_value['webhook_url'])
+                                    ? esc_url_raw($channel_value['webhook_url'])
+                                    : '';
+                            }
+                        }
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_performance_settings':
+                $defaults = $this->default_settings['performance'];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['multi_threading'])) {
+                        $sanitized['multi_threading'] = $this->to_bool($value['multi_threading']);
+                    }
+                    if (isset($value['max_workers'])) {
+                        $sanitized['max_workers'] = max(1, intval($value['max_workers']));
+                    }
+                    if (isset($value['chunk_size'])) {
+                        $sanitized['chunk_size'] = max(1, intval($value['chunk_size']));
+                    }
+                    if (isset($value['compression_level'])) {
+                        $sanitized['compression_level'] = max(0, intval($value['compression_level']));
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_gdrive_settings':
+                $defaults = [
+                    'client_id' => '',
+                    'client_secret' => '',
+                    'folder_id' => '',
+                    'enabled' => false,
+                ];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['client_id'])) {
+                        $sanitized['client_id'] = sanitize_text_field($value['client_id']);
+                    }
+                    if (isset($value['client_secret'])) {
+                        $sanitized['client_secret'] = sanitize_text_field($value['client_secret']);
+                    }
+                    if (isset($value['folder_id'])) {
+                        $sanitized['folder_id'] = sanitize_text_field($value['folder_id']);
+                    }
+                    if (isset($value['enabled'])) {
+                        $sanitized['enabled'] = $this->to_bool($value['enabled']);
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_webhook_settings':
+                $defaults = [
+                    'enabled' => false,
+                    'urls' => [
+                        'backup_complete' => '',
+                        'backup_failed' => '',
+                        'cleanup_complete' => '',
+                    ],
+                    'secret' => '',
+                ];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['enabled'])) {
+                        $sanitized['enabled'] = $this->to_bool($value['enabled']);
+                    }
+                    if (isset($value['urls']) && is_array($value['urls'])) {
+                        foreach ($sanitized['urls'] as $url_key => $default) {
+                            if (isset($value['urls'][$url_key])) {
+                                $sanitized['urls'][$url_key] = esc_url_raw($value['urls'][$url_key]);
+                            }
+                        }
+                    }
+                    if (isset($value['secret'])) {
+                        $sanitized['secret'] = sanitize_text_field($value['secret']);
+                    }
+                }
+
+                return $sanitized;
+
+            case 'bjlg_schedule_settings':
+                $defaults = [
+                    'recurrence' => 'disabled',
+                    'day' => 'sunday',
+                    'time' => '23:59',
+                    'components' => ['db', 'plugins', 'themes', 'uploads'],
+                    'encrypt' => false,
+                    'incremental' => false,
+                ];
+                $sanitized = $defaults;
+
+                if (is_array($value)) {
+                    if (isset($value['recurrence'])) {
+                        $candidate = sanitize_key($value['recurrence']);
+                        $valid = ['disabled', 'hourly', 'twice_daily', 'daily', 'weekly', 'monthly'];
+                        if (in_array($candidate, $valid, true)) {
+                            $sanitized['recurrence'] = $candidate;
+                        }
+                    }
+                    if (isset($value['day'])) {
+                        $candidate = sanitize_key($value['day']);
+                        $valid_days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+                        if (in_array($candidate, $valid_days, true)) {
+                            $sanitized['day'] = $candidate;
+                        }
+                    }
+                    if (isset($value['time']) && is_string($value['time'])) {
+                        $candidate = sanitize_text_field($value['time']);
+                        if (preg_match('/^([0-1]?[0-9]|2[0-3]):([0-5][0-9])$/', $candidate)) {
+                            $sanitized['time'] = $candidate;
+                        }
+                    }
+                    if (isset($value['components']) && is_array($value['components'])) {
+                        $components = array_filter(array_map('sanitize_key', $value['components']));
+                        if (!empty($components)) {
+                            $sanitized['components'] = array_values(array_unique($components));
+                        }
+                    }
+                    if (isset($value['encrypt'])) {
+                        $sanitized['encrypt'] = $this->to_bool($value['encrypt']);
+                    }
+                    if (isset($value['incremental'])) {
+                        $sanitized['incremental'] = $this->to_bool($value['incremental']);
+                    }
+                }
+
+                return $sanitized;
+
+            default:
+                return null;
         }
     }
-    
-    return implode(',', $valid_emails);
-}
+
+    /**
+     * Convertit une valeur en booléen normalisé.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    private function to_bool($value) {
+        if (is_string($value)) {
+            $normalized = strtolower($value);
+            return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return (bool) $value;
+    }
+
+    /**
+     * Valide une adresse email ou une liste d'adresses
+     */
+    public function validate_email_list($emails) {
+        $email_list = explode(',', $emails);
+        $valid_emails = [];
+
+        foreach ($email_list as $email) {
+            $email = trim($email);
+            if (is_email($email)) {
+                $valid_emails[] = $email;
+            }
+        }
+
+        return implode(',', $valid_emails);
+    }
     
     /**
      * Obtient un paramètre spécifique

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -921,10 +921,11 @@ namespace {
 
             $this->assertSame($token, $query_args['token'] ?? null);
             $this->assertCount(1, $GLOBALS['bjlg_test_transients']);
-            $this->assertSame(
-                $filepath,
-                $GLOBALS['bjlg_test_transients']['bjlg_download_' . $token] ?? null
-            );
+            $stored_payload = $GLOBALS['bjlg_test_transients']['bjlg_download_' . $token] ?? null;
+            $this->assertIsArray($stored_payload);
+            $this->assertSame($filepath, $stored_payload['file'] ?? null);
+            $this->assertSame(BJLG_CAPABILITY, $stored_payload['requires_cap'] ?? null);
+            $this->assertArrayHasKey('issued_at', $stored_payload);
         } finally {
             if (file_exists($filepath)) {
                 unlink($filepath);
@@ -1422,7 +1423,10 @@ namespace {
 
         $this->assertArrayHasKey('token', $query_args);
         $this->assertSame($data['download_token'], $query_args['token']);
-        $this->assertSame($tempFile, get_transient('bjlg_download_' . $data['download_token']));
+        $payload = get_transient('bjlg_download_' . $data['download_token']);
+        $this->assertIsArray($payload);
+        $this->assertSame($tempFile, $payload['file'] ?? null);
+        $this->assertSame(BJLG_CAPABILITY, $payload['requires_cap'] ?? null);
 
         if (file_exists($tempFile)) {
             unlink($tempFile);


### PR DESCRIPTION
## Summary
- generate backup download tokens on demand with capability checks and shorter lifetimes
- update the admin UI and REST endpoints to request secure tokens only when needed
- normalize option sanitization and validate imported settings payloads before saving

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d44c18220c832e9c51a4d843018950