### PR TITLE
Handle download token persistence failures

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -2248,17 +2248,25 @@ class BJLG_REST_API {
             $transient_key = 'bjlg_download_' . $download_token;
             $token_ttl = BJLG_Actions::get_download_token_ttl($filepath);
 
-            set_transient(
+            $persisted = set_transient(
                 $transient_key,
                 BJLG_Actions::build_download_token_payload($filepath),
                 $token_ttl
             );
 
-            $download_url = BJLG_Actions::build_download_url($download_token);
+            if ($persisted === false) {
+                BJLG_Debug::error(sprintf(
+                    'Échec de la persistance du token de téléchargement "%s" pour "%s".',
+                    $download_token,
+                    $filepath
+                ));
+            } else {
+                $download_url = BJLG_Actions::build_download_url($download_token);
 
-            $data['download_url'] = $download_url;
-            $data['download_token'] = $download_token;
-            $data['download_expires_in'] = $token_ttl;
+                $data['download_url'] = $download_url;
+                $data['download_token'] = $download_token;
+                $data['download_expires_in'] = $token_ttl;
+            }
         }
 
         return $data;


### PR DESCRIPTION
## Summary
- guard download token generation in backup listing against transient persistence failures
- log the failure and omit download fields when tokens cannot be saved
- add a regression test that simulates set_transient returning false for backup listings with tokens

## Testing
- vendor-bjlg/bin/phpunit --stderr

------
https://chatgpt.com/codex/tasks/task_e_68dad6c19178832e8a6e85a466a38f9f