### PR TITLE
Handle missing restore manifest components

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -604,7 +604,11 @@ class BJLG_Restore {
             }
 
             if (empty($components_to_restore)) {
-                $error_message = "Aucun composant valide n'a été trouvé dans l'archive de sauvegarde.";
+                if (empty($manifest_components)) {
+                    $error_message = "Aucun composant utile n'a été trouvé dans le manifeste de sauvegarde.";
+                } else {
+                    $error_message = "Les composants demandés ne sont pas disponibles dans l'archive de sauvegarde.";
+                }
 
                 if (class_exists('BJLG_Debug')) {
                     BJLG_Debug::log('ERREUR: ' . $error_message, 'error');


### PR DESCRIPTION
## Summary
- add explicit error messaging when no usable components are available from the backup manifest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf75d074c832ebbd8e906b55be890