### PR TITLE
Add label for restore file input

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -254,7 +254,7 @@ class BJLG_Admin {
                 <table class="form-table">
                     <tbody>
                         <tr>
-                            <th scope="row">Fichier de sauvegarde</th>
+                            <th scope="row"><label for="bjlg-restore-file-input">Fichier de sauvegarde</label></th>
                             <td>
                                 <input type="file" id="bjlg-restore-file-input" name="restore_file" accept=".zip,.zip.enc" required>
                                 <p class="description">Formats acceptés : .zip, .zip.enc (chiffré)</p>


### PR DESCRIPTION
## Summary
- wrap the restore file header text in a label associated with the file input to improve accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0edd8308832e96291fc3321cfeb1