### PR TITLE
Improve accessibility of admin progress indicators

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -168,8 +168,22 @@ class BJLG_Admin {
             </form>
             <div id="bjlg-backup-progress-area" style="display: none;">
                 <h3>Progression</h3>
-                <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-backup-progress-bar">0%</div></div>
-                <p id="bjlg-backup-status-text">Initialisation...</p>
+                <div class="bjlg-progress-bar"><div
+                        class="bjlg-progress-bar-inner"
+                        id="bjlg-backup-progress-bar"
+                        role="progressbar"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        aria-valuenow="0"
+                        aria-valuetext="0%"
+                        aria-live="off"
+                        aria-atomic="true"
+                        aria-busy="false">0%</div></div>
+                <p id="bjlg-backup-status-text"
+                   role="status"
+                   aria-live="polite"
+                   aria-atomic="true"
+                   aria-busy="false">Initialisation...</p>
             </div>
             <div id="bjlg-backup-debug-wrapper" style="display: none;">
                 <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>
@@ -294,8 +308,22 @@ class BJLG_Admin {
             </form>
             <div id="bjlg-restore-status" style="display: none;">
                 <h3>Statut de la restauration</h3>
-                <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-restore-progress-bar">0%</div></div>
-                <p id="bjlg-restore-status-text">Préparation...</p>
+                <div class="bjlg-progress-bar"><div
+                        class="bjlg-progress-bar-inner"
+                        id="bjlg-restore-progress-bar"
+                        role="progressbar"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        aria-valuenow="0"
+                        aria-valuetext="0%"
+                        aria-live="off"
+                        aria-atomic="true"
+                        aria-busy="false">0%</div></div>
+                <p id="bjlg-restore-status-text"
+                   role="status"
+                   aria-live="polite"
+                   aria-atomic="true"
+                   aria-busy="false">Préparation...</p>
             </div>
             <div id="bjlg-restore-debug-wrapper" style="display: none;">
                 <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>

--- a/backup-jlg/tests/BJLG_AdminAccessibilityTest.php
+++ b/backup-jlg/tests/BJLG_AdminAccessibilityTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+use BJLG\BJLG_Admin;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-admin.php';
+
+final class BJLG_AdminAccessibilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    /**
+     * @param string $methodName
+     */
+    private function renderSection(string $methodName): \DOMXPath
+    {
+        $admin = new BJLG_Admin();
+        $reflection = new ReflectionClass(BJLG_Admin::class);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        ob_start();
+        $method->invoke($admin);
+        $html = (string) ob_get_clean();
+
+        $document = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $document->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>');
+        libxml_clear_errors();
+
+        return new \DOMXPath($document);
+    }
+
+    private function assertProgressAccessibility(\DOMXPath $xpath, string $progressId, string $statusId): void
+    {
+        $progress = $xpath->query('//*[@id="' . $progressId . '"]')->item(0);
+        $this->assertInstanceOf(\DOMElement::class, $progress, 'Progress element not found.');
+        /** @var \DOMElement $progressElement */
+        $progressElement = $progress;
+
+        $this->assertSame('progressbar', $progressElement->getAttribute('role'));
+        $this->assertSame('0', $progressElement->getAttribute('aria-valuemin'));
+        $this->assertSame('100', $progressElement->getAttribute('aria-valuemax'));
+        $this->assertSame('0', $progressElement->getAttribute('aria-valuenow'));
+        $this->assertSame('0%', $progressElement->getAttribute('aria-valuetext'));
+        $this->assertSame('off', $progressElement->getAttribute('aria-live'));
+        $this->assertSame('true', $progressElement->getAttribute('aria-atomic'));
+        $this->assertSame('false', $progressElement->getAttribute('aria-busy'));
+        $this->assertSame('0%', trim($progressElement->textContent));
+
+        $status = $xpath->query('//*[@id="' . $statusId . '"]')->item(0);
+        $this->assertInstanceOf(\DOMElement::class, $status, 'Status element not found.');
+        /** @var \DOMElement $statusElement */
+        $statusElement = $status;
+
+        $this->assertSame('status', $statusElement->getAttribute('role'));
+        $this->assertSame('polite', $statusElement->getAttribute('aria-live'));
+        $this->assertSame('true', $statusElement->getAttribute('aria-atomic'));
+        $this->assertSame('false', $statusElement->getAttribute('aria-busy'));
+    }
+
+    public function test_backup_section_has_accessible_progress_elements(): void
+    {
+        $xpath = $this->renderSection('render_backup_creation_section');
+        $this->assertProgressAccessibility($xpath, 'bjlg-backup-progress-bar', 'bjlg-backup-status-text');
+    }
+
+    public function test_restore_section_has_accessible_progress_elements(): void
+    {
+        $xpath = $this->renderSection('render_restore_section');
+        $this->assertProgressAccessibility($xpath, 'bjlg-restore-progress-bar', 'bjlg-restore-status-text');
+    }
+}


### PR DESCRIPTION
## Summary
- add ARIA attributes to the backup and restore progress indicators and status text in the admin UI
- synchronize progress bar aria attributes and status updates in the admin JavaScript controller
- add a PHPUnit DOMDocument test covering the rendered accessibility markup for both sections

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd41fff714832e8aa4d5e7f9f49f98