### PR TITLE
Handle non-array backup component requests safely

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -317,7 +317,8 @@ class BJLG_Backup {
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
 
-        $components = isset($_POST['components']) ? array_map('sanitize_text_field', $_POST['components']) : [];
+        $raw = isset($_POST['components']) ? (array) $_POST['components'] : [];
+        $components = array_map('sanitize_text_field', $raw);
 
         $encrypt = $this->get_boolean_request_value('encrypt', 'encrypt_backup');
         $incremental = $this->get_boolean_request_value('incremental', 'incremental_backup');


### PR DESCRIPTION
## Summary
- ensure backup component request data is always treated as an array before sanitization

## Testing
- composer test *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68d59116550c832eb5809d229c701033