### PR TITLE
Handle trimmed disabled functions list before shell_exec

### DIFF
--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -51,7 +51,16 @@ class BJLG_Performance {
      */
     private function detect_system_capabilities() {
         // Détection du nombre de cœurs CPU
-        if (function_exists('shell_exec') && !in_array('shell_exec', explode(',', ini_get('disable_functions')))) {
+        $disable_functions = ini_get('disable_functions');
+        $disabled_functions = [];
+
+        if (is_string($disable_functions) && $disable_functions !== '') {
+            $disabled_functions = array_filter(array_map('trim', explode(',', $disable_functions)));
+        }
+
+        $can_use_shell_exec = function_exists('shell_exec') && !in_array('shell_exec', $disabled_functions, true);
+
+        if ($can_use_shell_exec) {
             if (PHP_OS_FAMILY === 'Windows') {
                 $cores = shell_exec('wmic cpu get NumberOfCores');
                 // CORRECTION: Vérifier que $cores n'est pas null avant de l'utiliser


### PR DESCRIPTION
## Summary
- sanitize the disable_functions value before checking shell_exec availability
- ensure shell_exec-based core detection only runs when the function is enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6b615d674832e91304ab70a280c18