### PR TITLE
Add admin API key management interface

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -1353,4 +1353,407 @@ jQuery(document).ready(function($) {
             $button.prop('disabled', false).removeAttr('aria-busy');
         });
     });
+
+    // --- GESTION DES CLÉS API ---
+    const $apiSection = $('#bjlg-api-keys-section');
+
+    if ($apiSection.length && typeof bjlg_ajax !== 'undefined') {
+        const nonceKey = typeof bjlg_ajax.api_keys_nonce !== 'undefined'
+            ? 'api_keys_nonce'
+            : 'nonce';
+        const $feedback = $apiSection.find('#bjlg-api-keys-feedback');
+        const $table = $apiSection.find('#bjlg-api-keys-table');
+        const $tbody = $table.find('tbody');
+        const $emptyState = $apiSection.find('.bjlg-api-keys-empty');
+        const $form = $apiSection.find('#bjlg-create-api-key');
+
+        function getNonce() {
+            if (typeof bjlg_ajax[nonceKey] === 'string' && bjlg_ajax[nonceKey].length) {
+                return bjlg_ajax[nonceKey];
+            }
+
+            return bjlg_ajax.nonce;
+        }
+
+        function setNonce(newNonce) {
+            if (typeof newNonce === 'string' && newNonce.length) {
+                bjlg_ajax[nonceKey] = newNonce;
+            }
+        }
+
+        function clearFeedback() {
+            if (!$feedback.length) {
+                return;
+            }
+
+            $feedback
+                .removeClass('notice-success notice-error notice-info')
+                .hide()
+                .empty()
+                .removeAttr('role');
+        }
+
+        function renderFeedback(type, message, details) {
+            if (!$feedback.length) {
+                return;
+            }
+
+            clearFeedback();
+
+            const classes = ['notice'];
+
+            if (type === 'success') {
+                classes.push('notice-success');
+            } else if (type === 'error') {
+                classes.push('notice-error');
+            } else {
+                classes.push('notice-info');
+            }
+
+            $feedback.attr('class', classes.join(' '));
+
+            if (typeof message === 'string' && message.trim() !== '') {
+                $('<p/>').text(message).appendTo($feedback);
+            }
+
+            if (Array.isArray(details) && details.length) {
+                const $list = $('<ul/>');
+                details.forEach(function(item) {
+                    if (typeof item === 'string' && item.trim() !== '') {
+                        $('<li/>').text(item).appendTo($list);
+                    }
+                });
+
+                if ($list.children().length) {
+                    $feedback.append($list);
+                }
+            }
+
+            $feedback.attr('role', 'alert').show();
+        }
+
+        function toggleEmptyState() {
+            const hasRows = $tbody.children('tr').length > 0;
+
+            if (hasRows) {
+                $table.show().attr('aria-hidden', 'false');
+                $emptyState.hide().attr('aria-hidden', 'true');
+            } else {
+                $table.hide().attr('aria-hidden', 'true');
+                $emptyState.show().attr('aria-hidden', 'false');
+            }
+        }
+
+        function buildKeyRow(key) {
+            const id = key && key.id ? key.id : '';
+            const label = key && typeof key.label === 'string' && key.label.trim() !== ''
+                ? key.label
+                : 'Sans nom';
+            const secret = key && key.secret ? key.secret : '';
+            const createdAt = key && typeof key.created_at !== 'undefined' ? key.created_at : '';
+            const createdHuman = key && key.created_at_human ? key.created_at_human : '';
+            const createdIso = key && key.created_at_iso ? key.created_at_iso : '';
+            const rotatedAt = key && typeof key.last_rotated_at !== 'undefined'
+                ? key.last_rotated_at
+                : createdAt;
+            const rotatedHuman = key && key.last_rotated_at_human ? key.last_rotated_at_human : createdHuman;
+            const rotatedIso = key && key.last_rotated_at_iso ? key.last_rotated_at_iso : createdIso;
+
+            const $row = $('<tr/>', {
+                'data-key-id': id,
+                'data-created-at': createdAt,
+                'data-last-rotated-at': rotatedAt
+            });
+
+            $('<td/>').append(
+                $('<strong/>', {
+                    'class': 'bjlg-api-key-label',
+                    text: label
+                })
+            ).appendTo($row);
+
+            $('<td/>').append(
+                $('<code/>', {
+                    'class': 'bjlg-api-key-value',
+                    'aria-label': 'Clé API',
+                    text: secret
+                })
+            ).appendTo($row);
+
+            $('<td/>').append(
+                $('<time/>', {
+                    'class': 'bjlg-api-key-created',
+                    datetime: createdIso,
+                    text: createdHuman
+                })
+            ).appendTo($row);
+
+            $('<td/>').append(
+                $('<time/>', {
+                    'class': 'bjlg-api-key-rotated',
+                    datetime: rotatedIso,
+                    text: rotatedHuman
+                })
+            ).appendTo($row);
+
+            const $actionsCell = $('<td/>').appendTo($row);
+            const $actionsWrapper = $('<div/>', {
+                'class': 'bjlg-api-key-actions'
+            }).appendTo($actionsCell);
+
+            const $rotateButton = $('<button/>', {
+                type: 'button',
+                'class': 'button bjlg-rotate-api-key',
+                'data-key-id': id
+            });
+
+            $('<span/>', {
+                'class': 'dashicons dashicons-update',
+                'aria-hidden': 'true'
+            }).appendTo($rotateButton);
+            $rotateButton.append(' Régénérer');
+            $actionsWrapper.append($rotateButton);
+
+            const $revokeButton = $('<button/>', {
+                type: 'button',
+                'class': 'button button-link-delete bjlg-revoke-api-key',
+                'data-key-id': id
+            });
+
+            $('<span/>', {
+                'class': 'dashicons dashicons-no',
+                'aria-hidden': 'true'
+            }).appendTo($revokeButton);
+            $revokeButton.append(' Révoquer');
+            $actionsWrapper.append($revokeButton);
+
+            return $row;
+        }
+
+        function upsertKeyRow(key) {
+            if (!key || !key.id) {
+                return;
+            }
+
+            const $row = buildKeyRow(key);
+            const $existing = $tbody.find('tr[data-key-id="' + key.id + '"]');
+
+            if ($existing.length) {
+                $existing.replaceWith($row);
+            } else {
+                $tbody.prepend($row);
+            }
+
+            toggleEmptyState();
+        }
+
+        function removeKeyRow(keyId) {
+            if (typeof keyId !== 'string' || keyId === '') {
+                return;
+            }
+
+            $tbody.find('tr[data-key-id="' + keyId + '"]').remove();
+            toggleEmptyState();
+        }
+
+        function extractErrorMessages(payload) {
+            const messages = [];
+
+            if (!payload) {
+                return messages;
+            }
+
+            if (typeof payload === 'string') {
+                messages.push(payload);
+                return messages;
+            }
+
+            if (payload.message && typeof payload.message === 'string') {
+                messages.push(payload.message);
+            }
+
+            if (Array.isArray(payload.errors)) {
+                payload.errors.forEach(function(item) {
+                    if (typeof item === 'string' && item.trim() !== '') {
+                        messages.push(item.trim());
+                    }
+                });
+            }
+
+            return messages;
+        }
+
+        function handleAjaxError(jqXHR) {
+            let message = 'Erreur de communication avec le serveur.';
+            let details = [];
+
+            if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data) {
+                const payload = jqXHR.responseJSON.data;
+                details = extractErrorMessages(payload);
+
+                if (payload.message && typeof payload.message === 'string') {
+                    message = payload.message;
+                } else if (details.length) {
+                    message = details.shift();
+                }
+            }
+
+            renderFeedback('error', message, details);
+        }
+
+        toggleEmptyState();
+
+        $form.on('submit', function(event) {
+            event.preventDefault();
+
+            clearFeedback();
+
+            const $submitButton = $form.find('button[type="submit"]').first();
+            $submitButton.prop('disabled', true).attr('aria-busy', 'true');
+
+            const payload = {
+                action: 'bjlg_create_api_key',
+                nonce: getNonce(),
+                label: ($form.find('input[name="label"]').val() || '').toString()
+            };
+
+            $.ajax({
+                url: bjlg_ajax.ajax_url,
+                method: 'POST',
+                dataType: 'json',
+                data: payload
+            })
+            .done(function(response) {
+                if (response && response.success && response.data) {
+                    if (response.data.key) {
+                        upsertKeyRow(response.data.key);
+                    }
+
+                    if ($form.length && $form[0]) {
+                        $form[0].reset();
+                    }
+
+                    if (response.data.nonce) {
+                        setNonce(response.data.nonce);
+                    }
+
+                    renderFeedback('success', response.data.message || 'Clé API créée.');
+                } else if (response && response.data) {
+                    const messages = extractErrorMessages(response.data);
+                    const message = response.data.message || (messages.length ? messages[0] : 'Échec de la création de la clé API.');
+                    renderFeedback('error', message, messages);
+                } else {
+                    renderFeedback('error', 'Échec de la création de la clé API.');
+                }
+            })
+            .fail(handleAjaxError)
+            .always(function() {
+                $submitButton.prop('disabled', false).removeAttr('aria-busy');
+            });
+        });
+
+        $tbody.on('click', '.bjlg-revoke-api-key', function(event) {
+            event.preventDefault();
+
+            clearFeedback();
+
+            const $button = $(this);
+            const keyId = ($button.data('key-id') || '').toString();
+
+            if (!keyId) {
+                renderFeedback('error', 'Identifiant de clé introuvable.');
+                return;
+            }
+
+            const confirmation = window.confirm('Êtes-vous sûr de vouloir révoquer cette clé ?');
+
+            if (!confirmation) {
+                return;
+            }
+
+            $button.prop('disabled', true).attr('aria-busy', 'true');
+
+            $.ajax({
+                url: bjlg_ajax.ajax_url,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'bjlg_revoke_api_key',
+                    nonce: getNonce(),
+                    key_id: keyId
+                }
+            })
+            .done(function(response) {
+                if (response && response.success && response.data) {
+                    removeKeyRow(keyId);
+
+                    if (response.data.nonce) {
+                        setNonce(response.data.nonce);
+                    }
+
+                    renderFeedback('success', response.data.message || 'Clé API révoquée.');
+                } else if (response && response.data) {
+                    const messages = extractErrorMessages(response.data);
+                    const message = response.data.message || (messages.length ? messages[0] : 'Échec de la révocation.');
+                    renderFeedback('error', message, messages);
+                } else {
+                    renderFeedback('error', 'Échec de la révocation.');
+                }
+            })
+            .fail(handleAjaxError)
+            .always(function() {
+                $button.prop('disabled', false).removeAttr('aria-busy');
+            });
+        });
+
+        $tbody.on('click', '.bjlg-rotate-api-key', function(event) {
+            event.preventDefault();
+
+            clearFeedback();
+
+            const $button = $(this);
+            const keyId = ($button.data('key-id') || '').toString();
+
+            if (!keyId) {
+                renderFeedback('error', 'Identifiant de clé introuvable.');
+                return;
+            }
+
+            $button.prop('disabled', true).attr('aria-busy', 'true');
+
+            $.ajax({
+                url: bjlg_ajax.ajax_url,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'bjlg_rotate_api_key',
+                    nonce: getNonce(),
+                    key_id: keyId
+                }
+            })
+            .done(function(response) {
+                if (response && response.success && response.data) {
+                    if (response.data.key) {
+                        upsertKeyRow(response.data.key);
+                    }
+
+                    if (response.data.nonce) {
+                        setNonce(response.data.nonce);
+                    }
+
+                    renderFeedback('success', response.data.message || 'Clé API régénérée.');
+                } else if (response && response.data) {
+                    const messages = extractErrorMessages(response.data);
+                    const message = response.data.message || (messages.length ? messages[0] : 'Échec de la rotation de la clé.');
+                    renderFeedback('error', message, messages);
+                } else {
+                    renderFeedback('error', 'Échec de la rotation de la clé.');
+                }
+            })
+            .fail(handleAjaxError)
+            .always(function() {
+                $button.prop('disabled', false).removeAttr('aria-busy');
+            });
+        });
+    }
 });

