### PR TITLE
Add password handling for encrypted restore archives

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -129,8 +129,65 @@ jQuery(document).ready(function($) {
         const $debugOutput = $('#bjlg-restore-ajax-debug');
         const fileInput = document.getElementById('bjlg-restore-file-input');
         const passwordInput = document.getElementById('bjlg-restore-password');
+        const passwordHelp = document.getElementById('bjlg-restore-password-help');
+        const passwordHelpDefaultText = passwordHelp
+            ? (passwordHelp.getAttribute('data-default-text') || passwordHelp.textContent.trim())
+            : '';
+        const passwordHelpEncryptedText = passwordHelp
+            ? (passwordHelp.getAttribute('data-encrypted-text') || passwordHelpDefaultText)
+            : '';
         const $errorNotice = $('#bjlg-restore-errors');
         const errorFieldClass = 'bjlg-input-error';
+
+        function applyPasswordHelpText(text) {
+            if (!passwordHelp) {
+                return;
+            }
+
+            const resolved = typeof text === 'string' && text.trim() !== ''
+                ? text.trim()
+                : passwordHelpDefaultText;
+
+            passwordHelp.textContent = resolved;
+        }
+
+        function updatePasswordRequirement() {
+            if (!passwordInput) {
+                return;
+            }
+
+            let requiresPassword = false;
+
+            if (fileInput && fileInput.files && fileInput.files.length > 0) {
+                const filename = fileInput.files[0].name || '';
+                requiresPassword = /\.zip\.enc$/i.test(filename.trim());
+            }
+
+            if (requiresPassword) {
+                passwordInput.setAttribute('required', 'required');
+                passwordInput.setAttribute('aria-required', 'true');
+                applyPasswordHelpText(passwordHelpEncryptedText);
+            } else {
+                passwordInput.removeAttribute('required');
+                passwordInput.removeAttribute('aria-required');
+                applyPasswordHelpText(passwordHelpDefaultText);
+            }
+        }
+
+        if (fileInput) {
+            fileInput.addEventListener('change', updatePasswordRequirement);
+        }
+
+        if (passwordInput) {
+            passwordInput.addEventListener('input', function() {
+                $(this)
+                    .removeClass(errorFieldClass)
+                    .removeAttr('aria-invalid');
+                $(this).nextAll('.bjlg-field-error').remove();
+            });
+        }
+
+        updatePasswordRequirement();
 
         function getValidationErrors(payload) {
             if (!payload || typeof payload !== 'object') {

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -253,8 +253,19 @@ class BJLG_Admin {
                         <tr>
                             <th scope="row"><label for="bjlg-restore-password">Mot de passe</label></th>
                             <td>
-                                <input type="password" id="bjlg-restore-password" name="password" class="regular-text" autocomplete="current-password" placeholder="Requis pour les archives .zip.enc">
-                                <p class="description">Requis pour restaurer les sauvegardes chiffrées (<code>.zip.enc</code>). Laissez vide pour les archives non chiffrées.</p>
+                                <input type="password"
+                                       id="bjlg-restore-password"
+                                       name="password"
+                                       class="regular-text"
+                                       autocomplete="current-password"
+                                       aria-describedby="bjlg-restore-password-help"
+                                       placeholder="Requis pour les archives .zip.enc">
+                                <p class="description"
+                                   id="bjlg-restore-password-help"
+                                   data-default-text="<?php echo esc_attr('Requis pour restaurer les sauvegardes chiffrées (.zip.enc). Laissez vide pour les archives non chiffrées.'); ?>"
+                                   data-encrypted-text="<?php echo esc_attr('Mot de passe obligatoire : renseignez-le pour déchiffrer l\'archive (.zip.enc).'); ?>">
+                                    Requis pour restaurer les sauvegardes chiffrées (<code>.zip.enc</code>). Laissez vide pour les archives non chiffrées.
+                                </p>
                             </td>
                         </tr>
                         <tr>

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -341,12 +341,24 @@ class BJLG_Restore {
             if ($password === '') {
                 $password = null;
             } elseif (strlen($password) < 4) {
-                wp_send_json_error(['message' => 'Le mot de passe doit contenir au moins 4 caractères.']);
+                $message = 'Le mot de passe doit contenir au moins 4 caractères.';
+                wp_send_json_error([
+                    'message' => $message,
+                    'validation_errors' => [
+                        'password' => [$message],
+                    ],
+                ]);
             }
         }
 
         if ($is_encrypted_backup && $password === null) {
-            wp_send_json_error(['message' => 'Un mot de passe est requis pour restaurer une sauvegarde chiffrée.']);
+            $message = 'Un mot de passe est requis pour restaurer une sauvegarde chiffrée.';
+            wp_send_json_error([
+                'message' => $message,
+                'validation_errors' => [
+                    'password' => [$message],
+                ],
+            ]);
         }
 
         try {

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -189,6 +189,44 @@ final class BJLG_RestoreSecurityTest extends TestCase
             $this->assertIsArray($response->data);
             $this->assertArrayHasKey('message', $response->data);
             $this->assertSame('Un mot de passe est requis pour restaurer une sauvegarde chiffrée.', $response->data['message']);
+            $this->assertArrayHasKey('validation_errors', $response->data);
+            $this->assertIsArray($response->data['validation_errors']);
+            $this->assertArrayHasKey('password', $response->data['validation_errors']);
+            $this->assertContains(
+                'Un mot de passe est requis pour restaurer une sauvegarde chiffrée.',
+                $response->data['validation_errors']['password']
+            );
+        }
+
+        $this->assertSame([], $GLOBALS['bjlg_test_transients']);
+    }
+
+    public function test_handle_run_restore_requires_minimum_password_length(): void
+    {
+        $_POST['nonce'] = 'nonce';
+        $_POST['filename'] = 'backup.zip';
+        $_POST['password'] = '123';
+
+        $restore = new BJLG\BJLG_Restore();
+
+        try {
+            $restore->handle_run_restore();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertTrue(
+                $response->status_code === null || $response->status_code === 200,
+                'Expected wp_send_json_error to use the default HTTP status code.'
+            );
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame('Le mot de passe doit contenir au moins 4 caractères.', $response->data['message']);
+            $this->assertArrayHasKey('validation_errors', $response->data);
+            $this->assertIsArray($response->data['validation_errors']);
+            $this->assertArrayHasKey('password', $response->data['validation_errors']);
+            $this->assertContains(
+                'Le mot de passe doit contenir au moins 4 caractères.',
+                $response->data['validation_errors']['password']
+            );
         }
 
         $this->assertSame([], $GLOBALS['bjlg_test_transients']);


### PR DESCRIPTION
## Summary
- add a password input and contextual help to the restore form for encrypted backups
- teach the admin restore workflow to enforce password requirements and surface validation feedback
- return structured password validation errors on the server and extend restore tests for encrypted archives

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d675add7fc832ea0c635a16cf1ffe0