### PR TITLE
Handle restore scheduling failures explicitly

### DIFF
--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -225,6 +225,50 @@ final class BJLG_RestoreSecurityTest extends TestCase
         $this->assertEmpty($GLOBALS['bjlg_test_scheduled_events']['single']);
     }
 
+    public function test_handle_run_restore_cleans_up_when_scheduling_returns_wp_error(): void
+    {
+        $_POST['nonce'] = 'nonce';
+        $_POST['filename'] = 'backup.zip';
+
+        $captured_task_id = null;
+
+        $GLOBALS['bjlg_test_set_transient_mock'] = static function (string $transient, $value = null, $expiration = null) use (&$captured_task_id) {
+            if (strpos($transient, 'bjlg_restore_') === 0) {
+                $captured_task_id = $transient;
+            }
+
+            return null;
+        };
+
+        $GLOBALS['bjlg_test_schedule_single_event_mock'] = static function ($timestamp, $hook, $args = []) {
+            if ($hook === 'bjlg_run_restore_task') {
+                return new WP_Error('cron_failure', 'Unexpected cron failure');
+            }
+
+            return null;
+        };
+
+        $restore = new BJLG\BJLG_Restore();
+
+        try {
+            $restore->handle_run_restore();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertNotNull($captured_task_id, 'The restore task identifier should have been captured.');
+            $this->assertSame(500, $response->status_code);
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame("Impossible de planifier la tâche de restauration en arrière-plan.", $response->data['message']);
+            $this->assertArrayHasKey('details', $response->data);
+            $this->assertSame('Unexpected cron failure', $response->data['details']);
+        }
+
+        $this->assertNotNull($captured_task_id);
+        $this->assertArrayNotHasKey($captured_task_id, $GLOBALS['bjlg_test_transients']);
+        $this->assertArrayHasKey('single', $GLOBALS['bjlg_test_scheduled_events']);
+        $this->assertEmpty($GLOBALS['bjlg_test_scheduled_events']['single']);
+    }
+
     public function test_restore_rejects_directory_traversal_entries(): void
     {
         $malicious_target = rtrim(BJLG_BACKUP_DIR, '/\\') . '/malicious.php';

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -694,8 +694,8 @@ if (!function_exists('wp_schedule_single_event')) {
             $mock_result = $mock($timestamp, $hook, $args);
 
             if ($mock_result !== null) {
-                if ($mock_result === false) {
-                    return false;
+                if ($mock_result === false || $mock_result instanceof WP_Error) {
+                    return $mock_result;
                 }
 
                 $GLOBALS['bjlg_test_scheduled_events']['single'][] = [


### PR DESCRIPTION
## Summary
- bail out of the AJAX restore handler when initializing the transient fails and include detailed feedback when scheduling the cron task fails
- ensure the REST restore endpoint mirrors transient and scheduling failures, surfacing cron error details when available
- update the test bootstrap and add regression tests that simulate `wp_schedule_single_event` returning `false` or `WP_Error`

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6510a77e4832ea42a74a6827e3379