### PR TITLE
Handle backup task state save failures

### DIFF
--- a/backup-jlg/tests/BJLG_BackupTest.php
+++ b/backup-jlg/tests/BJLG_BackupTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class BJLG_BackupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_scheduled_events'] = [
+            'recurring' => [],
+            'single' => [],
+        ];
+        $GLOBALS['bjlg_test_set_transient_mock'] = null;
+
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['bjlg_test_set_transient_mock'] = null;
+        $_POST = [];
+
+        parent::tearDown();
+    }
+
+    public function test_handle_start_backup_task_releases_lock_when_state_save_fails(): void
+    {
+        $backup = new BJLG\BJLG_Backup();
+
+        $_POST['components'] = ['database'];
+        $_POST['nonce'] = 'test-nonce';
+
+        $captured_task_id = null;
+
+        $GLOBALS['bjlg_test_set_transient_mock'] = static function (string $transient, $value = null, $expiration = null) use (&$captured_task_id) {
+            if ($transient === 'bjlg_backup_task_lock') {
+                return null;
+            }
+
+            if (strpos($transient, 'bjlg_backup_') === 0) {
+                $captured_task_id = $transient;
+
+                return false;
+            }
+
+            return null;
+        };
+
+        try {
+            $backup->handle_start_backup_task();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertNotNull($captured_task_id, 'The task identifier should have been captured.');
+            $this->assertSame(500, $response->status_code);
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame("Impossible d'initialiser la tâche de sauvegarde.", $response->data['message']);
+
+            $this->assertFalse(BJLG\BJLG_Backup::is_task_locked());
+            $this->assertEmpty($GLOBALS['bjlg_test_scheduled_events']['single']);
+
+            $this->assertArrayNotHasKey($captured_task_id, $GLOBALS['bjlg_test_transients']);
+            $this->assertArrayNotHasKey('bjlg_backup_task_lock', $GLOBALS['bjlg_test_transients']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- save the backup task state before scheduling and handle failures by releasing the lock, unscheduling, and cleaning up
- extend the test bootstrap to support transient mocking and unscheduling of single events
- add regression coverage ensuring AJAX start errors when the task state cannot be persisted

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d5b29026ac832e98c41a3d96099cca