### PR TITLE
Implement Google Drive destination

### DIFF
--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -46,6 +46,12 @@ class BJLG_Settings {
             'chunk_size' => 50,
             'compression_level' => 6
         ],
+        'gdrive' => [
+            'client_id' => '',
+            'client_secret' => '',
+            'folder_id' => '',
+            'enabled' => false,
+        ],
         'advanced' => [
             'debug_mode' => false,
             'ajax_debug' => false,
@@ -250,7 +256,7 @@ class BJLG_Settings {
             'encryption' => get_option('bjlg_encryption_settings', $this->default_settings['encryption']),
             'notifications' => get_option('bjlg_notification_settings', $this->default_settings['notifications']),
             'performance' => get_option('bjlg_performance_settings', $this->default_settings['performance']),
-            'gdrive' => get_option('bjlg_gdrive_settings', []),
+            'gdrive' => get_option('bjlg_gdrive_settings', $this->default_settings['gdrive']),
             'webhooks' => get_option('bjlg_webhook_settings', []),
             'schedule' => get_option('bjlg_schedule_settings', []),
             'ajax_debug' => get_option('bjlg_ajax_debug_enabled', false)

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -193,7 +193,7 @@ class BJLG_Webhooks {
             BJLG_History::log('webhook_secure_mode', 'success', sprintf('Webhook déclenché via mode sécurisé (%s).', $key_source ?: 'unknown'));
         }
 
-        if ($legacy_mode) {
+        if ($legacy_mode && !headers_sent()) {
             header('Warning: 299 BJLG "Legacy webhook scheme is deprecated and will be removed in a future release."');
         }
 

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -1,36 +1,380 @@
 <?php
 namespace BJLG;
 
+use Exception;
+use Google\Client as Google_Client;
+use Google\Service\Drive as Google_Service_Drive;
+use Google\Service\Drive\DriveFile as Google_Service_DriveFile;
+
 if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!interface_exists(BJLG_Destination_Interface::class)) {
+    return;
+}
+
+// Charger automatiquement les dépendances du SDK Google si elles sont disponibles.
+$bjlg_base_dir = defined('BJLG_PLUGIN_DIR') ? BJLG_PLUGIN_DIR : dirname(__DIR__, 2) . '/';
+$bjlg_autoload = $bjlg_base_dir . 'vendor-bjlg/autoload.php';
+if (file_exists($bjlg_autoload)) {
+    require_once $bjlg_autoload;
+}
+
 /**
- * Intégration Google Drive (future version).
+ * Destination Google Drive pour l'envoi de sauvegardes.
  */
-if (interface_exists(BJLG_Destination_Interface::class)) {
+class BJLG_Google_Drive implements BJLG_Destination_Interface {
 
-    class BJLG_Google_Drive implements BJLG_Destination_Interface {
+    private const OPTION_SETTINGS = 'bjlg_gdrive_settings';
+    private const OPTION_TOKEN = 'bjlg_gdrive_token';
+    private const OPTION_STATE = 'bjlg_gdrive_state';
+    private const SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
-        public function __construct() {
-            // Pas de hooks pour l’instant
+    /** @var callable */
+    private $client_factory;
+
+    /** @var callable */
+    private $drive_factory;
+
+    /** @var callable */
+    private $state_generator;
+
+    /** @var bool */
+    private $sdk_available;
+
+    /**
+     * @param callable|null $client_factory
+     * @param callable|null $drive_factory
+     * @param callable|null $state_generator
+     */
+    public function __construct(?callable $client_factory = null, ?callable $drive_factory = null, ?callable $state_generator = null) {
+        $this->sdk_available = class_exists(Google_Client::class) && class_exists(Google_Service_Drive::class);
+
+        $this->client_factory = $client_factory ?: static function () {
+            return new Google_Client();
+        };
+        $this->drive_factory = $drive_factory ?: static function (Google_Client $client) {
+            return new Google_Service_Drive($client);
+        };
+        $this->state_generator = $state_generator ?: static function () {
+            return bin2hex(random_bytes(16));
+        };
+
+        add_action('admin_init', [$this, 'handle_oauth_callback']);
+        add_action('admin_post_bjlg_gdrive_disconnect', [$this, 'handle_disconnect_request']);
+    }
+
+    public function get_id() {
+        return 'google_drive';
+    }
+
+    public function get_name() {
+        return 'Google Drive';
+    }
+
+    public function is_connected() {
+        $token = $this->get_stored_token();
+
+        return $this->sdk_available && !empty($token) && isset($token['refresh_token']);
+    }
+
+    public function disconnect() {
+        if (function_exists('delete_option')) {
+            delete_option(self::OPTION_TOKEN);
+        } else {
+            update_option(self::OPTION_TOKEN, []);
+        }
+    }
+
+    public function render_settings() {
+        echo "<div class='bjlg-destination bjlg-destination--gdrive'>";
+        echo "<h4><span class='dashicons dashicons-google'></span> Google Drive</h4>";
+
+        if (!$this->sdk_available) {
+            echo "<p class='description'>Le SDK Google n'est pas disponible. Installez les dépendances via Composer pour activer cette destination.</p></div>";
+            return;
         }
 
-        public function get_id() { return 'google_drive'; }
+        $settings = $this->get_settings();
+        $is_connected = $this->is_connected();
 
-        public function get_name() { return 'Google Drive (Bientôt disponible)'; }
+        echo "<p class='description'>Transférez automatiquement vos sauvegardes vers un dossier Google Drive dédié.</p>";
 
-        public function is_connected() { return false; }
+        echo "<table class='form-table'>";
+        echo "<tr><th scope='row'>Client ID</th><td><input type='text' name='gdrive_client_id' value='" . esc_attr($settings['client_id']) . "' class='regular-text'></td></tr>";
+        echo "<tr><th scope='row'>Client Secret</th><td><input type='text' name='gdrive_client_secret' value='" . esc_attr($settings['client_secret']) . "' class='regular-text'></td></tr>";
+        echo "<tr><th scope='row'>ID du dossier cible</th><td><input type='text' name='gdrive_folder_id' value='" . esc_attr($settings['folder_id']) . "' class='regular-text'><p class='description'>Laissez vide pour utiliser le dossier racine.</p></td></tr>";
+        $enabled_attr = $settings['enabled'] ? " checked='checked'" : '';
+        echo "<tr><th scope='row'>Activer Google Drive</th><td><label><input type='checkbox' name='gdrive_enabled' value='true'{$enabled_attr}> Activer l'envoi automatique vers Google Drive.</label></td></tr>";
+        echo "</table>";
 
-        public function disconnect() { /* noop */ }
-
-        public function render_settings() {
-            echo "<h4><span class='dashicons dashicons-google'></span> Google Drive</h4>";
-            echo "<p class='description'>La connexion à Google Drive sera disponible dans une future mise à jour.</p>";
+        if (!$settings['enabled']) {
+            echo "<p class='description'>Enregistrez vos identifiants puis activez Google Drive pour poursuivre la connexion.</p>";
         }
 
-        public function upload_file($filepath, $task_id) {
-            // Stub temporaire
+        if (!$is_connected && $settings['enabled'] && $settings['client_id'] !== '' && $settings['client_secret'] !== '') {
+            $auth_url = esc_url($this->build_authorization_url());
+            echo "<p><a class='button button-secondary' href='{$auth_url}'>Connecter mon compte Google Drive</a></p>";
         }
+
+        if ($is_connected) {
+            echo "<p class='description'><span class='dashicons dashicons-yes'></span> Compte Google Drive connecté.</p>";
+            echo "<form method='post' action='" . esc_url(admin_url('admin-post.php')) . "'>";
+            echo "<input type='hidden' name='action' value='bjlg_gdrive_disconnect'>";
+            if (function_exists('wp_nonce_field')) {
+                wp_nonce_field('bjlg_gdrive_disconnect', 'bjlg_gdrive_nonce');
+            }
+            echo "<button type='submit' class='button'>Déconnecter Google Drive</button></form>";
+        }
+
+        echo "</div>";
+    }
+
+    public function upload_file($filepath, $task_id) {
+        if (!$this->sdk_available) {
+            throw new Exception('Le SDK Google n\'est pas disponible.');
+        }
+
+        if (!is_readable($filepath)) {
+            throw new Exception('Fichier de sauvegarde introuvable : ' . $filepath);
+        }
+
+        if (!$this->is_connected()) {
+            throw new Exception('Google Drive n\'est pas connecté.');
+        }
+
+        $client = $this->build_configured_client();
+        $drive_service = call_user_func($this->drive_factory, $client);
+
+        $settings = $this->get_settings();
+        $folder_id = $settings['folder_id'] !== '' ? $settings['folder_id'] : 'root';
+
+        $file_metadata = new Google_Service_DriveFile([
+            'name' => basename($filepath),
+            'parents' => [$folder_id],
+        ]);
+
+        $mime_type = 'application/zip';
+        $content = file_get_contents($filepath);
+
+        try {
+            $uploaded_file = $drive_service->files->create(
+                $file_metadata,
+                [
+                    'data' => $content,
+                    'mimeType' => $mime_type,
+                    'uploadType' => 'multipart',
+                    'fields' => 'id,name,size',
+                ]
+            );
+        } catch (\Throwable $exception) {
+            throw new Exception('Erreur lors de l\'envoi vers Google Drive : ' . $exception->getMessage(), 0, $exception);
+        }
+
+        if (!$uploaded_file || !$uploaded_file->getId()) {
+            throw new Exception('La réponse de Google Drive ne contient pas d\'identifiant de fichier.');
+        }
+
+        $expected_size = filesize($filepath);
+        $reported_size = (int) $uploaded_file->getSize();
+        if ($reported_size > 0 && $reported_size !== $expected_size) {
+            throw new Exception('Le fichier envoyé sur Google Drive est corrompu (taille inattendue).');
+        }
+
+        if (class_exists(BJLG_Debug::class)) {
+            BJLG_Debug::log(sprintf('Sauvegarde "%s" envoyée sur Google Drive (ID: %s).', basename($filepath), $uploaded_file->getId()));
+        }
+    }
+
+    /**
+     * Traite le callback OAuth de Google.
+     */
+    public function handle_oauth_callback() {
+        if (!$this->sdk_available) {
+            return;
+        }
+
+        if (!isset($_GET['bjlg_gdrive_auth'])) {
+            return;
+        }
+
+        if (function_exists('current_user_can') && !current_user_can(BJLG_CAPABILITY)) {
+            return;
+        }
+
+        $code = isset($_GET['code']) ? sanitize_text_field(wp_unslash($_GET['code'])) : '';
+        $state = isset($_GET['state']) ? sanitize_text_field(wp_unslash($_GET['state'])) : '';
+
+        if ($code === '') {
+            return;
+        }
+
+        $expected_state = get_option(self::OPTION_STATE, '');
+        if ($expected_state === '' || !hash_equals($expected_state, $state)) {
+            return;
+        }
+
+        $client = $this->build_client();
+        $client->setRedirectUri($this->get_redirect_uri());
+        $client->setClientId($this->get_settings()['client_id']);
+        $client->setClientSecret($this->get_settings()['client_secret']);
+        $client->setAccessType('offline');
+        $client->setPrompt('consent');
+        $client->addScope(self::SCOPE);
+
+        $token = $client->fetchAccessTokenWithAuthCode($code);
+        if (isset($token['error'])) {
+            return;
+        }
+
+        $this->store_token($token);
+
+        if (function_exists('delete_option')) {
+            delete_option(self::OPTION_STATE);
+        } else {
+            update_option(self::OPTION_STATE, '');
+        }
+    }
+
+    /**
+     * Gère la requête de déconnexion.
+     */
+    public function handle_disconnect_request() {
+        if (function_exists('current_user_can') && !current_user_can(BJLG_CAPABILITY)) {
+            return;
+        }
+
+        if (function_exists('wp_verify_nonce') && isset($_POST['bjlg_gdrive_nonce'])) {
+            if (!wp_verify_nonce(wp_unslash($_POST['bjlg_gdrive_nonce']), 'bjlg_gdrive_disconnect')) {
+                return;
+            }
+        }
+
+        $this->disconnect();
+    }
+
+    /**
+     * Crée un client Google configuré sans gérer le token.
+     *
+     * @return Google_Client
+     */
+    private function build_client() {
+        return call_user_func($this->client_factory);
+    }
+
+    /**
+     * Construit un client configuré pour les requêtes authentifiées.
+     *
+     * @return Google_Client
+     */
+    private function build_configured_client() {
+        $settings = $this->get_settings();
+        $client = $this->build_client();
+
+        $client->setClientId($settings['client_id']);
+        $client->setClientSecret($settings['client_secret']);
+        $client->setRedirectUri($this->get_redirect_uri());
+        $client->setAccessType('offline');
+        $client->setPrompt('consent');
+        $client->setScopes([self::SCOPE]);
+
+        $token = $this->get_stored_token();
+        if (!empty($token)) {
+            $client->setAccessToken($token);
+
+            if ($client->isAccessTokenExpired() && $client->getRefreshToken()) {
+                $new_token = $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+                if (!isset($new_token['error'])) {
+                    if (!isset($new_token['refresh_token']) && isset($token['refresh_token'])) {
+                        $new_token['refresh_token'] = $token['refresh_token'];
+                    }
+                    $this->store_token($new_token);
+                    $client->setAccessToken($new_token);
+                }
+            }
+        }
+
+        return $client;
+    }
+
+    /**
+     * Retourne l'URL de redirection utilisée pour OAuth.
+     *
+     * @return string
+     */
+    private function get_redirect_uri() {
+        $redirect = admin_url('admin.php?page=backup-jlg&tab=settings');
+        $redirect = add_query_arg(['bjlg_gdrive_auth' => '1'], $redirect);
+
+        return $redirect;
+    }
+
+    /**
+     * Crée et stocke un nouvel état OAuth puis génère l'URL d'autorisation.
+     *
+     * @return string
+     */
+    private function build_authorization_url() {
+        $settings = $this->get_settings();
+        $client = $this->build_client();
+
+        $client->setClientId($settings['client_id']);
+        $client->setClientSecret($settings['client_secret']);
+        $client->setRedirectUri($this->get_redirect_uri());
+        $client->setAccessType('offline');
+        $client->setPrompt('consent');
+        $client->setScopes([self::SCOPE]);
+
+        $state = call_user_func($this->state_generator);
+        if (method_exists($client, 'setState')) {
+            $client->setState($state);
+        }
+
+        update_option(self::OPTION_STATE, $state);
+
+        return $client->createAuthUrl();
+    }
+
+    /**
+     * Retourne les réglages Google Drive.
+     *
+     * @return array{client_id:string,client_secret:string,folder_id:string,enabled:bool}
+     */
+    private function get_settings() {
+        $defaults = [
+            'client_id' => '',
+            'client_secret' => '',
+            'folder_id' => '',
+            'enabled' => false,
+        ];
+
+        $settings = get_option(self::OPTION_SETTINGS, $defaults);
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
+        return array_merge($defaults, $settings);
+    }
+
+    /**
+     * Récupère le token d'accès stocké.
+     *
+     * @return array<string, mixed>
+     */
+    private function get_stored_token() {
+        $token = get_option(self::OPTION_TOKEN, []);
+
+        return is_array($token) ? $token : [];
+    }
+
+    /**
+     * Persiste le token obtenu depuis Google.
+     *
+     * @param array<string, mixed> $token
+     * @return void
+     */
+    private function store_token(array $token) {
+        update_option(self::OPTION_TOKEN, $token);
     }
 }

--- a/backup-jlg/tests/BJLG_GoogleDriveDestinationTest.php
+++ b/backup-jlg/tests/BJLG_GoogleDriveDestinationTest.php
@@ -1,0 +1,374 @@
+<?php
+declare(strict_types=1);
+
+use BJLG\BJLG_Google_Drive;
+use Google\Service\Drive\DriveFile;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/destinations/interface-bjlg-destination.php';
+require_once __DIR__ . '/../includes/destinations/class-bjlg-google-drive.php';
+
+final class BJLG_GoogleDriveDestinationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_options'] = [];
+        $_GET = [];
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['bjlg_test_options'] = [];
+        $_GET = [];
+        $_POST = [];
+
+        parent::tearDown();
+    }
+
+    public function test_upload_file_sends_backup_to_google_drive(): void
+    {
+        $client = new FakeGoogleClient();
+        $drive_files = new FakeDriveFiles();
+        $drive_service = new FakeDriveService($drive_files);
+
+        $destination = $this->createDestination($client, $drive_service);
+
+        update_option('bjlg_gdrive_settings', [
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'folder_id' => 'folder-42',
+            'enabled' => true,
+        ]);
+
+        update_option('bjlg_gdrive_token', [
+            'access_token' => 'token',
+            'refresh_token' => 'refresh-token',
+            'created' => time(),
+            'expires_in' => 3600,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        file_put_contents($file, 'backup-content');
+
+        $destination->upload_file($file, 'task-1');
+
+        $this->assertSame('folder-42', $drive_files->lastMetadata->getParents()[0]);
+        $this->assertSame(basename($file), $drive_files->lastMetadata->getName());
+        $this->assertSame('multipart', $drive_files->lastParams['uploadType']);
+        $this->assertSame('application/zip', $drive_files->lastParams['mimeType']);
+        $this->assertSame(strlen('backup-content'), strlen($drive_files->lastParams['data']));
+    }
+
+    public function test_upload_file_refreshes_token_when_expired(): void
+    {
+        $client = new FakeGoogleClient();
+        $client->expired = true;
+        $client->refreshTokenResponse = [
+            'access_token' => 'fresh-token',
+            'expires_in' => 3600,
+        ];
+
+        $drive_service = new FakeDriveService(new FakeDriveFiles());
+        $destination = $this->createDestination($client, $drive_service);
+
+        update_option('bjlg_gdrive_settings', [
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'folder_id' => '',
+            'enabled' => true,
+        ]);
+
+        update_option('bjlg_gdrive_token', [
+            'access_token' => 'old-token',
+            'refresh_token' => 'refresh-token',
+            'created' => time() - 7200,
+            'expires_in' => 3600,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        file_put_contents($file, 'content');
+
+        $destination->upload_file($file, 'task-refresh');
+
+        $stored = get_option('bjlg_gdrive_token');
+        $this->assertSame('fresh-token', $stored['access_token']);
+        $this->assertSame('refresh-token', $stored['refresh_token']);
+        $this->assertSame(['https://www.googleapis.com/auth/drive.file'], $client->scopes);
+        $this->assertSame('offline', $client->config['access_type']);
+    }
+
+    public function test_upload_file_throws_exception_when_api_fails(): void
+    {
+        $client = new FakeGoogleClient();
+        $drive_files = new FakeDriveFiles();
+        $drive_files->exception = new \Exception('Boom');
+
+        $destination = $this->createDestination($client, new FakeDriveService($drive_files));
+
+        update_option('bjlg_gdrive_settings', [
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'folder_id' => '',
+            'enabled' => true,
+        ]);
+
+        update_option('bjlg_gdrive_token', [
+            'access_token' => 'token',
+            'refresh_token' => 'refresh',
+            'created' => time(),
+            'expires_in' => 3600,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        file_put_contents($file, 'content');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Boom');
+
+        $destination->upload_file($file, 'task-error');
+    }
+
+    public function test_handle_oauth_callback_stores_token_on_success(): void
+    {
+        $client = new FakeGoogleClient();
+        $client->authTokenResponse = [
+            'access_token' => 'auth-token',
+            'refresh_token' => 'auth-refresh',
+            'expires_in' => 3600,
+        ];
+
+        $destination = $this->createDestination($client, new FakeDriveService(new FakeDriveFiles()));
+
+        update_option('bjlg_gdrive_settings', [
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'folder_id' => '',
+            'enabled' => true,
+        ]);
+
+        update_option('bjlg_gdrive_state', 'state-token');
+
+        $_GET['bjlg_gdrive_auth'] = '1';
+        $_GET['code'] = 'auth-code';
+        $_GET['state'] = 'state-token';
+
+        $destination->handle_oauth_callback();
+
+        $token = get_option('bjlg_gdrive_token');
+        $this->assertSame('auth-token', $token['access_token']);
+        $this->assertSame('auth-refresh', $token['refresh_token']);
+        $this->assertSame('auth-code', $client->authCodeReceived);
+        $this->assertSame('', get_option('bjlg_gdrive_state', ''));
+    }
+
+    public function test_handle_oauth_callback_ignores_invalid_state(): void
+    {
+        $client = new FakeGoogleClient();
+        $destination = $this->createDestination($client, new FakeDriveService(new FakeDriveFiles()));
+
+        update_option('bjlg_gdrive_settings', [
+            'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
+            'folder_id' => '',
+            'enabled' => true,
+        ]);
+
+        update_option('bjlg_gdrive_state', 'expected-state');
+
+        $_GET['bjlg_gdrive_auth'] = '1';
+        $_GET['code'] = 'auth-code';
+        $_GET['state'] = 'invalid-state';
+
+        $destination->handle_oauth_callback();
+
+        $this->assertSame([], get_option('bjlg_gdrive_token', []));
+        $this->assertNull($client->authCodeReceived);
+    }
+
+    private function createDestination(FakeGoogleClient $client, FakeDriveService $drive_service): BJLG_Google_Drive
+    {
+        $test_case = $this;
+
+        return new BJLG_Google_Drive(
+            static function () use ($client) {
+                return $client;
+            },
+            static function ($provided_client) use ($client, $drive_service, $test_case) {
+                $test_case->assertSame($client, $provided_client);
+
+                return $drive_service;
+            },
+            static function () {
+                return 'state-token';
+            }
+        );
+    }
+}
+
+final class FakeGoogleClient
+{
+    /** @var array<string, mixed> */
+    public $config = [];
+
+    /** @var array<int, string> */
+    public $scopes = [];
+
+    /** @var array<string, mixed> */
+    public $accessToken = [];
+
+    /** @var bool */
+    public $expired = false;
+
+    /** @var array<string, mixed> */
+    public $authTokenResponse = [];
+
+    /** @var array<string, mixed> */
+    public $refreshTokenResponse = [];
+
+    /** @var string|null */
+    public $authCodeReceived = null;
+
+    /** @var string|null */
+    public $state = null;
+
+    /** @var string|null */
+    private $refreshToken = null;
+
+    public function __construct()
+    {
+        $this->authTokenResponse = [
+            'access_token' => 'auth-token',
+            'refresh_token' => 'auth-refresh',
+            'expires_in' => 3600,
+        ];
+
+        $this->refreshTokenResponse = [
+            'access_token' => 'refresh-token',
+            'refresh_token' => 'auth-refresh',
+            'expires_in' => 3600,
+        ];
+    }
+
+    public function setClientId($id): void
+    {
+        $this->config['client_id'] = $id;
+    }
+
+    public function setClientSecret($secret): void
+    {
+        $this->config['client_secret'] = $secret;
+    }
+
+    public function setRedirectUri($uri): void
+    {
+        $this->config['redirect_uri'] = $uri;
+    }
+
+    public function setAccessType($type): void
+    {
+        $this->config['access_type'] = $type;
+    }
+
+    public function setPrompt($prompt): void
+    {
+        $this->config['prompt'] = $prompt;
+    }
+
+    public function setScopes(array $scopes): void
+    {
+        $this->scopes = $scopes;
+    }
+
+    public function addScope($scope): void
+    {
+        $this->scopes[] = $scope;
+    }
+
+    public function setAccessToken($token): void
+    {
+        $this->accessToken = $token;
+        if (isset($token['refresh_token'])) {
+            $this->refreshToken = (string) $token['refresh_token'];
+        }
+    }
+
+    public function isAccessTokenExpired(): bool
+    {
+        return $this->expired;
+    }
+
+    public function getRefreshToken(): ?string
+    {
+        return $this->refreshToken;
+    }
+
+    public function fetchAccessTokenWithRefreshToken($refreshToken): array
+    {
+        $this->refreshToken = (string) $refreshToken;
+        $this->accessToken = $this->refreshTokenResponse;
+
+        return $this->refreshTokenResponse;
+    }
+
+    public function fetchAccessTokenWithAuthCode($code): array
+    {
+        $this->authCodeReceived = (string) $code;
+        $this->refreshToken = $this->authTokenResponse['refresh_token'] ?? $this->refreshToken;
+        $this->accessToken = $this->authTokenResponse;
+
+        return $this->authTokenResponse;
+    }
+
+    public function createAuthUrl(): string
+    {
+        return 'https://example.com/auth?state=' . rawurlencode((string) $this->state);
+    }
+
+    public function setState($state): void
+    {
+        $this->state = (string) $state;
+    }
+}
+
+final class FakeDriveService
+{
+    /** @var FakeDriveFiles */
+    public $files;
+
+    public function __construct(FakeDriveFiles $files)
+    {
+        $this->files = $files;
+    }
+}
+
+final class FakeDriveFiles
+{
+    /** @var DriveFile|null */
+    public $lastMetadata = null;
+
+    /** @var array<string, mixed>|null */
+    public $lastParams = null;
+
+    /** @var \Exception|null */
+    public $exception = null;
+
+    public function create($metadata, $params)
+    {
+        if ($this->exception instanceof \Exception) {
+            throw $this->exception;
+        }
+
+        $this->lastMetadata = $metadata;
+        $this->lastParams = $params;
+
+        $file = new DriveFile();
+        $file->setId('file-123');
+        $file->setName($metadata->getName());
+        $file->setSize((string) strlen($params['data'] ?? ''));
+
+        return $file;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the Google Drive destination stub with a working OAuth flow, token management, and uploads backed by google/apiclient
- expose default Google Drive settings via BJLG_Settings and guard webhook warning headers in CLI contexts
- add integration-style PHPUnit tests with mocked Google API clients to cover successful uploads, token refresh, and error handling

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dad6c6137c832eba8322a5565251b0