### PR TITLE
Refactor backup task lock payload handling

### DIFF
--- a/backup-jlg/tests/BJLG_BackupTest.php
+++ b/backup-jlg/tests/BJLG_BackupTest.php
@@ -69,4 +69,21 @@ final class BJLG_BackupTest extends TestCase
             $this->assertArrayNotHasKey('bjlg_backup_task_lock', $GLOBALS['bjlg_test_transients']);
         }
     }
+
+    public function test_second_task_cannot_reserve_lock_before_initialization(): void
+    {
+        $task_one = 'bjlg_backup_' . md5('first');
+        $task_two = 'bjlg_backup_' . md5('second');
+
+        $this->assertTrue(BJLG\BJLG_Backup::reserve_task_slot($task_one));
+        $this->assertTrue(BJLG\BJLG_Backup::is_task_locked());
+        $this->assertFalse(BJLG\BJLG_Backup::reserve_task_slot($task_two));
+
+        $this->assertTrue(
+            BJLG\BJLG_Backup::reserve_task_slot($task_one),
+            'The original task should be able to refresh its reservation.'
+        );
+
+        BJLG\BJLG_Backup::release_task_slot($task_one);
+    }
 }


### PR DESCRIPTION
## Summary
- store structured lock payloads across all storage backends and keep them in sync
- flag backup task locks as initialized after saving state and respect initialization grace windows when reading the lock
- add a regression test ensuring a second task cannot claim the lock before the first task state is persisted

## Testing
- ./vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d65d7836ec832ebef3df298ce2f24e