### PR TITLE
Validate task IDs before reporting task status

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -2167,9 +2167,19 @@ class BJLG_REST_API {
      * Endpoint : Obtenir le statut d'une tâche
      */
     public function get_task_status($request) {
-        $task_id = $request->get_param('id');
+        $raw_task_id = $request->get_param('id');
+        $task_id = sanitize_key($raw_task_id);
+
+        if (empty($task_id) || !preg_match('/^bjlg_(?:backup|restore)_[a-z0-9_]+$/', $task_id)) {
+            return new WP_Error(
+                'invalid_task_id',
+                __('Invalid task identifier.', 'backup-jlg'),
+                ['status' => 400]
+            );
+        }
+
         $task_data = get_transient($task_id);
-        
+
         if (!$task_data) {
             return new WP_Error(
                 'task_not_found',

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -2059,6 +2059,37 @@ namespace {
         $this->deleteBackupIfExists($archive_path);
     }
 
+    public function test_get_task_status_rejects_invalid_identifier(): void
+    {
+        $api = new BJLG\BJLG_REST_API();
+
+        $request = new class {
+            /** @var array<string, mixed> */
+            private $params;
+
+            public function __construct()
+            {
+                $this->params = [
+                    'id' => 'bjlg_invalid_123',
+                ];
+            }
+
+            public function get_param($key)
+            {
+                return $this->params[$key] ?? null;
+            }
+        };
+
+        $response = $api->get_task_status($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+        $this->assertSame('invalid_task_id', $response->get_error_code());
+
+        $error_data = $response->get_error_data();
+        $this->assertIsArray($error_data);
+        $this->assertSame(400, $error_data['status']);
+    }
+
         public function test_update_settings_rejects_empty_payload(): void
         {
             $api = new BJLG\BJLG_REST_API();


### PR DESCRIPTION
## Summary
- ensure the task status endpoint sanitizes and validates task identifiers before fetching a transient
- return a 400 WP_Error when the identifier is missing or does not match backup/restore prefixes
- cover the new validation with a REST API test for rejected task IDs

## Testing
- composer test *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dad6c230d4832e8f57d934a12c9397