### PR TITLE
Validate webhook component handling

### DIFF
--- a/backup-jlg/readme.md
+++ b/backup-jlg/readme.md
@@ -194,6 +194,8 @@ curl -X POST https://site.com/?bjlg_trigger_backup=1 \
 
 > ℹ️ L'ancien format `https://site.com/?bjlg_trigger_backup=VOTRE_CLE_WEBHOOK` reste supporté durant la période de transition, mais sera retiré après migration.
 
+> ❗ Si aucun composant valide n'est demandé (`components=foo` par exemple), l'API répond désormais avec un code **400** et le message `No valid components were requested. Allowed components are: db, plugins, themes, uploads.` sans réserver de créneau de sauvegarde.
+
 ## 📊 Endpoints API
 
 | Méthode | Endpoint | Description |

--- a/backup-jlg/tests/BJLG_WebhooksTest.php
+++ b/backup-jlg/tests/BJLG_WebhooksTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('BJLG\\BJLG_Debug') && !class_exists('BJLG_Debug')) {
+    class BJLG_Debug
+    {
+        /** @var array<int, string> */
+        public static $logs = [];
+
+        /**
+         * @param mixed $message
+         */
+        public static function log($message): void
+        {
+            self::$logs[] = (string) $message;
+        }
+    }
+
+    class_alias('BJLG_Debug', 'BJLG\\BJLG_Debug');
+}
+
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+require_once __DIR__ . '/../includes/class-bjlg-webhooks.php';
+
+final class BJLG_WebhooksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_scheduled_events'] = [
+            'recurring' => [],
+            'single' => [],
+        ];
+        $GLOBALS['bjlg_test_options'] = [];
+        $GLOBALS['bjlg_test_set_transient_mock'] = null;
+        $GLOBALS['bjlg_test_schedule_single_event_mock'] = null;
+        BJLG_Debug::$logs = [];
+
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [];
+
+        $lock_property = new ReflectionProperty(BJLG\BJLG_Backup::class, 'in_memory_lock');
+        $lock_property->setAccessible(true);
+        $lock_property->setValue(null, null);
+    }
+
+    protected function tearDown(): void
+    {
+        $lock_property = new ReflectionProperty(BJLG\BJLG_Backup::class, 'in_memory_lock');
+        $lock_property->setAccessible(true);
+        $lock_property->setValue(null, null);
+
+        $_GET = [];
+        $_POST = [];
+        $_SERVER = [];
+
+        parent::tearDown();
+    }
+
+    public function test_webhook_rejects_invalid_components_without_reserving_slot(): void
+    {
+        update_option('bjlg_webhook_key', 'webhook-test-key');
+
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_USER_AGENT'] = 'PHPUnit Test';
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['HTTP_X_BJLG_WEBHOOK_KEY'] = 'webhook-test-key';
+
+        $_GET[BJLG\BJLG_Webhooks::WEBHOOK_QUERY_VAR] = BJLG\BJLG_Webhooks::WEBHOOK_SECURE_MARKER;
+        $_GET['components'] = 'foo';
+
+        $webhooks = new BJLG\BJLG_Webhooks();
+
+        try {
+            $webhooks->listen_for_webhook();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame(400, $response->status_code);
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame(
+                'No valid components were requested. Allowed components are: db, plugins, themes, uploads.',
+                $response->data['message']
+            );
+        }
+
+        $this->assertArrayNotHasKey('bjlg_backup_task_lock', $GLOBALS['bjlg_test_transients']);
+        $this->assertEmpty($GLOBALS['bjlg_test_scheduled_events']['single']);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize and validate webhook component requests, add a filter for allowed components, and return HTTP 400 when none remain
- document the new invalid-component response in the webhook section of the README
- cover invalid webhook component requests with a PHPUnit test

## Testing
- ./vendor-bjlg/bin/phpunit --filter BJLG_WebhooksTest

------
https://chatgpt.com/codex/tasks/task_e_68dc0689d5e4832eae43bb619b58ad75