### PR TITLE
Handle encrypted restore passwords in admin UI and tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -251,11 +251,19 @@ class BJLG_Admin {
                             </td>
                         </tr>
                         <tr>
+                            <th scope="row"><label for="bjlg-restore-password">Mot de passe</label></th>
+                            <td>
+                                <input type="password" id="bjlg-restore-password" name="password" class="regular-text" autocomplete="current-password" placeholder="Requis pour les archives .zip.enc">
+                                <p class="description">Requis pour restaurer les sauvegardes chiffrées (<code>.zip.enc</code>). Laissez vide pour les archives non chiffrées.</p>
+                            </td>
+                        </tr>
+                        <tr>
                             <th scope="row">Options</th>
                             <td><label><input type="checkbox" name="create_backup_before_restore" value="1" checked> Créer une sauvegarde de sécurité avant la restauration</label></td>
                         </tr>
                     </tbody>
                 </table>
+                <div id="bjlg-restore-errors" class="notice notice-error" style="display: none;" role="alert"></div>
                 <p class="submit">
                     <button type="submit" class="button button-primary"><span class="dashicons dashicons-upload"></span> Téléverser et Restaurer</button>
                 </p>


### PR DESCRIPTION
## Summary
- add a password field to the restore form with guidance for encrypted `.zip.enc` archives
- send the restore password in the admin AJAX flow and display validation errors from the server
- cover encrypted restore password requirements with new PHPUnit tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d66fb76608832e91efedde153c7b2d