### PR TITLE
Handle missing disk space information in REST status

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1929,15 +1929,32 @@ class BJLG_REST_API {
     public function get_status($request) {
         $backup_files = glob(BJLG_BACKUP_DIR . '*.zip*') ?: [];
 
+        $backup_directory = BJLG_BACKUP_DIR;
+        $disk_free_space = null;
+        $disk_space_error = false;
+
+        if (is_dir($backup_directory) && is_readable($backup_directory)) {
+            $available_space = @disk_free_space($backup_directory);
+
+            if ($available_space !== false) {
+                $disk_free_space = $available_space;
+            } else {
+                $disk_space_error = true;
+            }
+        } else {
+            $disk_space_error = true;
+        }
+
         $status = [
             'plugin_version' => BJLG_VERSION,
             'wordpress_version' => get_bloginfo('version'),
             'php_version' => PHP_VERSION,
-            'backup_directory' => BJLG_BACKUP_DIR,
-            'backup_directory_writable' => is_writable(BJLG_BACKUP_DIR),
+            'backup_directory' => $backup_directory,
+            'backup_directory_writable' => is_writable($backup_directory),
             'total_backups' => count($backup_files),
             'total_size' => $this->get_total_backup_size(),
-            'disk_free_space' => disk_free_space(BJLG_BACKUP_DIR),
+            'disk_free_space' => $disk_free_space,
+            'disk_space_error' => $disk_space_error,
             'memory_limit' => ini_get('memory_limit'),
             'max_execution_time' => ini_get('max_execution_time'),
             'active_tasks' => $this->get_active_tasks_count()


### PR DESCRIPTION
## Summary
- guard the REST status endpoint against missing backup directories when calculating free disk space
- include a disk_space_error flag and null disk_free_space when the value cannot be determined
- add a regression test to confirm no warnings are emitted when the backup directory is absent

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68da6283aa58832ea2fcb81e1b7fa675