### PR TITLE
Ensure pre-restore backups use unique filenames

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -82,8 +82,21 @@ class BJLG_Restore {
 
         $backup_manager = $this->backup_manager;
 
-        $backup_filename = 'pre-restore-backup-' . date('Y-m-d-H-i-s') . '.zip';
+        $timestamp = date('Y-m-d-H-i-s');
+        $base_filename = 'pre-restore-backup-' . $timestamp;
+        $backup_filename = $base_filename . '.zip';
+
+        if (function_exists('wp_unique_filename')) {
+            $backup_filename = wp_unique_filename(BJLG_BACKUP_DIR, $backup_filename);
+        }
+
         $backup_filepath = BJLG_BACKUP_DIR . $backup_filename;
+
+        while (file_exists($backup_filepath)) {
+            $unique_suffix = str_replace('.', '-', uniqid('', true));
+            $backup_filename = sprintf('%s-%s.zip', $base_filename, $unique_suffix);
+            $backup_filepath = BJLG_BACKUP_DIR . $backup_filename;
+        }
         $sql_filepath = BJLG_BACKUP_DIR . 'database_temp_prerestore.sql';
 
         $zip = new ZipArchive();


### PR DESCRIPTION
## Summary
- ensure pre-restore backups always select a collision-resistant filename before creating the archive
- add a regression test that runs the pre-restore backup twice and confirms distinct backup files are produced
- provide lightweight testing helpers to support the new restore backup test harness

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d723d31a00832eb6dd3deda318f657