### PR TITLE
Handle download token persistence failures

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -68,7 +68,19 @@ class BJLG_Actions {
         $ttl = self::get_download_token_ttl($real_filepath);
         $payload = self::build_download_token_payload($real_filepath);
 
-        set_transient($transient_key, $payload, $ttl);
+        $persisted = set_transient($transient_key, $payload, $ttl);
+
+        if ($persisted === false) {
+            BJLG_Debug::error(sprintf(
+                'Échec de la persistance du token de téléchargement "%s" pour "%s".',
+                $download_token,
+                $real_filepath
+            ));
+
+            wp_send_json_error([
+                'message' => __('Impossible de créer un token de téléchargement.', 'backup-jlg'),
+            ], 500);
+        }
 
         $download_url = self::build_download_url($download_token);
 


### PR DESCRIPTION
## Summary
- ensure the REST download endpoint logs and returns a 500 when transient persistence for download tokens fails
- prevent the AJAX download preparation action from returning links when token persistence fails and surface a 500 error instead
- extend the transient test doubles to simulate set_transient failures and cover the new behaviors

## Testing
- ./vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d8412c0668832e9cc434bf3482d923