### PR TITLE
Improve restore upload handling and tests

### DIFF
--- a/backup-jlg/tests/BJLG_RestoreUploadTest.php
+++ b/backup-jlg/tests/BJLG_RestoreUploadTest.php
@@ -1,0 +1,187 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('BJLG_VERSION')) {
+    define('BJLG_VERSION', 'test-version');
+}
+
+require_once __DIR__ . '/../includes/class-bjlg-restore.php';
+
+final class BJLG_RestoreUploadTest extends TestCase
+{
+    /** @var array<int, string> */
+    private $temporaryPaths = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['bjlg_test_current_user_can'] = true;
+        $GLOBALS['bjlg_test_last_json_error'] = null;
+        $GLOBALS['bjlg_test_last_json_success'] = null;
+        $GLOBALS['bjlg_test_wp_handle_upload_mock'] = null;
+        $GLOBALS['bjlg_test_wp_check_filetype_and_ext_mock'] = null;
+
+        if (!isset($GLOBALS['bjlg_test_hooks'])) {
+            $GLOBALS['bjlg_test_hooks'] = [
+                'actions' => [],
+                'filters' => [],
+            ];
+        }
+
+        $GLOBALS['bjlg_test_hooks']['filters'] = [];
+        $GLOBALS['bjlg_test_hooks']['actions'] = [];
+
+        $_POST = [];
+        $_FILES = [];
+
+        if (!is_dir(BJLG_BACKUP_DIR)) {
+            mkdir(BJLG_BACKUP_DIR, 0777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryPaths as $path) {
+            if (is_string($path) && $path !== '' && file_exists($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->temporaryPaths = [];
+        $_FILES = [];
+        $GLOBALS['bjlg_test_wp_handle_upload_mock'] = null;
+        $GLOBALS['bjlg_test_wp_check_filetype_and_ext_mock'] = null;
+
+        parent::tearDown();
+    }
+
+    public function test_handle_upload_restore_file_returns_ini_size_error_message(): void
+    {
+        $_POST['nonce'] = 'nonce';
+
+        $tempFile = $this->createTemporaryFile('ini-size-error');
+
+        $_FILES['restore_file'] = [
+            'name' => 'oversized.zip',
+            'type' => 'application/zip',
+            'tmp_name' => $tempFile,
+            'error' => UPLOAD_ERR_INI_SIZE,
+            'size' => filesize($tempFile),
+        ];
+
+        $restore = new BJLG\BJLG_Restore();
+
+        try {
+            $restore->handle_upload_restore_file();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame(
+                'Le fichier dépasse la taille maximale autorisée par la configuration PHP.',
+                $response->data['message']
+            );
+            $this->assertArrayHasKey('upload_error_code', $response->data);
+            $this->assertSame(UPLOAD_ERR_INI_SIZE, $response->data['upload_error_code']);
+        }
+    }
+
+    public function test_handle_upload_restore_file_rejects_disallowed_extension(): void
+    {
+        $_POST['nonce'] = 'nonce';
+
+        $tempFile = $this->createTemporaryFile('not-zip');
+
+        $_FILES['restore_file'] = [
+            'name' => 'payload.txt',
+            'type' => 'text/plain',
+            'tmp_name' => $tempFile,
+            'error' => UPLOAD_ERR_OK,
+            'size' => filesize($tempFile),
+        ];
+
+        add_filter('bjlg_restore_validate_is_uploaded_file', static function () {
+            return true;
+        }, 10, 2);
+
+        $restore = new BJLG\BJLG_Restore();
+
+        try {
+            $restore->handle_upload_restore_file();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame('Type ou extension de fichier non autorisé.', $response->data['message']);
+        }
+    }
+
+    public function test_handle_upload_restore_file_moves_file_to_backup_directory(): void
+    {
+        $_POST['nonce'] = 'nonce';
+
+        $tempFile = $this->createTemporaryFile('valid-zip');
+
+        $_FILES['restore_file'] = [
+            'name' => 'archive.zip',
+            'type' => 'application/zip',
+            'tmp_name' => $tempFile,
+            'error' => UPLOAD_ERR_OK,
+            'size' => filesize($tempFile),
+        ];
+
+        add_filter('bjlg_restore_validate_is_uploaded_file', static function () {
+            return true;
+        }, 10, 2);
+
+        $handledPath = sys_get_temp_dir() . '/bjlg-handled-' . uniqid('', true) . '.zip';
+        $this->temporaryPaths[] = $handledPath;
+
+        $GLOBALS['bjlg_test_wp_handle_upload_mock'] = static function ($file) use ($handledPath) {
+            copy($file['tmp_name'], $handledPath);
+
+            return [
+                'file' => $handledPath,
+                'url' => 'http://example.com/' . basename($handledPath),
+                'type' => $file['type'] ?? '',
+            ];
+        };
+
+        $restore = new BJLG\BJLG_Restore();
+
+        try {
+            $restore->handle_upload_restore_file();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertIsArray($response->data);
+            $this->assertArrayHasKey('filepath', $response->data);
+            $this->assertArrayHasKey('filename', $response->data);
+            $this->assertArrayHasKey('message', $response->data);
+            $this->assertSame('Fichier téléversé avec succès.', $response->data['message']);
+
+            $destination = $response->data['filepath'];
+            $this->assertStringContainsString('restore_', basename($destination));
+            $this->assertFileExists($destination);
+            $this->assertStringEndsWith('.zip', $response->data['filename']);
+
+            $this->temporaryPaths[] = $destination;
+            $this->assertFileDoesNotExist($handledPath);
+        }
+    }
+
+    private function createTemporaryFile(string $contents): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'bjlg');
+        if ($tempFile === false) {
+            $this->fail('Unable to create temporary file for test.');
+        }
+
+        file_put_contents($tempFile, $contents);
+        $this->temporaryPaths[] = $tempFile;
+
+        return $tempFile;
+    }
+}

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -127,6 +127,8 @@ $GLOBALS['bjlg_test_last_json_success'] = null;
 $GLOBALS['bjlg_test_last_json_error'] = null;
 $GLOBALS['bjlg_test_set_transient_mock'] = null;
 $GLOBALS['bjlg_test_schedule_single_event_mock'] = null;
+$GLOBALS['bjlg_test_wp_handle_upload_mock'] = null;
+$GLOBALS['bjlg_test_wp_check_filetype_and_ext_mock'] = null;
 $GLOBALS['bjlg_test_options'] = [];
 $GLOBALS['bjlg_registered_routes'] = [];
 $GLOBALS['bjlg_history_entries'] = [];
@@ -729,6 +731,85 @@ if (!function_exists('wp_salt')) {
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value) {
         return $value;
+    }
+}
+
+if (!function_exists('wp_mkdir_p')) {
+    function wp_mkdir_p($target) {
+        if (is_dir($target)) {
+            return true;
+        }
+
+        if ($target === '' || $target === null) {
+            return false;
+        }
+
+        return mkdir($target, 0777, true);
+    }
+}
+
+if (!function_exists('wp_check_filetype_and_ext')) {
+    function wp_check_filetype_and_ext($file, $filename, $mimes = null) {
+        $mock = $GLOBALS['bjlg_test_wp_check_filetype_and_ext_mock'] ?? null;
+
+        if (is_callable($mock)) {
+            return $mock($file, $filename, $mimes);
+        }
+
+        $extension = strtolower((string) pathinfo((string) $filename, PATHINFO_EXTENSION));
+
+        if (is_array($mimes) && $mimes !== []) {
+            if ($extension === '' || !array_key_exists($extension, $mimes)) {
+                return [
+                    'ext' => false,
+                    'type' => false,
+                    'proper_filename' => false,
+                ];
+            }
+
+            return [
+                'ext' => $extension,
+                'type' => $mimes[$extension],
+                'proper_filename' => $filename,
+            ];
+        }
+
+        return [
+            'ext' => $extension ?: false,
+            'type' => $extension ? 'application/octet-stream' : false,
+            'proper_filename' => $filename,
+        ];
+    }
+}
+
+if (!function_exists('wp_handle_upload')) {
+    function wp_handle_upload($file, $overrides = false, $time = null, $action = '') {
+        $mock = $GLOBALS['bjlg_test_wp_handle_upload_mock'] ?? null;
+
+        if (is_callable($mock)) {
+            return $mock($file, $overrides, $time, $action);
+        }
+
+        $upload_dir = sys_get_temp_dir() . '/bjlg-uploaded-files';
+
+        if (!is_dir($upload_dir)) {
+            mkdir($upload_dir, 0777, true);
+        }
+
+        $original_name = isset($file['name']) ? basename((string) $file['name']) : 'upload.tmp';
+        $destination = $upload_dir . '/' . uniqid('upload_', true) . '_' . $original_name;
+
+        if (!empty($file['tmp_name']) && file_exists($file['tmp_name'])) {
+            copy($file['tmp_name'], $destination);
+        } else {
+            file_put_contents($destination, '');
+        }
+
+        return [
+            'file' => $destination,
+            'url' => 'http://example.com/' . basename($destination),
+            'type' => $file['type'] ?? '',
+        ];
     }
 }
 


### PR DESCRIPTION
## Summary
- add explicit upload error handling to `handle_upload_restore_file`, switch to `wp_handle_upload`, and harden file moves
- provide test doubles for WordPress upload helpers used in the restore workflow
- cover success and failure scenarios for restore file uploads with new PHPUnit tests

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd2e9d499c832e99ec36c5ecd72f32