### PR TITLE
Reuse cached backup metadata in REST API

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1963,14 +1963,32 @@ class BJLG_REST_API {
             ? rest_url(ltrim($rest_download_route, '/'))
             : $rest_download_route;
 
+        $filesize = @filesize($filepath);
+        if ($filesize === false) {
+            $filesize = null;
+            $size_formatted = null;
+        } else {
+            $size_formatted = size_format($filesize);
+        }
+
+        $filemtime = @filemtime($filepath);
+        if ($filemtime === false) {
+            $created_at = null;
+            $modified_at = null;
+        } else {
+            $timestamp = date('c', $filemtime);
+            $created_at = $timestamp;
+            $modified_at = $timestamp;
+        }
+
         $data = [
             'id' => $filename,
             'filename' => $filename,
             'type' => $type,
-            'size' => filesize($filepath),
-            'size_formatted' => size_format(filesize($filepath)),
-            'created_at' => date('c', filemtime($filepath)),
-            'modified_at' => date('c', filemtime($filepath)),
+            'size' => $filesize,
+            'size_formatted' => $size_formatted,
+            'created_at' => $created_at,
+            'modified_at' => $modified_at,
             'is_encrypted' => $is_encrypted,
             'components' => $manifest['contains'] ?? [],
             'download_rest_url' => $rest_download_url,


### PR DESCRIPTION
## Summary
- cache backup size and timestamp lookups to avoid repeated filesystem access and handle missing files gracefully
- add REST API tests with mocks for filesize and filemtime to cover the new logic

## Testing
- composer test -- --filter format_backup_data

------
https://chatgpt.com/codex/tasks/task_e_68d91e3b9510832eba0ccce2c83199ca