### PR TITLE
Handle encrypted restore passwords via REST API

### DIFF
--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -389,7 +389,7 @@ class BJLG_Restore {
         }
 
         try {
-            $encrypted_password = $this->encrypt_password_for_transient($password);
+            $encrypted_password = self::encrypt_password_for_transient($password);
         } catch (Exception $exception) {
             if (class_exists(BJLG_Debug::class)) {
                 BJLG_Debug::log('Échec du chiffrement du mot de passe de restauration : ' . $exception->getMessage(), 'error');
@@ -1078,12 +1078,12 @@ class BJLG_Restore {
      * @param string|null $password
      * @return string|null
      */
-    private function encrypt_password_for_transient($password) {
+    public static function encrypt_password_for_transient($password) {
         if ($password === null) {
             return null;
         }
 
-        $key = $this->get_password_encryption_key();
+        $key = self::get_password_encryption_key();
         $iv_length = openssl_cipher_iv_length('aes-256-cbc');
         if ($iv_length === false) {
             throw new RuntimeException('Méthode de chiffrement indisponible.');
@@ -1116,7 +1116,7 @@ class BJLG_Restore {
             return null;
         }
 
-        $key = $this->get_password_encryption_key();
+        $key = self::get_password_encryption_key();
         $iv_length = openssl_cipher_iv_length('aes-256-cbc');
         if ($iv_length === false) {
             throw new RuntimeException('Méthode de déchiffrement indisponible.');
@@ -1149,7 +1149,7 @@ class BJLG_Restore {
      *
      * @return string
      */
-    private function get_password_encryption_key() {
+    private static function get_password_encryption_key() {
         $salts = [];
 
         if (function_exists('wp_salt')) {

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -587,7 +587,7 @@ final class BJLG_RestoreSecurityTest extends TestCase
 
         $manifest = [
             'type' => 'test',
-            'contains' => [],
+            'contains' => ['db'],
         ];
 
         $zip->addFromString('backup-manifest.json', json_encode($manifest));


### PR DESCRIPTION
## Summary
- allow the `/backups/{id}/restore` REST endpoint to accept an optional password, validate it, and encrypt it before scheduling the task
- expose the restore password encryption helper for reuse and avoid manifest-aware type filtering from matching aliases erroneously
- add coverage for encrypted restores via the API and adjust the restore security test manifest

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dbfb9ed6fc832eb73d667908f3f142