### PR TITLE
Make backup lock initialization grace filterable

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -154,7 +154,9 @@ class BJLG_Backup {
             return null;
         }
 
-        if (!$payload['initialized'] && ($now - (int) $payload['acquired_at']) > self::TASK_LOCK_INITIALIZATION_GRACE) {
+        $initialization_grace = self::get_task_lock_initialization_grace();
+
+        if (!$payload['initialized'] && ($now - (int) $payload['acquired_at']) > $initialization_grace) {
             self::delete_lock_payload();
 
             return null;
@@ -179,6 +181,22 @@ class BJLG_Backup {
         }
 
         return (int) $filtered_ttl;
+    }
+
+    /**
+     * Retourne le délai de grâce accordé pour initialiser la tâche verrouillée.
+     *
+     * @return int
+     */
+    private static function get_task_lock_initialization_grace() {
+        $default_grace = self::TASK_LOCK_INITIALIZATION_GRACE;
+        $filtered_grace = apply_filters('bjlg_task_lock_initialization_grace', $default_grace);
+
+        if (!is_numeric($filtered_grace) || (int) $filtered_grace < 0) {
+            return $default_grace;
+        }
+
+        return (int) $filtered_grace;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the backup task lock stores a structured payload everywhere and marks the payload initialized after persisting task state
- allow the lock initialization grace period to be filtered so fresh locks are not evicted too aggressively while keeping stale ones purged
- add a regression test proving a second task cannot reserve the lock before the first task finishes initializing

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d6615d3284832eae34635e60a0390b