### PR TITLE
Support secure webhook authentication with headers

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -431,13 +431,26 @@ class BJLG_Admin {
             </form>
             
             <h3><span class="dashicons dashicons-admin-links"></span> Webhook</h3>
-            <p>Utilisez cette URL pour déclencher une sauvegarde à distance :</p>
-            <div class="bjlg-webhook-url">
-                <input type="text" readonly value="<?php echo esc_url(home_url('/?bjlg_trigger_backup=' . $webhook_key)); ?>" class="regular-text code" style="width: 70%;">
-                <button class="button bjlg-copy-webhook">Copier</button>
-                <button class="button" id="bjlg-regenerate-webhook">Régénérer</button>
+            <p>Utilisez ce point de terminaison pour déclencher une sauvegarde à distance en toute sécurité :</p>
+            <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
+                <label for="bjlg-webhook-endpoint" style="display:block; font-weight:600;">Point de terminaison</label>
+                <div>
+                    <input type="text" id="bjlg-webhook-endpoint" readonly value="<?php echo esc_url(BJLG_Webhooks::get_webhook_endpoint()); ?>" class="regular-text code" style="width: 70%;">
+                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-endpoint">Copier l'URL</button>
+                </div>
             </div>
-            
+            <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
+                <label for="bjlg-webhook-key" style="display:block; font-weight:600;">Clé secrète</label>
+                <div>
+                    <input type="text" id="bjlg-webhook-key" readonly value="<?php echo esc_attr($webhook_key); ?>" class="regular-text code" style="width: 70%;">
+                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-key">Copier la clé</button>
+                    <button class="button" id="bjlg-regenerate-webhook">Régénérer</button>
+                </div>
+            </div>
+            <p class="description">Envoyez une requête <strong>POST</strong> à l'URL ci-dessus en ajoutant l'en-tête <code><?php echo esc_html(BJLG_Webhooks::WEBHOOK_HEADER); ?></code> (ou <code>Authorization: Bearer &lt;clé&gt;</code>) contenant votre clé.</p>
+            <pre class="code"><code><?php echo esc_html(sprintf("curl -X POST %s \\n  -H 'Content-Type: application/json' \\n  -H '%s: %s'", BJLG_Webhooks::get_webhook_endpoint(), BJLG_Webhooks::WEBHOOK_HEADER, $webhook_key)); ?></code></pre>
+            <p class="description"><strong>Compatibilité :</strong> L'ancien format <code><?php echo esc_html(add_query_arg(BJLG_Webhooks::WEBHOOK_QUERY_VAR, 'VOTRE_CLE', home_url('/'))); ?></code> reste supporté provisoirement mais sera retiré après la période de transition.</p>
+
             <form class="bjlg-settings-form">
                 <h3><span class="dashicons dashicons-trash"></span> Rétention des Sauvegardes</h3>
                 <table class="form-table">

--- a/backup-jlg/readme.md
+++ b/backup-jlg/readme.md
@@ -181,11 +181,18 @@ wp bjlg cleanup --keep=5
 
 ### Webhook
 
-Déclenchez une sauvegarde via URL :
+Déclenchez une sauvegarde via une requête POST sécurisée :
 
+* **Endpoint** : `https://site.com/?bjlg_trigger_backup=1`
+* **Header** : `X-BJLG-Webhook-Key: VOTRE_CLE_WEBHOOK` (ou utilisez `Authorization: Bearer VOTRE_CLE_WEBHOOK`)
+
+```bash
+curl -X POST https://site.com/?bjlg_trigger_backup=1 \
+  -H "Content-Type: application/json" \
+  -H "X-BJLG-Webhook-Key: VOTRE_CLE_WEBHOOK"
 ```
-https://site.com/?bjlg_trigger_backup=VOTRE_CLE_WEBHOOK
-```
+
+> ℹ️ L'ancien format `https://site.com/?bjlg_trigger_backup=VOTRE_CLE_WEBHOOK` reste supporté durant la période de transition, mais sera retiré après migration.
 
 ## 📊 Endpoints API
 


### PR DESCRIPTION
## Summary
- accept webhook authentication via headers or POST payloads while logging secure usage and deprecating legacy query access
- refresh the admin webhook panel with separated endpoint/key fields, secure usage guidance, and clipboard helpers
- document the secure webhook workflow and add a copy-to-clipboard utility for the new fields

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da7a498354832e965d5c8baa418fde