### PR TITLE
Handle restore task initialization failures

### DIFF
--- a/backup-jlg/tests/BJLG_BackupTest.php
+++ b/backup-jlg/tests/BJLG_BackupTest.php
@@ -15,6 +15,7 @@ final class BJLG_BackupTest extends TestCase
             'single' => [],
         ];
         $GLOBALS['bjlg_test_set_transient_mock'] = null;
+        $GLOBALS['bjlg_test_schedule_single_event_mock'] = null;
 
         $_POST = [];
     }
@@ -22,6 +23,7 @@ final class BJLG_BackupTest extends TestCase
     protected function tearDown(): void
     {
         $GLOBALS['bjlg_test_set_transient_mock'] = null;
+        $GLOBALS['bjlg_test_schedule_single_event_mock'] = null;
         $_POST = [];
 
         parent::tearDown();

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -106,6 +106,7 @@ $GLOBALS['bjlg_test_scheduled_events'] = [
     'single' => [],
 ];
 $GLOBALS['bjlg_test_set_transient_mock'] = null;
+$GLOBALS['bjlg_test_schedule_single_event_mock'] = null;
 $GLOBALS['bjlg_test_options'] = [];
 $GLOBALS['bjlg_registered_routes'] = [];
 $GLOBALS['bjlg_history_entries'] = [];
@@ -687,6 +688,26 @@ if (!function_exists('delete_transient')) {
 
 if (!function_exists('wp_schedule_single_event')) {
     function wp_schedule_single_event($timestamp, $hook, $args = []) {
+        $mock = $GLOBALS['bjlg_test_schedule_single_event_mock'] ?? null;
+
+        if (is_callable($mock)) {
+            $mock_result = $mock($timestamp, $hook, $args);
+
+            if ($mock_result !== null) {
+                if ($mock_result === false) {
+                    return false;
+                }
+
+                $GLOBALS['bjlg_test_scheduled_events']['single'][] = [
+                    'timestamp' => $timestamp,
+                    'hook' => $hook,
+                    'args' => $args,
+                ];
+
+                return true;
+            }
+        }
+
         $GLOBALS['bjlg_test_scheduled_events']['single'][] = [
             'timestamp' => $timestamp,
             'hook' => $hook,


### PR DESCRIPTION
## Summary
- guard restore task initialization in both the AJAX handler and REST endpoint to surface transient creation and scheduling failures
- add cleanup when scheduling fails so created transients are removed before returning errors
- extend the test bootstrap to mock wp_schedule_single_event(), and add regression tests covering the new failure paths

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d5c04cd5e4832e8fef9cdc03090893