### PR TITLE
Add restore debug logging UI

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -48,6 +48,23 @@
     border: 1px solid #ccd0d4;
 }
 
+#bjlg-backup-debug-wrapper,
+#bjlg-restore-debug-wrapper {
+    margin-top: 20px;
+    padding: 15px;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+    background-color: #fdfdfd;
+}
+
+#bjlg-backup-debug-wrapper h3,
+#bjlg-restore-debug-wrapper h3 {
+    margin-top: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 #wp-debug-log {
     color: #b32d2e; /* Erreurs en rouge foncé pour se démarquer */
 }

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -265,6 +265,10 @@ class BJLG_Admin {
                 <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-restore-progress-bar">0%</div></div>
                 <p id="bjlg-restore-status-text">Préparation...</p>
             </div>
+            <div id="bjlg-restore-debug-wrapper" style="display: none;">
+                <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>
+                <pre id="bjlg-restore-ajax-debug" class="bjlg-log-textarea"></pre>
+            </div>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- add a restore debug log wrapper with technical details output
- extend the restore javascript to stream request/response diagnostics into the debug area
- style the restore debug panel alongside the existing backup debug layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d66fbcc76c832e85df2a030de28cf8