### PR TITLE
Handle missing AUTH_KEY when generating JWT

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -937,7 +937,9 @@ class BJLG_REST_API {
      * Génère un token JWT
      */
     private function generate_jwt_token($user_id, $username) {
-        if (!defined('AUTH_KEY') || trim((string) AUTH_KEY) === '') {
+        $auth_key = defined('AUTH_KEY') ? trim((string) AUTH_KEY) : '';
+
+        if ($auth_key === '') {
             if (function_exists('error_log')) {
                 error_log('[Backup JLG] AUTH_KEY is missing or empty; unable to generate JWT token.');
             }
@@ -960,7 +962,7 @@ class BJLG_REST_API {
         $base64Header = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($header));
         $base64Payload = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($payload));
         
-        $signature = hash_hmac('sha256', $base64Header . '.' . $base64Payload, AUTH_KEY, true);
+        $signature = hash_hmac('sha256', $base64Header . '.' . $base64Payload, $auth_key, true);
         $base64Signature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($signature));
         
         return $base64Header . '.' . $base64Payload . '.' . $base64Signature;

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -247,6 +247,10 @@ namespace {
 
             $this->assertInstanceOf(\WP_Error::class, $response);
             $this->assertSame('jwt_missing_signing_key', $response->get_error_code());
+            $this->assertSame(
+                __('La clé AUTH_KEY est manquante; impossible de générer un token JWT.', 'backup-jlg'),
+                $response->get_error_message('jwt_missing_signing_key')
+            );
 
             $error_data = $response->get_error_data('jwt_missing_signing_key');
             $this->assertIsArray($error_data);


### PR DESCRIPTION
## Summary
- ensure JWT generation fails gracefully when the AUTH_KEY constant is missing or empty
- reuse the sanitized AUTH_KEY when signing JWT payloads
- extend the REST API authentication test to assert the missing-key error message is returned

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d8412aaf0c832ea654b350ad3a98c8