### PR TITLE
Handle failure when adding database dump to pre-restore backup

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -124,7 +124,14 @@ class BJLG_Restore {
 
             // Export de la base de données
             $backup_manager->dump_database($sql_filepath);
-            $zip->addFile($sql_filepath, 'database.sql');
+            $added_to_zip = $zip->addFile($sql_filepath, 'database.sql');
+
+            if ($added_to_zip === false) {
+                $cleanup_sql_file();
+                throw new Exception(
+                    "Impossible d'ajouter l'export de la base de données à l'archive de pré-restauration."
+                );
+            }
 
             // Ajout des dossiers
             $upload_dir_info = wp_get_upload_dir();


### PR DESCRIPTION
## Summary
- guard against failures when adding the SQL dump to the pre-restore backup archive
- ensure the temporary SQL export is cleaned up before aborting the backup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe8da3a4c832eae8f67e35d124d00