--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -88,7 +88,7 @@ final class BJLG_Plugin {
             'class-bjlg-cleanup.php', 'class-bjlg-encryption.php', 'class-bjlg-health-check.php',
             'class-bjlg-diagnostics.php', 'class-bjlg-webhooks.php', 'class-bjlg-incremental.php',
             'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php',
-            'class-bjlg-admin.php', 'class-bjlg-actions.php',
+            'class-bjlg-api-keys.php', 'class-bjlg-admin.php', 'class-bjlg-actions.php',
             'destinations/interface-bjlg-destination.php', 'destinations/class-bjlg-google-drive.php', 'destinations/class-bjlg-aws-s3.php',
         ];
         foreach ($files_to_load as $file) {
@@ -117,17 +117,19 @@ final class BJLG_Plugin {
         new BJLG\BJLG_Incremental();
         new BJLG\BJLG_REST_API();
         new BJLG\BJLG_Settings();
+        new BJLG\BJLG_API_Keys();
     }
-    
+
     public function enqueue_admin_assets($hook) {
         if (strpos($hook, 'backup-jlg') === false) return;
-        
+
         wp_enqueue_style('bjlg-admin', BJLG_PLUGIN_URL . 'assets/css/admin.css', [], BJLG_VERSION);
         wp_enqueue_style('bjlg-admin-advanced', BJLG_PLUGIN_URL . 'assets/css/admin-advanced.css', [], BJLG_VERSION);
         wp_enqueue_script('bjlg-admin', BJLG_PLUGIN_URL . 'assets/js/admin.js', ['jquery'], BJLG_VERSION, true);
         wp_localize_script('bjlg-admin', 'bjlg_ajax', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce'    => wp_create_nonce('bjlg_nonce'),
+            'api_keys_nonce' => wp_create_nonce('bjlg_api_keys'),
         ]);
     }
 

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -34,13 +34,20 @@ class BJLG_Admin {
      * Retourne les onglets par défaut
      */
     public function get_default_tabs($tabs) {
-        return [
+        $defaults = [
             'backup_restore' => 'Sauvegarde & Restauration',
             'history' => 'Historique',
             'health_check' => 'Bilan de Santé',
             'settings' => 'Réglages',
-            'logs' => 'Logs & Outils'
+            'logs' => 'Logs & Outils',
+            'api' => 'API & Intégrations',
         ];
+
+        if (is_array($tabs) && !empty($tabs)) {
+            return array_merge($defaults, $tabs);
+        }
+
+        return $defaults;
     }
 
     /**
@@ -100,6 +107,9 @@ class BJLG_Admin {
                         break;
                     case 'logs':
                         $this->render_logs_section();
+                        break;
+                    case 'api':
+                        $this->render_api_section();
                         break;
                     case 'backup_restore':
                     default:
@@ -552,6 +562,84 @@ class BJLG_Admin {
             <div id="bjlg-support-package-status" style="display: none;">
                 <p class="description">Génération du pack de support en cours...</p>
             </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Section : API & Intégrations
+     */
+    private function render_api_section() {
+        $keys = BJLG_API_Keys::get_keys();
+        $has_keys = !empty($keys);
+        ?>
+        <div class="bjlg-section" id="bjlg-api-keys-section">
+            <h2>API &amp; Intégrations</h2>
+            <p class="description">
+                Gérez les clés d'accès utilisées par vos intégrations externes. Créez une nouvelle clé pour chaque service,
+                puis régénérez-la ou révoquez-la si nécessaire.
+            </p>
+
+            <div id="bjlg-api-keys-feedback" class="notice" style="display:none;" aria-live="polite"></div>
+
+            <form id="bjlg-create-api-key" class="bjlg-inline-form">
+                <h3>Créer une nouvelle clé</h3>
+                <p class="description">Donnez un nom à la clé pour identifier l'intégration correspondante.</p>
+                <label for="bjlg-api-key-label" class="screen-reader-text">Nom de la clé API</label>
+                <input type="text" id="bjlg-api-key-label" name="label" class="regular-text"
+                       placeholder="Ex. : CRM Marketing" autocomplete="off" />
+                <button type="submit" class="button button-primary">
+                    <span class="dashicons dashicons-plus"></span> Générer une clé API
+                </button>
+            </form>
+
+            <p class="description bjlg-api-keys-empty"<?php echo $has_keys ? ' style="display:none;"' : ''; ?>>
+                Aucune clé API n'a été générée pour le moment.
+            </p>
+
+            <table id="bjlg-api-keys-table" class="wp-list-table widefat striped bjlg-responsive-table"<?php echo $has_keys ? '' : ' style="display:none;"'; ?>>
+                <thead>
+                    <tr>
+                        <th scope="col">Nom</th>
+                        <th scope="col">Clé</th>
+                        <th scope="col">Créée le</th>
+                        <th scope="col">Dernière rotation</th>
+                        <th scope="col">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($keys as $key): ?>
+                    <tr data-key-id="<?php echo esc_attr($key['id']); ?>" data-created-at="<?php echo esc_attr($key['created_at']); ?>" data-last-rotated-at="<?php echo esc_attr($key['last_rotated_at']); ?>">
+                        <td>
+                            <strong class="bjlg-api-key-label"><?php echo esc_html($key['label']); ?></strong>
+                        </td>
+                        <td>
+                            <code class="bjlg-api-key-value" aria-label="Clé API"><?php echo esc_html($key['secret']); ?></code>
+                        </td>
+                        <td>
+                            <time class="bjlg-api-key-created" datetime="<?php echo esc_attr($key['created_at_iso']); ?>">
+                                <?php echo esc_html($key['created_at_human']); ?>
+                            </time>
+                        </td>
+                        <td>
+                            <time class="bjlg-api-key-rotated" datetime="<?php echo esc_attr($key['last_rotated_at_iso']); ?>">
+                                <?php echo esc_html($key['last_rotated_at_human']); ?>
+                            </time>
+                        </td>
+                        <td>
+                            <div class="bjlg-api-key-actions">
+                                <button type="button" class="button bjlg-rotate-api-key" data-key-id="<?php echo esc_attr($key['id']); ?>">
+                                    <span class="dashicons dashicons-update"></span> Régénérer
+                                </button>
+                                <button type="button" class="button button-link-delete bjlg-revoke-api-key" data-key-id="<?php echo esc_attr($key['id']); ?>">
+                                    <span class="dashicons dashicons-no"></span> Révoquer
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
         <?php
     }

--- a/backup-jlg/includes/class-bjlg-api-keys.php
+++ b/backup-jlg/includes/class-bjlg-api-keys.php
@@ -1,0 +1,387 @@
+<?php
+namespace BJLG;
+
+use Exception;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Gestionnaire des clés API utilisées par les intégrations externes.
+ */
+class BJLG_API_Keys {
+
+    public const OPTION_NAME = 'bjlg_api_keys';
+    private const SECRET_LENGTH = 40;
+
+    public function __construct() {
+        add_action('wp_ajax_bjlg_create_api_key', [$this, 'handle_create_key']);
+        add_action('wp_ajax_bjlg_revoke_api_key', [$this, 'handle_revoke_key']);
+        add_action('wp_ajax_bjlg_rotate_api_key', [$this, 'handle_rotate_key']);
+    }
+
+    /**
+     * Retourne toutes les clés API formatées pour l'affichage.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_keys() {
+        $keys = self::get_indexed_keys();
+
+        uasort($keys, static function ($a, $b) {
+            $a_time = isset($a['created_at']) ? (int) $a['created_at'] : 0;
+            $b_time = isset($b['created_at']) ? (int) $b['created_at'] : 0;
+
+            if ($a_time === $b_time) {
+                return 0;
+            }
+
+            return ($a_time < $b_time) ? 1 : -1;
+        });
+
+        return array_map([self::class, 'format_key_for_output'], $keys);
+    }
+
+    /**
+     * Crée une nouvelle clé API.
+     */
+    public function handle_create_key() {
+        $this->validate_request();
+
+        $label = '';
+        if (isset($_POST['label'])) {
+            $label = sanitize_text_field(wp_unslash((string) $_POST['label']));
+        }
+
+        $label = self::truncate($label, 200);
+
+        $keys = self::get_indexed_keys();
+
+        $identifier = self::generate_identifier();
+        while (isset($keys[$identifier])) {
+            $identifier = self::generate_identifier();
+        }
+
+        $secret = self::generate_secret();
+        $timestamp = time();
+
+        $keys[$identifier] = [
+            'id' => $identifier,
+            'label' => $label,
+            'secret' => $secret,
+            'created_at' => $timestamp,
+            'last_rotated_at' => $timestamp,
+        ];
+
+        self::save_indexed_keys($keys);
+
+        wp_send_json_success([
+            'message' => __('Clé API créée avec succès.', 'backup-jlg'),
+            'key' => self::format_key_for_output($keys[$identifier]),
+            'nonce' => self::generate_nonce_value(),
+        ]);
+    }
+
+    /**
+     * Révoque (supprime) une clé API existante.
+     */
+    public function handle_revoke_key() {
+        $this->validate_request();
+
+        $key_id = self::sanitize_identifier(self::get_request_value('key_id'));
+
+        if ($key_id === '') {
+            wp_send_json_error([
+                'message' => __('Identifiant de clé invalide.', 'backup-jlg'),
+            ], 400);
+        }
+
+        $keys = self::get_indexed_keys();
+
+        if (!isset($keys[$key_id])) {
+            wp_send_json_error([
+                'message' => __('Clé API introuvable.', 'backup-jlg'),
+            ], 404);
+        }
+
+        unset($keys[$key_id]);
+        self::save_indexed_keys($keys);
+
+        wp_send_json_success([
+            'message' => __('Clé API révoquée.', 'backup-jlg'),
+            'key_id' => $key_id,
+            'nonce' => self::generate_nonce_value(),
+        ]);
+    }
+
+    /**
+     * Régénère le secret associé à une clé API existante.
+     */
+    public function handle_rotate_key() {
+        $this->validate_request();
+
+        $key_id = self::sanitize_identifier(self::get_request_value('key_id'));
+
+        if ($key_id === '') {
+            wp_send_json_error([
+                'message' => __('Identifiant de clé invalide.', 'backup-jlg'),
+            ], 400);
+        }
+
+        $keys = self::get_indexed_keys();
+
+        if (!isset($keys[$key_id])) {
+            wp_send_json_error([
+                'message' => __('Clé API introuvable.', 'backup-jlg'),
+            ], 404);
+        }
+
+        $keys[$key_id]['secret'] = self::generate_secret();
+        $keys[$key_id]['last_rotated_at'] = time();
+
+        self::save_indexed_keys($keys);
+
+        wp_send_json_success([
+            'message' => __('Clé API régénérée.', 'backup-jlg'),
+            'key' => self::format_key_for_output($keys[$key_id]),
+            'nonce' => self::generate_nonce_value(),
+        ]);
+    }
+
+    /**
+     * Valide la requête AJAX.
+     */
+    private function validate_request() {
+        if (!current_user_can(BJLG_CAPABILITY)) {
+            wp_send_json_error([
+                'message' => __('Permission refusée.', 'backup-jlg'),
+            ], 403);
+        }
+
+        check_ajax_referer('bjlg_api_keys', 'nonce');
+    }
+
+    /**
+     * Récupère toutes les clés stockées sous la forme d'un tableau associatif indexé par identifiant.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function get_indexed_keys() {
+        $stored = get_option(self::OPTION_NAME, []);
+
+        if (!is_array($stored)) {
+            return [];
+        }
+
+        $indexed = [];
+
+        foreach ($stored as $key => $record) {
+            if (!is_array($record)) {
+                continue;
+            }
+
+            if (!isset($record['id']) && is_string($key)) {
+                $record['id'] = $key;
+            }
+
+            $normalized = self::normalize_record($record);
+
+            if ($normalized === null) {
+                continue;
+            }
+
+            $indexed[$normalized['id']] = $normalized;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * Enregistre la liste des clés API.
+     *
+     * @param array<string, array<string, mixed>> $keys
+     */
+    private static function save_indexed_keys(array $keys) {
+        $prepared = [];
+
+        foreach ($keys as $key => $record) {
+            if (!is_array($record)) {
+                continue;
+            }
+
+            $normalized = self::normalize_record($record);
+
+            if ($normalized === null) {
+                continue;
+            }
+
+            $prepared[$normalized['id']] = $normalized;
+        }
+
+        update_option(self::OPTION_NAME, $prepared);
+    }
+
+    /**
+     * Prépare une clé pour l'affichage ou la réponse JSON.
+     *
+     * @param array<string, mixed> $record
+     *
+     * @return array<string, mixed>
+     */
+    private static function format_key_for_output(array $record) {
+        $created_at = isset($record['created_at']) ? (int) $record['created_at'] : time();
+        $rotated_at = isset($record['last_rotated_at']) ? (int) $record['last_rotated_at'] : $created_at;
+
+        if ($rotated_at <= 0) {
+            $rotated_at = $created_at;
+        }
+
+        if ($created_at <= 0) {
+            $created_at = time();
+        }
+
+        $label = isset($record['label']) ? (string) $record['label'] : '';
+        $label = self::truncate($label, 200);
+
+        if ($label === '') {
+            $label = __('Sans nom', 'backup-jlg');
+        }
+
+        return [
+            'id' => (string) $record['id'],
+            'label' => $label,
+            'secret' => (string) $record['secret'],
+            'created_at' => $created_at,
+            'last_rotated_at' => $rotated_at,
+            'created_at_iso' => gmdate('c', $created_at),
+            'last_rotated_at_iso' => gmdate('c', $rotated_at),
+            'created_at_human' => gmdate('Y-m-d H:i:s', $created_at),
+            'last_rotated_at_human' => gmdate('Y-m-d H:i:s', $rotated_at),
+        ];
+    }
+
+    /**
+     * Normalise un enregistrement brut issu de la base de données.
+     *
+     * @param array<string, mixed> $record
+     *
+     * @return array<string, mixed>|null
+     */
+    private static function normalize_record(array $record) {
+        if (!isset($record['id']) && isset($record['key'])) {
+            $record['id'] = $record['key'];
+        }
+
+        $identifier = isset($record['id']) ? self::sanitize_identifier($record['id']) : '';
+        $secret = isset($record['secret']) ? self::sanitize_secret($record['secret']) : '';
+
+        if ($identifier === '' || $secret === '') {
+            return null;
+        }
+
+        $label = '';
+        if (isset($record['label'])) {
+            $label = sanitize_text_field((string) $record['label']);
+            $label = self::truncate($label, 200);
+        }
+
+        $created_at = isset($record['created_at']) ? (int) $record['created_at'] : time();
+        $rotated_at = isset($record['last_rotated_at']) ? (int) $record['last_rotated_at'] : $created_at;
+
+        if ($created_at <= 0) {
+            $created_at = time();
+        }
+
+        if ($rotated_at <= 0) {
+            $rotated_at = $created_at;
+        }
+
+        return [
+            'id' => $identifier,
+            'label' => $label,
+            'secret' => $secret,
+            'created_at' => $created_at,
+            'last_rotated_at' => $rotated_at,
+        ];
+    }
+
+    /**
+     * Génère un identifiant unique pour une clé API.
+     */
+    private static function generate_identifier() {
+        try {
+            return bin2hex(random_bytes(16));
+        } catch (Exception $exception) {
+            return strtolower(wp_generate_password(32, false, false));
+        }
+    }
+
+    /**
+     * Génère un secret pour une clé API.
+     */
+    private static function generate_secret() {
+        return wp_generate_password(self::SECRET_LENGTH, false, false);
+    }
+
+    /**
+     * Sanitize an identifier string.
+     */
+    private static function sanitize_identifier($value) {
+        $value = preg_replace('/[^A-Za-z0-9_-]/', '', (string) $value);
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * Sanitize a secret string.
+     */
+    private static function sanitize_secret($value) {
+        $value = preg_replace('/[^A-Za-z0-9]/', '', (string) $value);
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * Retourne une valeur depuis la requête courante.
+     */
+    private static function get_request_value($key) {
+        if (isset($_POST[$key])) {
+            return wp_unslash($_POST[$key]);
+        }
+
+        if (isset($_REQUEST[$key])) {
+            return wp_unslash($_REQUEST[$key]);
+        }
+
+        return '';
+    }
+
+    /**
+     * Limite la longueur d'une chaîne.
+     */
+    private static function truncate($value, $length) {
+        $value = (string) $value;
+
+        if ($length <= 0) {
+            return '';
+        }
+
+        if (strlen($value) <= $length) {
+            return $value;
+        }
+
+        return substr($value, 0, $length);
+    }
+
+    /**
+     * Génère un nonce pour sécuriser les actions AJAX.
+     */
+    private static function generate_nonce_value() {
+        if (function_exists('wp_create_nonce')) {
+            return wp_create_nonce('bjlg_api_keys');
+        }
+
+        return sha1('bjlg-api-keys-' . microtime(true));
+    }
+}

--- a/backup-jlg/tests/BJLG_API_KeysTest.php
+++ b/backup-jlg/tests/BJLG_API_KeysTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-api-keys.php';
+
+final class BJLG_API_KeysTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = true;
+        $GLOBALS['bjlg_test_options'] = [];
+        $_POST = [];
+        $_REQUEST = [];
+    }
+
+    public function test_handle_create_key_persists_option(): void
+    {
+        $service = new BJLG\BJLG_API_Keys();
+
+        $_POST['label'] = 'Intégration Test';
+        $_POST['nonce'] = 'test-nonce';
+
+        try {
+            $service->handle_create_key();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertIsArray($response->data);
+            $this->assertSame('Clé API créée avec succès.', $response->data['message']);
+            $this->assertArrayHasKey('key', $response->data);
+            $this->assertArrayHasKey('nonce', $response->data);
+            $this->assertNotEmpty($response->data['nonce']);
+
+            $createdKey = $response->data['key'];
+            $this->assertArrayHasKey('id', $createdKey);
+            $this->assertArrayHasKey('secret', $createdKey);
+            $this->assertSame('Intégration Test', $createdKey['label']);
+        }
+
+        $stored = $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME] ?? [];
+        $this->assertCount(1, $stored);
+
+        $record = reset($stored);
+        $this->assertSame('Intégration Test', $record['label']);
+        $this->assertArrayHasKey('secret', $record);
+        $this->assertNotEmpty($record['secret']);
+    }
+
+    public function test_handle_create_key_requires_capability(): void
+    {
+        $GLOBALS['bjlg_test_current_user_can'] = false;
+
+        $service = new BJLG\BJLG_API_Keys();
+
+        $_POST['nonce'] = 'test-nonce';
+
+        try {
+            $service->handle_create_key();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame(403, $response->status_code);
+            $this->assertSame(['message' => 'Permission refusée.'], $response->data);
+        }
+    }
+
+    public function test_handle_revoke_key_removes_record(): void
+    {
+        $service = new BJLG\BJLG_API_Keys();
+
+        $keyId = 'cle123';
+        $existing = [
+            'id' => $keyId,
+            'label' => 'Clé existante',
+            'secret' => 'SECRET123',
+            'created_at' => time() - 100,
+            'last_rotated_at' => time() - 50,
+        ];
+
+        $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME] = [
+            $keyId => $existing,
+        ];
+
+        $_POST['nonce'] = 'test-nonce';
+        $_POST['key_id'] = $keyId;
+
+        try {
+            $service->handle_revoke_key();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame('Clé API révoquée.', $response->data['message']);
+            $this->assertSame($keyId, $response->data['key_id']);
+            $this->assertArrayHasKey('nonce', $response->data);
+        }
+
+        $stored = $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME] ?? [];
+        $this->assertArrayNotHasKey($keyId, $stored);
+    }
+
+    public function test_handle_rotate_key_updates_secret_and_timestamp(): void
+    {
+        $service = new BJLG\BJLG_API_Keys();
+
+        $keyId = 'cle456';
+        $existing = [
+            'id' => $keyId,
+            'label' => 'Rotation',
+            'secret' => 'ANCIENSECRET',
+            'created_at' => time() - 200,
+            'last_rotated_at' => time() - 150,
+        ];
+
+        $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME] = [
+            $keyId => $existing,
+        ];
+
+        $_POST['nonce'] = 'test-nonce';
+        $_POST['key_id'] = $keyId;
+
+        try {
+            $service->handle_rotate_key();
+            $this->fail('Expected BJLG_Test_JSON_Response to be thrown.');
+        } catch (BJLG_Test_JSON_Response $response) {
+            $this->assertSame('Clé API régénérée.', $response->data['message']);
+            $this->assertArrayHasKey('key', $response->data);
+
+            $rotated = $response->data['key'];
+            $this->assertSame($keyId, $rotated['id']);
+            $this->assertNotSame('ANCIENSECRET', $rotated['secret']);
+            $this->assertGreaterThan($existing['last_rotated_at'], $rotated['last_rotated_at']);
+        }
+
+        $stored = $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME][$keyId] ?? null;
+        $this->assertNotNull($stored);
+        $this->assertNotSame('ANCIENSECRET', $stored['secret']);
+        $this->assertGreaterThan($existing['last_rotated_at'], $stored['last_rotated_at']);
+    }
+}

