### PR TITLE
Handle support package generation via AJAX and add diagnostics test

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -741,6 +741,83 @@ jQuery(document).ready(function($) {
 
     // --- GESTIONNAIRE DU PACK DE SUPPORT ---
     $('#bjlg-generate-support-package').on('click', function(e) {
-        // ... (Code complet fourni précédemment) ...
+        e.preventDefault();
+
+        const $button = $(this);
+        const $statusArea = $('#bjlg-support-package-status');
+
+        $button.prop('disabled', true).attr('aria-busy', 'true');
+
+        if ($statusArea.length) {
+            $statusArea.removeClass('bjlg-status-error bjlg-status-success');
+            $statusArea.text('Génération du pack de support en cours...');
+        }
+
+        $.ajax({
+            url: bjlg_ajax.ajax_url,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                action: 'bjlg_generate_support_package',
+                nonce: bjlg_ajax.nonce
+            }
+        })
+        .done(function(response) {
+            const data = response && response.data ? response.data : null;
+
+            if (response && response.success && data && data.download_url) {
+                const details = [];
+
+                if (data.filename) {
+                    details.push('Fichier : ' + data.filename);
+                }
+
+                if (data.size) {
+                    details.push('Taille : ' + data.size);
+                }
+
+                if ($statusArea.length) {
+                    const message = data.message || 'Pack de support généré avec succès.';
+                    const suffix = details.length ? ' (' + details.join(' • ') + ')' : '';
+                    $statusArea.text(message + suffix);
+                }
+
+                const link = document.createElement('a');
+                link.href = data.download_url;
+
+                if (data.filename) {
+                    link.download = data.filename;
+                }
+
+                link.style.display = 'none';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            } else {
+                const errorMessage = data && data.message
+                    ? data.message
+                    : 'Réponse inattendue du serveur.';
+
+                if ($statusArea.length) {
+                    $statusArea.text('Erreur : ' + errorMessage);
+                }
+            }
+        })
+        .fail(function(xhr) {
+            let errorMessage = 'Erreur de communication avec le serveur.';
+
+            if (xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message) {
+                errorMessage = xhr.responseJSON.data.message;
+            } else if (xhr && xhr.responseText) {
+                errorMessage = xhr.responseText;
+            }
+
+            if ($statusArea.length) {
+                $statusArea.text('Erreur : ' + errorMessage);
+            }
+        })
+        .always(function() {
+            $button.prop('disabled', false).removeAttr('aria-busy');
+        });
     });
 });

--- a/backup-jlg/tests/BJLG_DiagnosticsSupportPackageTest.php
+++ b/backup-jlg/tests/BJLG_DiagnosticsSupportPackageTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace BJLG {
+    if (!class_exists(__NAMESPACE__ . '\\BJLG_Health_Check')) {
+        class BJLG_Health_Check
+        {
+            public function export_health_report(): string
+            {
+                return "Rapport de test";
+            }
+        }
+    }
+}
+
+namespace {
+
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+require_once __DIR__ . '/../includes/class-bjlg-actions.php';
+require_once __DIR__ . '/../includes/class-bjlg-diagnostics.php';
+
+final class BJLG_DiagnosticsSupportPackageTest extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_current_user_can'] = true;
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_last_json_success'] = null;
+        $GLOBALS['bjlg_test_last_json_error'] = null;
+        $GLOBALS['current_user'] = null;
+        $GLOBALS['current_user_id'] = 0;
+        \BJLG\BJLG_Debug::$logs = [];
+        $_POST = [];
+
+        foreach (glob(BJLG_BACKUP_DIR . 'support-package-*.zip') ?: [] as $existing) {
+            @unlink($existing);
+        }
+    }
+
+    public function test_handle_generate_support_package_returns_download_payload(): void
+    {
+        $diagnostics = new \BJLG\BJLG_Diagnostics();
+
+        $_POST['nonce'] = 'test-nonce';
+
+        try {
+            $diagnostics->handle_generate_support_package();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame('JSON response', $response->getMessage());
+            $lastSuccess = $GLOBALS['bjlg_test_last_json_success'];
+            $this->assertIsArray($lastSuccess);
+            $this->assertArrayHasKey('data', $lastSuccess);
+
+            $data = $lastSuccess['data'];
+            $this->assertIsArray($data);
+            $this->assertArrayHasKey('download_url', $data);
+            $this->assertArrayHasKey('filename', $data);
+            $this->assertArrayHasKey('size', $data);
+            $this->assertSame('Pack de support généré avec succès.', $data['message']);
+
+            $downloadUrl = $data['download_url'];
+            $this->assertIsString($downloadUrl);
+            $this->assertNotEmpty($downloadUrl);
+
+            parse_str((string) parse_url($downloadUrl, PHP_URL_QUERY), $query);
+            $this->assertArrayHasKey('token', $query);
+            $token = $query['token'];
+
+            $transientKey = 'bjlg_download_' . $token;
+            $this->assertArrayHasKey($transientKey, $GLOBALS['bjlg_test_transients']);
+
+            $payload = $GLOBALS['bjlg_test_transients'][$transientKey];
+            $this->assertArrayHasKey('file', $payload);
+            $this->assertArrayHasKey('delete_after_download', $payload);
+            $this->assertTrue($payload['delete_after_download']);
+
+            $filePath = $payload['file'];
+            $this->assertIsString($filePath);
+            $this->assertFileExists($filePath);
+            $this->assertGreaterThan(0, filesize($filePath));
+
+            @unlink($filePath);
+            unset($GLOBALS['bjlg_test_transients'][$transientKey]);
+        }
+    }
+
+    public function test_handle_generate_support_package_requires_capability(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = false;
+
+        $diagnostics = new \BJLG\BJLG_Diagnostics();
+        $_POST['nonce'] = 'test-nonce';
+
+        try {
+            $diagnostics->handle_generate_support_package();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame(['message' => 'Permission refusée.'], $response->data);
+
+            $lastError = $GLOBALS['bjlg_test_last_json_error'];
+            $this->assertIsArray($lastError);
+            $this->assertSame(['message' => 'Permission refusée.'], $lastError['data']);
+        } finally {
+            $GLOBALS['bjlg_test_current_user_can'] = true;
+        }
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- implement the admin support package click handler to call the AJAX endpoint, surface status updates, and trigger the returned download
- extend the PHPUnit bootstrap to load the real debug class, stub missing WP helpers, and capture last JSON responses used by the diagnostics flow
- add a dedicated diagnostics support package test covering both success and permission failure scenarios

## Testing
- `./vendor-bjlg/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dd0ed8122c832ea5a92e21d7d09302