### PR TITLE
chore: align composer metadata with 2.0.3 release

### DIFF
--- a/backup-jlg/composer.json
+++ b/backup-jlg/composer.json
@@ -3,7 +3,7 @@
     "description": "Une solution complète de sauvegarde, restauration et gestion pour WordPress.",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
-    "version": "2.0.0",
+    "version": "2.0.3",
     "authors": [
         {
             "name": "JLG",

--- a/backup-jlg/readme.md
+++ b/backup-jlg/readme.md
@@ -302,6 +302,10 @@ header('X-XSS-Protection: 1; mode=block');
 
 ## 📝 Changelog
 
+### Version 2.0.3 (2024-04-23)
+- 🔧 Harmonisation de la version Composer avec la version déclarée dans le plugin principal.
+- 📦 Préparation de la diffusion Packagist pour garantir la distribution de la version correcte.
+
 ### Version 2.0.0 (2024-01-15)
 - ✨ Ajout du chiffrement AES-256
 - ✨ API REST complète


### PR DESCRIPTION
## Summary
- bump the package version in composer.json to match the plugin's 2.0.3 release
- update the changelog in the readme to document the 2.0.3 packaging update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d2a8d740832e8116351d6cced218