### PR TITLE
Normalize REST settings sanitization

### DIFF
--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -546,6 +546,34 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url) {
+        $url = trim((string) $url);
+
+        if ($url === '') {
+            return '';
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            return '';
+        }
+
+        $sanitized = filter_var($url, FILTER_SANITIZE_URL);
+
+        if ($sanitized === false) {
+            return '';
+        }
+
+        return str_replace(
+            ['<', '>', '"', "'", ' '],
+            ['%3C', '%3E', '%22', '%27', '%20'],
+            $sanitized
+        );
+    }
+}
+
 if (!function_exists('wp_cache_flush')) {
     function wp_cache_flush() {
         return true;


### PR DESCRIPTION
## Summary
- reuse the BJLG_Settings sanitization logic when handling REST settings updates, ensuring cleanup and schedule payloads are normalized before persisting
- expose a reusable sanitizer helper within BJLG_Settings while safeguarding instantiation and update the test bootstrap URL sanitizer stub
- expand the REST API test suite to cover messy PUT /settings payloads and verify sanitized option storage

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d99f880020832e89471ba78d238db2