### PR TITLE
Handle WP_Error when scheduling backup events

### DIFF
--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -716,6 +716,23 @@ if (!function_exists('delete_transient')) {
 
 if (!function_exists('wp_schedule_single_event')) {
     function wp_schedule_single_event($timestamp, $hook, $args = []) {
+        $event = [
+            'timestamp' => (int) $timestamp,
+            'schedule' => false,
+            'hook' => $hook,
+            'args' => (array) $args,
+        ];
+
+        $pre = apply_filters('pre_schedule_event', null, $event);
+
+        if ($pre instanceof WP_Error) {
+            return $pre;
+        }
+
+        if ($pre === false) {
+            return false;
+        }
+
         $mock = $GLOBALS['bjlg_test_schedule_single_event_mock'] ?? null;
 
         if (is_callable($mock)) {
@@ -765,6 +782,23 @@ if (!function_exists('wp_unschedule_event')) {
 
 if (!function_exists('wp_schedule_event')) {
     function wp_schedule_event($timestamp, $recurrence, $hook, $args = []) {
+        $event = [
+            'timestamp' => (int) $timestamp,
+            'schedule' => $recurrence,
+            'hook' => $hook,
+            'args' => (array) $args,
+        ];
+
+        $pre = apply_filters('pre_schedule_event', null, $event);
+
+        if ($pre instanceof WP_Error) {
+            return $pre;
+        }
+
+        if ($pre === false) {
+            return false;
+        }
+
         $GLOBALS['bjlg_test_scheduled_events']['recurring'][$hook] = [
             'timestamp' => $timestamp,
             'recurrence' => $recurrence,


### PR DESCRIPTION
## Summary
- add explicit handling of `WP_Error` returns from cron scheduling calls in the backup, REST, scheduler, and webhook flows, including logging, cleanup, and detailed error responses
- return richer error information from the scheduler when WordPress refuses to register cron events
- extend the test bootstrap and suites to cover the `pre_schedule_event` filter returning `WP_Error`

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68da57452ba0832eaefd2c8027376299