### PR TITLE
Handle database dump zip failure during pre-restore backup

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -126,10 +126,10 @@ class BJLG_Restore {
             $backup_manager->dump_database($sql_filepath);
             $added_to_zip = $zip->addFile($sql_filepath, 'database.sql');
 
-            if ($added_to_zip === false) {
+            if ($added_to_zip !== true) {
                 $cleanup_sql_file();
                 throw new Exception(
-                    "Impossible d'ajouter l'export de la base de données à l'archive de pré-restauration."
+                    "Impossible d'ajouter l'export de la base de données (database.sql) à l'archive de pré-restauration."
                 );
             }
 


### PR DESCRIPTION
## Summary
- ensure the database export is successfully added to the pre-restore backup archive
- abort the backup with a clear exception and clean up the temporary SQL dump if the add operation fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf7595990832ea0dfcbc9c0e03473