--- a/backup-jlg/tests/BJLG_AdminApiTabTest.php
+++ b/backup-jlg/tests/BJLG_AdminApiTabTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-api-keys.php';
+require_once __DIR__ . '/../includes/class-bjlg-admin.php';
+
+if (!defined('BJLG_VERSION')) {
+    define('BJLG_VERSION', 'test-version');
+}
+
+if (!function_exists('get_admin_page_title')) {
+    function get_admin_page_title() {
+        return 'Backup - JLG';
+    }
+}
+
+final class BJLG_AdminApiTabTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    public function test_render_api_section_outputs_expected_markup(): void
+    {
+        $timestamp = time();
+
+        $GLOBALS['bjlg_test_options'][BJLG\BJLG_API_Keys::OPTION_NAME] = [
+            'demo' => [
+                'id' => 'demo',
+                'label' => 'Mon intégration',
+                'secret' => 'SECRETXYZ',
+                'created_at' => $timestamp,
+                'last_rotated_at' => $timestamp,
+            ],
+        ];
+
+        $admin = new BJLG\BJLG_Admin();
+
+        $reflection = new ReflectionClass(BJLG\BJLG_Admin::class);
+        $method = $reflection->getMethod('render_api_section');
+        $method->setAccessible(true);
+
+        ob_start();
+        $method->invoke($admin);
+        $output = (string) ob_get_clean();
+
+        $this->assertStringContainsString('API &amp; Intégrations', $output);
+        $this->assertStringContainsString('bjlg-api-keys-table', $output);
+        $this->assertStringContainsString('Mon intégration', $output);
+        $this->assertStringContainsString('SECRETXYZ', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add an API & Integrations admin tab with UI for API key management
- implement the BJLG_API_Keys service to provide secure AJAX handlers and option storage
- enhance the admin JavaScript to create, rotate, and revoke keys without reload and cover the logic with PHPUnit tests

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd4209f17c832ebe7cfbd9db63c130