### PR TITLE
Handle ZipArchive failures during backup

### DIFF
--- a/backup-jlg/tests/BJLG_BackupDatabaseTest.php
+++ b/backup-jlg/tests/BJLG_BackupDatabaseTest.php
@@ -226,7 +226,8 @@ final class BJLG_BackupDatabaseTest extends TestCase
                 $method->invokeArgs($backup, [&$zip, false]);
                 $this->fail("Expected exception was not thrown when addFile failed");
             } catch (Exception $exception) {
-                $this->assertStringContainsString("Impossible d'ajouter l'export SQL à l'archive.", $exception->getMessage());
+                $this->assertStringContainsString("Impossible d'ajouter l'export SQL temporaire", $exception->getMessage());
+                $this->assertStringContainsString('database.sql', $exception->getMessage());
             }
 
             $temporaryFilesProperty = new ReflectionProperty(BJLG\BJLG_Backup::class, 'temporary_files');


### PR DESCRIPTION
## Summary
- log and throw explicit exceptions when ZipArchive::addFile or ::setCompressionName fails during backup creation
- ensure database export errors report the temporary file path before bubbling up to the task handler
- extend filesystem and database tests to cover ZipArchive failure scenarios

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68dc0682a8d0832e8a2a201f6e13d812