### PR TITLE
Improve webhook backup task initialization

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -80,6 +80,18 @@ class BJLG_Backup {
     }
 
     /**
+     * Supprime l'état stocké d'une tâche.
+     *
+     * @param string $task_id
+     * @return void
+     */
+    public static function delete_task_state($task_id) {
+        if (function_exists('delete_transient')) {
+            delete_transient($task_id);
+        }
+    }
+
+    /**
      * Indique si un verrou d'exécution est actuellement actif.
      *
      * @return bool

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1128,7 +1128,7 @@ class BJLG_REST_API {
         $scheduled = wp_schedule_single_event(time(), 'bjlg_run_backup_task', ['task_id' => $task_id]);
 
         if ($scheduled === false) {
-            delete_transient($task_id);
+            BJLG_Backup::delete_task_state($task_id);
             BJLG_Backup::release_task_slot($task_id);
 
             return new WP_Error(

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -154,10 +154,7 @@ class BJLG_Webhooks {
             BJLG_Debug::log("Échec de la planification de la tâche de sauvegarde webhook pour {$task_id}.");
             BJLG_History::log('webhook_backup_failed', 'failure', "Planification impossible pour la tâche {$task_id}.");
 
-            if (function_exists('delete_transient')) {
-                delete_transient($task_id);
-            }
-
+            BJLG_Backup::delete_task_state($task_id);
             BJLG_Backup::release_task_slot($task_id);
 
             wp_send_json_error([


### PR DESCRIPTION
## Summary
- add a helper on BJLG_Backup to remove task state transients
- ensure webhook listener releases locks and reports errors when scheduling fails
- reuse the new cleanup helper in the REST API when cron scheduling cannot be queued

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d8003b0ad8832e982102fc7eedead0