### PR TITLE
Localize admin interface and regenerate translations

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -35,11 +35,11 @@ class BJLG_Admin {
      */
     public function get_default_tabs($tabs) {
         return [
-            'backup_restore' => 'Sauvegarde & Restauration',
-            'history' => 'Historique',
-            'health_check' => 'Bilan de Santé',
-            'settings' => 'Réglages',
-            'logs' => 'Logs & Outils'
+            'backup_restore' => __('Sauvegarde & Restauration', 'backup-jlg'),
+            'history' => __('Historique', 'backup-jlg'),
+            'health_check' => __('Bilan de Santé', 'backup-jlg'),
+            'settings' => __('Réglages', 'backup-jlg'),
+            'logs' => __('Logs & Outils', 'backup-jlg')
         ];
     }
 
@@ -48,7 +48,7 @@ class BJLG_Admin {
      */
     public function create_admin_page() {
         $wl_settings = get_option('bjlg_whitelabel_settings', []);
-        $plugin_name = !empty($wl_settings['plugin_name']) ? $wl_settings['plugin_name'] : 'Backup - JLG';
+        $plugin_name = !empty($wl_settings['plugin_name']) ? $wl_settings['plugin_name'] : __('Backup - JLG', 'backup-jlg');
         
         add_menu_page(
             $plugin_name,
@@ -120,40 +120,40 @@ class BJLG_Admin {
     private function render_backup_creation_section() {
         ?>
         <div class="bjlg-section">
-            <h2>Créer une sauvegarde</h2>
+            <h2><?php echo esc_html__('Créer une sauvegarde', 'backup-jlg'); ?></h2>
             <form id="bjlg-backup-creation-form">
-                <p>Choisissez les composants à inclure dans votre sauvegarde.</p>
+                <p><?php echo esc_html__('Choisissez les composants à inclure dans votre sauvegarde.', 'backup-jlg'); ?></p>
                 <table class="form-table">
                     <tbody>
                         <tr>
-                            <th scope="row">Contenu de la sauvegarde</th>
+                            <th scope="row"><?php echo esc_html__('Contenu de la sauvegarde', 'backup-jlg'); ?></th>
                             <td>
                                 <fieldset>
-                                    <label><input type="checkbox" name="backup_components[]" value="db" checked> <strong>Base de données</strong> <span class="description">Toutes les tables WordPress</span></label><br>
-                                    <label><input type="checkbox" name="backup_components[]" value="plugins" checked> Extensions (<code>/wp-content/plugins</code>)</label><br>
-                                    <label><input type="checkbox" name="backup_components[]" value="themes" checked> Thèmes (<code>/wp-content/themes</code>)</label><br>
-                                    <label><input type="checkbox" name="backup_components[]" value="uploads" checked> Médias (<code>/wp-content/uploads</code>)</label>
+                                    <label><input type="checkbox" name="backup_components[]" value="db" checked> <strong><?php echo esc_html__('Base de données', 'backup-jlg'); ?></strong> <span class="description"><?php echo esc_html__('Toutes les tables WordPress', 'backup-jlg'); ?></span></label><br>
+                                    <label><input type="checkbox" name="backup_components[]" value="plugins" checked> <?php echo esc_html__('Extensions', 'backup-jlg'); ?> (<code>/wp-content/plugins</code>)</label><br>
+                                    <label><input type="checkbox" name="backup_components[]" value="themes" checked> <?php echo esc_html__('Thèmes', 'backup-jlg'); ?> (<code>/wp-content/themes</code>)</label><br>
+                                    <label><input type="checkbox" name="backup_components[]" value="uploads" checked> <?php echo esc_html__('Médias', 'backup-jlg'); ?> (<code>/wp-content/uploads</code>)</label>
                                 </fieldset>
                             </td>
                         </tr>
                         <tr>
-                            <th scope="row">Options</th>
+                            <th scope="row"><?php echo esc_html__('Options', 'backup-jlg'); ?></th>
                             <td>
                                 <fieldset>
                                     <label>
                                         <input type="checkbox" name="encrypt_backup" value="1">
-                                        Chiffrer la sauvegarde (AES-256)
+                                        <?php echo esc_html__('Chiffrer la sauvegarde (AES-256)', 'backup-jlg'); ?>
                                     </label>
                                     <p class="description">
-                                        Sécurise votre fichier de sauvegarde avec un chiffrement robuste. Indispensable si vous stockez vos sauvegardes sur un service cloud tiers.
+                                        <?php echo esc_html__('Sécurise votre fichier de sauvegarde avec un chiffrement robuste. Indispensable si vous stockez vos sauvegardes sur un service cloud tiers.', 'backup-jlg'); ?>
                                     </p>
                                     <br>
                                     <label>
                                         <input type="checkbox" name="incremental_backup" value="1">
-                                        Sauvegarde incrémentale
+                                        <?php echo esc_html__('Sauvegarde incrémentale', 'backup-jlg'); ?>
                                     </label>
                                     <p class="description">
-                                        Ne sauvegarde que les fichiers modifiés depuis la dernière sauvegarde complète. Plus rapide et utilise moins d'espace disque.
+                                        <?php echo esc_html__('Ne sauvegarde que les fichiers modifiés depuis la dernière sauvegarde complète. Plus rapide et utilise moins d\'espace disque.', 'backup-jlg'); ?>
                                     </p>
                                 </fieldset>
                             </td>
@@ -162,17 +162,17 @@ class BJLG_Admin {
                 </table>
                 <p class="submit">
                     <button id="bjlg-create-backup" type="submit" class="button button-primary button-hero">
-                        <span class="dashicons dashicons-backup"></span> Lancer la création de la sauvegarde
+                        <span class="dashicons dashicons-backup"></span> <?php echo esc_html__('Lancer la création de la sauvegarde', 'backup-jlg'); ?>
                     </button>
                 </p>
             </form>
             <div id="bjlg-backup-progress-area" style="display: none;">
-                <h3>Progression</h3>
+                <h3><?php echo esc_html__('Progression', 'backup-jlg'); ?></h3>
                 <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-backup-progress-bar">0%</div></div>
-                <p id="bjlg-backup-status-text">Initialisation...</p>
+                <p id="bjlg-backup-status-text"><?php echo esc_html__('Initialisation...', 'backup-jlg'); ?></p>
             </div>
             <div id="bjlg-backup-debug-wrapper" style="display: none;">
-                <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>
+                <h3><span class="dashicons dashicons-info"></span> <?php echo esc_html__('Détails techniques', 'backup-jlg'); ?></h3>
                 <pre id="bjlg-backup-ajax-debug" class="bjlg-log-textarea"></pre>
             </div>
         </div>
@@ -186,18 +186,18 @@ class BJLG_Admin {
         $backups = glob(BJLG_BACKUP_DIR . '*.zip*');
         ?>
         <div class="bjlg-section">
-            <h2>Sauvegardes Disponibles</h2>
+            <h2><?php echo esc_html__('Sauvegardes disponibles', 'backup-jlg'); ?></h2>
             <?php if (!empty($backups)):
                 usort($backups, function($a, $b) { return filemtime($b) - filemtime($a); });
                 ?>
                 <table class="wp-list-table widefat striped bjlg-responsive-table bjlg-backup-table">
                     <thead>
                         <tr>
-                            <th scope="col">Nom du fichier</th>
-                            <th scope="col">Type</th>
-                            <th scope="col">Taille</th>
-                            <th scope="col">Date</th>
-                            <th scope="col">Actions</th>
+                            <th scope="col"><?php echo esc_html__('Nom du fichier', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Type', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Taille', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Date', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Actions', 'backup-jlg'); ?></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -206,24 +206,37 @@ class BJLG_Admin {
                             $is_encrypted = (substr($filename, -4) === '.enc');
                             ?>
                             <tr class="bjlg-card-row">
-                                <td class="bjlg-card-cell" data-label="Nom du fichier">
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Nom du fichier', 'backup-jlg'); ?>">
                                     <strong><?php echo esc_html($filename); ?></strong>
-                                    <?php if ($is_encrypted): ?><span class="bjlg-badge encrypted" style="background: #a78bfa; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; margin-left: 5px;">Chiffré</span><?php endif; ?>
+                                    <?php if ($is_encrypted): ?><span class="bjlg-badge encrypted" style="background: #a78bfa; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; margin-left: 5px;"><?php echo esc_html__('Chiffré', 'backup-jlg'); ?></span><?php endif; ?>
                                 </td>
-                                <td class="bjlg-card-cell" data-label="Type">
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Type', 'backup-jlg'); ?>">
                                     <?php
-                                    if (strpos($filename, 'full') !== false) { echo '<span class="bjlg-badge full" style="background: #34d399; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">Complète</span>'; }
-                                    elseif (strpos($filename, 'incremental') !== false) { echo '<span class="bjlg-badge incremental" style="background: #60a5fa; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">Incrémentale</span>'; }
-                                    else { echo '<span class="bjlg-badge standard" style="background: #9ca3af; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">Standard</span>'; }
+                                    if (strpos($filename, 'full') !== false) {
+                                        printf(
+                                            '<span class="bjlg-badge full" style="background: #34d399; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">%s</span>',
+                                            esc_html__('Complète', 'backup-jlg')
+                                        );
+                                    } elseif (strpos($filename, 'incremental') !== false) {
+                                        printf(
+                                            '<span class="bjlg-badge incremental" style="background: #60a5fa; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">%s</span>',
+                                            esc_html__('Incrémentale', 'backup-jlg')
+                                        );
+                                    } else {
+                                        printf(
+                                            '<span class="bjlg-badge standard" style="background: #9ca3af; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em;">%s</span>',
+                                            esc_html__('Standard', 'backup-jlg')
+                                        );
+                                    }
                                     ?>
                                 </td>
-                                <td class="bjlg-card-cell" data-label="Taille"><?php echo size_format(filesize($backup_file), 2); ?></td>
-                                <td class="bjlg-card-cell" data-label="Date"><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), filemtime($backup_file)); ?></td>
-                                <td class="bjlg-card-cell bjlg-card-actions-cell" data-label="Actions">
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Taille', 'backup-jlg'); ?>"><?php echo size_format(filesize($backup_file), 2); ?></td>
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Date', 'backup-jlg'); ?>"><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), filemtime($backup_file)); ?></td>
+                                <td class="bjlg-card-cell bjlg-card-actions-cell" data-label="<?php echo esc_attr__('Actions', 'backup-jlg'); ?>">
                                     <div class="bjlg-card-actions">
-                                        <button class="button button-primary bjlg-restore-button" data-filename="<?php echo esc_attr($filename); ?>">Restaurer</button>
-                                        <button type="button" class="button bjlg-download-button" data-filename="<?php echo esc_attr($filename); ?>">Télécharger</button>
-                                        <button class="button button-link-delete bjlg-delete-button" data-filename="<?php echo esc_attr($filename); ?>">Supprimer</button>
+                                        <button class="button button-primary bjlg-restore-button" data-filename="<?php echo esc_attr($filename); ?>"><?php echo esc_html__('Restaurer', 'backup-jlg'); ?></button>
+                                        <button type="button" class="button bjlg-download-button" data-filename="<?php echo esc_attr($filename); ?>"><?php echo esc_html__('Télécharger', 'backup-jlg'); ?></button>
+                                        <button class="button button-link-delete bjlg-delete-button" data-filename="<?php echo esc_attr($filename); ?>"><?php echo esc_html__('Supprimer', 'backup-jlg'); ?></button>
                                     </div>
                                 </td>
                             </tr>
@@ -233,13 +246,24 @@ class BJLG_Admin {
                 <div class="tablenav bottom">
                     <div class="alignleft">
                         <p class="description">
-                            Total : <?php echo count($backups); ?> sauvegarde(s) | 
-                            Espace utilisé : <?php echo size_format(function_exists('bjlg_get_backup_size') ? bjlg_get_backup_size() : 0); ?>
+                            <?php
+                            printf(
+                                /* translators: %d: number of backups */
+                                esc_html__('Total : %d sauvegarde(s)', 'backup-jlg'),
+                                count($backups)
+                            );
+                            echo ' | ';
+                            printf(
+                                /* translators: %s: total backup size */
+                                esc_html__('Espace utilisé : %s', 'backup-jlg'),
+                                size_format(function_exists('bjlg_get_backup_size') ? bjlg_get_backup_size() : 0)
+                            );
+                            ?>
                         </p>
                     </div>
                 </div>
             <?php else: ?>
-                <div class="notice notice-info"><p>Aucune sauvegarde locale trouvée. Créez votre première sauvegarde ci-dessus.</p></div>
+                <div class="notice notice-info"><p><?php echo esc_html__('Aucune sauvegarde locale trouvée. Créez votre première sauvegarde ci-dessus.', 'backup-jlg'); ?></p></div>
             <?php endif; ?>
         </div>
         <?php
@@ -251,20 +275,20 @@ class BJLG_Admin {
     private function render_restore_section() {
         ?>
         <div class="bjlg-section">
-            <h2>Restaurer depuis un fichier</h2>
-            <p>Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration.</p>
+            <h2><?php echo esc_html__('Restaurer depuis un fichier', 'backup-jlg'); ?></h2>
+            <p><?php echo esc_html__('Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration.', 'backup-jlg'); ?></p>
             <form id="bjlg-restore-form" method="post" enctype="multipart/form-data">
                 <table class="form-table">
                     <tbody>
                         <tr>
-                            <th scope="row"><label for="bjlg-restore-file-input">Fichier de sauvegarde</label></th>
+                            <th scope="row"><label for="bjlg-restore-file-input"><?php echo esc_html__('Fichier de sauvegarde', 'backup-jlg'); ?></label></th>
                             <td>
                                 <input type="file" id="bjlg-restore-file-input" name="restore_file" accept=".zip,.zip.enc" required>
-                                <p class="description">Formats acceptés : .zip, .zip.enc (chiffré)</p>
+                                <p class="description"><?php echo esc_html__('Formats acceptés : .zip, .zip.enc (chiffré)', 'backup-jlg'); ?></p>
                             </td>
                         </tr>
                         <tr>
-                            <th scope="row"><label for="bjlg-restore-password">Mot de passe</label></th>
+                            <th scope="row"><label for="bjlg-restore-password"><?php echo esc_html__('Mot de passe', 'backup-jlg'); ?></label></th>
                             <td>
                                 <input type="password"
                                        id="bjlg-restore-password"
@@ -272,33 +296,37 @@ class BJLG_Admin {
                                        class="regular-text"
                                        autocomplete="current-password"
                                        aria-describedby="bjlg-restore-password-help"
-                                       placeholder="Requis pour les archives .zip.enc">
+                                       placeholder="<?php echo esc_attr__('Requis pour les archives .zip.enc', 'backup-jlg'); ?>">
                                 <p class="description"
                                    id="bjlg-restore-password-help"
-                                   data-default-text="<?php echo esc_attr('Requis pour restaurer les sauvegardes chiffrées (.zip.enc). Laissez vide pour les archives non chiffrées.'); ?>"
-                                   data-encrypted-text="<?php echo esc_attr('Mot de passe obligatoire : renseignez-le pour déchiffrer l\'archive (.zip.enc).'); ?>">
-                                    Requis pour restaurer les sauvegardes chiffrées (<code>.zip.enc</code>). Laissez vide pour les archives non chiffrées.
+                                   data-default-text="<?php echo esc_attr__('Requis pour restaurer les sauvegardes chiffrées (.zip.enc). Laissez vide pour les archives non chiffrées.', 'backup-jlg'); ?>"
+                                   data-encrypted-text="<?php echo esc_attr__('Mot de passe obligatoire : renseignez-le pour déchiffrer l\'archive (.zip.enc).', 'backup-jlg'); ?>">
+                                    <?php printf(
+                                        /* translators: %s: file extension */
+                                        esc_html__('Requis pour restaurer les sauvegardes chiffrées (%s). Laissez vide pour les archives non chiffrées.', 'backup-jlg'),
+                                        '<code>.zip.enc</code>'
+                                    ); ?>
                                 </p>
                             </td>
                         </tr>
                         <tr>
-                            <th scope="row">Options</th>
-                            <td><label><input type="checkbox" name="create_backup_before_restore" value="1" checked> Créer une sauvegarde de sécurité avant la restauration</label></td>
+                            <th scope="row"><?php echo esc_html__('Options', 'backup-jlg'); ?></th>
+                            <td><label><input type="checkbox" name="create_backup_before_restore" value="1" checked> <?php echo esc_html__('Créer une sauvegarde de sécurité avant la restauration', 'backup-jlg'); ?></label></td>
                         </tr>
                     </tbody>
                 </table>
                 <div id="bjlg-restore-errors" class="notice notice-error" style="display: none;" role="alert"></div>
                 <p class="submit">
-                    <button type="submit" class="button button-primary"><span class="dashicons dashicons-upload"></span> Téléverser et Restaurer</button>
+                    <button type="submit" class="button button-primary"><span class="dashicons dashicons-upload"></span> <?php echo esc_html__('Téléverser et restaurer', 'backup-jlg'); ?></button>
                 </p>
             </form>
             <div id="bjlg-restore-status" style="display: none;">
-                <h3>Statut de la restauration</h3>
+                <h3><?php echo esc_html__('Statut de la restauration', 'backup-jlg'); ?></h3>
                 <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-restore-progress-bar">0%</div></div>
-                <p id="bjlg-restore-status-text">Préparation...</p>
+                <p id="bjlg-restore-status-text"><?php echo esc_html__('Préparation...', 'backup-jlg'); ?></p>
             </div>
             <div id="bjlg-restore-debug-wrapper" style="display: none;">
-                <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>
+                <h3><span class="dashicons dashicons-info"></span> <?php echo esc_html__('Détails techniques', 'backup-jlg'); ?></h3>
                 <pre id="bjlg-restore-ajax-debug" class="bjlg-log-textarea"></pre>
             </div>
         </div>
@@ -312,38 +340,51 @@ class BJLG_Admin {
         $history = class_exists(BJLG_History::class) ? BJLG_History::get_history(50) : [];
         ?>
         <div class="bjlg-section">
-            <h2>Historique des 50 dernières actions</h2>
+            <h2><?php echo esc_html__('Historique des 50 dernières actions', 'backup-jlg'); ?></h2>
             <?php if (!empty($history)): ?>
                 <table class="wp-list-table widefat striped bjlg-responsive-table bjlg-history-table">
                     <thead>
                         <tr>
-                            <th scope="col" style="width: 180px;">Date</th>
-                            <th scope="col">Action</th>
-                            <th scope="col" style="width: 100px;">Statut</th>
-                            <th scope="col">Détails</th>
+                            <th scope="col" style="width: 180px;"><?php echo esc_html__('Date', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Action', 'backup-jlg'); ?></th>
+                            <th scope="col" style="width: 100px;"><?php echo esc_html__('Statut', 'backup-jlg'); ?></th>
+                            <th scope="col"><?php echo esc_html__('Détails', 'backup-jlg'); ?></th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($history as $entry):
-                            $status_class = ''; $status_icon = '';
+                            $status_class = ''; $status_icon = ''; $status_text = '';
                             switch ($entry['status']) {
-                                case 'success': $status_class = 'success'; $status_icon = '✅'; break;
-                                case 'failure': $status_class = 'error'; $status_icon = '❌'; break;
-                                case 'info': $status_class = 'info'; $status_icon = 'ℹ️'; break;
+                                case 'success':
+                                    $status_class = 'success';
+                                    $status_icon = '✅';
+                                    $status_text = esc_html__('Succès', 'backup-jlg');
+                                    break;
+                                case 'failure':
+                                    $status_class = 'error';
+                                    $status_icon = '❌';
+                                    $status_text = esc_html__('Échec', 'backup-jlg');
+                                    break;
+                                case 'info':
+                                default:
+                                    $status_class = 'info';
+                                    $status_icon = 'ℹ️';
+                                    $status_text = esc_html__('Information', 'backup-jlg');
+                                    break;
                             } ?>
                             <tr class="bjlg-card-row">
-                                <td class="bjlg-card-cell" data-label="Date"><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($entry['timestamp'])); ?></td>
-                                <td class="bjlg-card-cell" data-label="Action"><strong><?php echo esc_html(str_replace('_', ' ', ucfirst($entry['action_type']))); ?></strong></td>
-                                <td class="bjlg-card-cell" data-label="Statut"><span class="bjlg-status <?php echo esc_attr($status_class); ?>"><?php echo $status_icon . ' ' . esc_html(ucfirst($entry['status'])); ?></span></td>
-                                <td class="bjlg-card-cell" data-label="Détails"><?php echo esc_html($entry['details']); ?></td>
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Date', 'backup-jlg'); ?>"><?php echo date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($entry['timestamp'])); ?></td>
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Action', 'backup-jlg'); ?>"><strong><?php echo esc_html(str_replace('_', ' ', ucfirst($entry['action_type']))); ?></strong></td>
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Statut', 'backup-jlg'); ?>"><span class="bjlg-status <?php echo esc_attr($status_class); ?>"><?php echo esc_html($status_icon . ' ' . $status_text); ?></span></td>
+                                <td class="bjlg-card-cell" data-label="<?php echo esc_attr__('Détails', 'backup-jlg'); ?>"><?php echo esc_html($entry['details']); ?></td>
                             </tr>
                         <?php endforeach; ?>
                     </tbody>
                 </table>
             <?php else: ?>
-                <div class="notice notice-info"><p>Aucun historique trouvé.</p></div>
+                <div class="notice notice-info"><p><?php echo esc_html__('Aucun historique trouvé.', 'backup-jlg'); ?></p></div>
             <?php endif; ?>
-            <p class="description" style="margin-top: 20px;">L'historique est conservé pendant 30 jours. Les entrées plus anciennes sont automatiquement supprimées.</p>
+            <p class="description" style="margin-top: 20px;"><?php echo esc_html__('L\'historique est conservé pendant 30 jours. Les entrées plus anciennes sont automatiquement supprimées.', 'backup-jlg'); ?></p>
         </div>
         <?php
     }
@@ -354,12 +395,20 @@ class BJLG_Admin {
     private function render_health_check_section() {
         $health_checker = new BJLG_Health_Check();
         $results = $health_checker->get_all_checks();
-        $plugin_checks = ['debug_mode' => 'Mode Débogage', 'cron_status' => 'Tâches planifiées (Cron)'];
-        $server_checks = ['backup_dir' => 'Dossier de sauvegarde', 'disk_space' => 'Espace disque', 'php_memory_limit' => 'Limite Mémoire PHP', 'php_execution_time' => 'Temps d\'exécution PHP'];
+        $plugin_checks = [
+            'debug_mode' => __('Mode Débogage', 'backup-jlg'),
+            'cron_status' => __('Tâches planifiées (Cron)', 'backup-jlg'),
+        ];
+        $server_checks = [
+            'backup_dir' => __('Dossier de sauvegarde', 'backup-jlg'),
+            'disk_space' => __('Espace disque', 'backup-jlg'),
+            'php_memory_limit' => __('Limite Mémoire PHP', 'backup-jlg'),
+            'php_execution_time' => __('Temps d\'exécution PHP', 'backup-jlg'),
+        ];
         ?>
         <div class="bjlg-section">
-            <h2>Bilan de Santé du Système</h2>
-            <h3>État du Plugin</h3>
+            <h2><?php echo esc_html__('Bilan de santé du système', 'backup-jlg'); ?></h2>
+            <h3><?php echo esc_html__('État du plugin', 'backup-jlg'); ?></h3>
             <table class="wp-list-table widefat striped bjlg-health-check-table">
                 <tbody>
                     <?php foreach ($plugin_checks as $key => $title): $result = $results[$key]; ?>
@@ -371,7 +420,7 @@ class BJLG_Admin {
                     <?php endforeach; ?>
                 </tbody>
             </table>
-            <h3>Configuration Serveur</h3>
+            <h3><?php echo esc_html__('Configuration serveur', 'backup-jlg'); ?></h3>
             <table class="wp-list-table widefat striped bjlg-health-check-table">
                 <tbody>
                     <?php foreach ($server_checks as $key => $title): $result = $results[$key]; ?>
@@ -383,7 +432,7 @@ class BJLG_Admin {
                     <?php endforeach; ?>
                 </tbody>
             </table>
-            <p style="margin-top: 20px;"><button class="button" onclick="window.location.reload();"><span class="dashicons dashicons-update"></span> Relancer les vérifications</button></p>
+            <p style="margin-top: 20px;"><button class="button" onclick="window.location.reload();"><span class="dashicons dashicons-update"></span> <?php echo esc_html__('Relancer les vérifications', 'backup-jlg'); ?></button></p>
         </div>
         <?php
     }
@@ -398,9 +447,9 @@ class BJLG_Admin {
         $webhook_key = class_exists(BJLG_Webhooks::class) ? BJLG_Webhooks::get_webhook_key() : '';
         ?>
         <div class="bjlg-section">
-            <h2>Configuration du Plugin</h2>
-            
-            <h3><span class="dashicons dashicons-cloud"></span> Destinations Cloud</h3>
+            <h2><?php echo esc_html__('Configuration du plugin', 'backup-jlg'); ?></h2>
+
+            <h3><span class="dashicons dashicons-cloud"></span> <?php echo esc_html__('Destinations cloud', 'backup-jlg'); ?></h3>
             <form class="bjlg-settings-form">
                 <div class="bjlg-settings-feedback notice" role="status" aria-live="polite" style="display:none;"></div>
                 <?php
@@ -409,105 +458,127 @@ class BJLG_Admin {
                         $destination->render_settings();
                     }
                 } else {
-                    echo '<p class="description">Aucune destination cloud configurée. Activez Google Drive ou Amazon S3 en complétant leurs réglages.</p>';
+                    echo '<p class="description">' . esc_html__('Aucune destination cloud configurée. Activez Google Drive ou Amazon S3 en complétant leurs réglages.', 'backup-jlg') . '</p>';
                 }
                 ?>
             </form>
             
-            <h3><span class="dashicons dashicons-calendar-alt"></span> Planification des Sauvegardes</h3>
+            <h3><span class="dashicons dashicons-calendar-alt"></span> <?php echo esc_html__('Planification des sauvegardes', 'backup-jlg'); ?></h3>
             <form id="bjlg-schedule-form">
                 <table class="form-table">
                     <tr>
-                        <th scope="row">Fréquence</th>
+                        <th scope="row"><?php echo esc_html__('Fréquence', 'backup-jlg'); ?></th>
                         <td>
                             <select name="recurrence" id="bjlg-schedule-recurrence">
-                                <option value="disabled" <?php selected($schedule_settings['recurrence'], 'disabled'); ?>>Désactivée</option>
-                                <option value="hourly" <?php selected($schedule_settings['recurrence'], 'hourly'); ?>>Toutes les heures</option>
-                                <option value="daily" <?php selected($schedule_settings['recurrence'], 'daily'); ?>>Journalière</option>
-                                <option value="weekly" <?php selected($schedule_settings['recurrence'], 'weekly'); ?>>Hebdomadaire</option>
-                                <option value="monthly" <?php selected($schedule_settings['recurrence'], 'monthly'); ?>>Mensuelle</option>
+                                <option value="disabled" <?php selected($schedule_settings['recurrence'], 'disabled'); ?>><?php echo esc_html__('Désactivée', 'backup-jlg'); ?></option>
+                                <option value="hourly" <?php selected($schedule_settings['recurrence'], 'hourly'); ?>><?php echo esc_html__('Toutes les heures', 'backup-jlg'); ?></option>
+                                <option value="daily" <?php selected($schedule_settings['recurrence'], 'daily'); ?>><?php echo esc_html__('Journalière', 'backup-jlg'); ?></option>
+                                <option value="weekly" <?php selected($schedule_settings['recurrence'], 'weekly'); ?>><?php echo esc_html__('Hebdomadaire', 'backup-jlg'); ?></option>
+                                <option value="monthly" <?php selected($schedule_settings['recurrence'], 'monthly'); ?>><?php echo esc_html__('Mensuelle', 'backup-jlg'); ?></option>
                             </select>
                         </td>
                     </tr>
                     <tr class="bjlg-schedule-weekly-options" <?php echo ($schedule_settings['recurrence'] !== 'weekly') ? 'style="display:none;"' : ''; ?>>
-                        <th scope="row">Jour de la semaine</th>
+                        <th scope="row"><?php echo esc_html__('Jour de la semaine', 'backup-jlg'); ?></th>
                         <td>
                             <select name="day" id="bjlg-schedule-day">
-                                <?php $days = ['monday' => 'Lundi', 'tuesday' => 'Mardi', 'wednesday' => 'Mercredi', 'thursday' => 'Jeudi', 'friday' => 'Vendredi', 'saturday' => 'Samedi', 'sunday' => 'Dimanche'];
+                                <?php $days = [
+                                    'monday' => __('Lundi', 'backup-jlg'),
+                                    'tuesday' => __('Mardi', 'backup-jlg'),
+                                    'wednesday' => __('Mercredi', 'backup-jlg'),
+                                    'thursday' => __('Jeudi', 'backup-jlg'),
+                                    'friday' => __('Vendredi', 'backup-jlg'),
+                                    'saturday' => __('Samedi', 'backup-jlg'),
+                                    'sunday' => __('Dimanche', 'backup-jlg'),
+                                ];
                                 foreach ($days as $day_key => $day_name): ?>
-                                    <option value="<?php echo $day_key; ?>" <?php selected(isset($schedule_settings['day']) ? $schedule_settings['day'] : 'sunday', $day_key); ?>><?php echo $day_name; ?></option>
+                                    <option value="<?php echo $day_key; ?>" <?php selected(isset($schedule_settings['day']) ? $schedule_settings['day'] : 'sunday', $day_key); ?>><?php echo esc_html($day_name); ?></option>
                                 <?php endforeach; ?>
                             </select>
                         </td>
                     </tr>
                     <tr class="bjlg-schedule-time-options" <?php echo ($schedule_settings['recurrence'] === 'disabled') ? 'style="display:none;"' : ''; ?>>
-                        <th scope="row">Heure</th>
+                        <th scope="row"><?php echo esc_html__('Heure', 'backup-jlg'); ?></th>
                         <td>
                             <input type="time" name="time" id="bjlg-schedule-time" value="<?php echo esc_attr(isset($schedule_settings['time']) ? $schedule_settings['time'] : '23:59'); ?>">
-                            <p class="description">Heure locale du serveur</p>
+                            <p class="description"><?php echo esc_html__('Heure locale du serveur', 'backup-jlg'); ?></p>
                         </td>
                     </tr>
                 </table>
-                <p class="submit"><button type="submit" class="button button-primary">Enregistrer la planification</button></p>
+                <p class="submit"><button type="submit" class="button button-primary"><?php echo esc_html__('Enregistrer la planification', 'backup-jlg'); ?></button></p>
             </form>
             
-            <h3><span class="dashicons dashicons-admin-links"></span> Webhook</h3>
-            <p>Utilisez ce point de terminaison pour déclencher une sauvegarde à distance en toute sécurité :</p>
+            <h3><span class="dashicons dashicons-admin-links"></span> <?php echo esc_html__('Webhook', 'backup-jlg'); ?></h3>
+            <p><?php echo esc_html__('Utilisez ce point de terminaison pour déclencher une sauvegarde à distance en toute sécurité :', 'backup-jlg'); ?></p>
             <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
-                <label for="bjlg-webhook-endpoint" style="display:block; font-weight:600;">Point de terminaison</label>
+                <label for="bjlg-webhook-endpoint" style="display:block; font-weight:600;"><?php echo esc_html__('Point de terminaison', 'backup-jlg'); ?></label>
                 <div>
                     <input type="text" id="bjlg-webhook-endpoint" readonly value="<?php echo esc_url(BJLG_Webhooks::get_webhook_endpoint()); ?>" class="regular-text code" style="width: 70%;">
-                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-endpoint">Copier l'URL</button>
+                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-endpoint"><?php echo esc_html__('Copier l\'URL', 'backup-jlg'); ?></button>
                 </div>
             </div>
             <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
-                <label for="bjlg-webhook-key" style="display:block; font-weight:600;">Clé secrète</label>
+                <label for="bjlg-webhook-key" style="display:block; font-weight:600;"><?php echo esc_html__('Clé secrète', 'backup-jlg'); ?></label>
                 <div>
                     <input type="text" id="bjlg-webhook-key" readonly value="<?php echo esc_attr($webhook_key); ?>" class="regular-text code" style="width: 70%;">
-                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-key">Copier la clé</button>
-                    <button class="button" id="bjlg-regenerate-webhook">Régénérer</button>
+                    <button class="button bjlg-copy-field" data-copy-target="#bjlg-webhook-key"><?php echo esc_html__('Copier la clé', 'backup-jlg'); ?></button>
+                    <button class="button" id="bjlg-regenerate-webhook"><?php echo esc_html__('Régénérer', 'backup-jlg'); ?></button>
                 </div>
             </div>
-            <p class="description">Envoyez une requête <strong>POST</strong> à l'URL ci-dessus en ajoutant l'en-tête <code><?php echo esc_html(BJLG_Webhooks::WEBHOOK_HEADER); ?></code> (ou <code>Authorization: Bearer &lt;clé&gt;</code>) contenant votre clé.</p>
+            <p class="description"><?php
+                printf(
+                    /* translators: %s: HTTP header name */
+                    esc_html__('Envoyez une requête %1$sPOST%2$s à l\'URL ci-dessus en ajoutant l\'en-tête %3$s (ou %4$sAuthorization: Bearer &lt;clé&gt;%5$s) contenant votre clé.', 'backup-jlg'),
+                    '<strong>',
+                    '</strong>',
+                    '<code>' . esc_html(BJLG_Webhooks::WEBHOOK_HEADER) . '</code>',
+                    '<code>',
+                    '</code>'
+                );
+            ?></p>
             <pre class="code"><code><?php echo esc_html(sprintf("curl -X POST %s \\n  -H 'Content-Type: application/json' \\n  -H '%s: %s'", BJLG_Webhooks::get_webhook_endpoint(), BJLG_Webhooks::WEBHOOK_HEADER, $webhook_key)); ?></code></pre>
-            <p class="description"><strong>Compatibilité :</strong> L'ancien format <code><?php echo esc_html(add_query_arg(BJLG_Webhooks::WEBHOOK_QUERY_VAR, 'VOTRE_CLE', home_url('/'))); ?></code> reste supporté provisoirement mais sera retiré après la période de transition.</p>
+            <p class="description"><strong><?php echo esc_html__('Compatibilité :', 'backup-jlg'); ?></strong> <?php printf(
+                /* translators: %s: legacy webhook URL */
+                esc_html__('L\'ancien format %s reste supporté provisoirement mais sera retiré après la période de transition.', 'backup-jlg'),
+                '<code>' . esc_html(add_query_arg(BJLG_Webhooks::WEBHOOK_QUERY_VAR, 'VOTRE_CLE', home_url('/'))) . '</code>'
+            ); ?></p>
 
             <form class="bjlg-settings-form">
                 <div class="bjlg-settings-feedback notice" role="status" aria-live="polite" style="display:none;"></div>
-                <h3><span class="dashicons dashicons-trash"></span> Rétention des Sauvegardes</h3>
+                <h3><span class="dashicons dashicons-trash"></span> <?php echo esc_html__('Rétention des sauvegardes', 'backup-jlg'); ?></h3>
                 <table class="form-table">
                     <tr>
-                        <th scope="row">Conserver par nombre</th>
+                        <th scope="row"><?php echo esc_html__('Conserver par nombre', 'backup-jlg'); ?></th>
                         <td>
-                            <input name="by_number" type="number" class="small-text" value="<?php echo esc_attr(isset($cleanup_settings['by_number']) ? $cleanup_settings['by_number'] : 3); ?>" min="0"> sauvegardes
-                            <p class="description">0 = illimité</p>
+                            <input name="by_number" type="number" class="small-text" value="<?php echo esc_attr(isset($cleanup_settings['by_number']) ? $cleanup_settings['by_number'] : 3); ?>" min="0"> <?php echo esc_html__('sauvegardes', 'backup-jlg'); ?>
+                            <p class="description"><?php echo esc_html__('0 = illimité', 'backup-jlg'); ?></p>
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row">Conserver par ancienneté</th>
+                        <th scope="row"><?php echo esc_html__('Conserver par ancienneté', 'backup-jlg'); ?></th>
                         <td>
-                            <input name="by_age" type="number" class="small-text" value="<?php echo esc_attr(isset($cleanup_settings['by_age']) ? $cleanup_settings['by_age'] : 0); ?>" min="0"> jours
-                            <p class="description">0 = illimité</p>
+                            <input name="by_age" type="number" class="small-text" value="<?php echo esc_attr(isset($cleanup_settings['by_age']) ? $cleanup_settings['by_age'] : 0); ?>" min="0"> <?php echo esc_html__('jours', 'backup-jlg'); ?>
+                            <p class="description"><?php echo esc_html__('0 = illimité', 'backup-jlg'); ?></p>
                         </td>
                     </tr>
                 </table>
-                
-                <h3><span class="dashicons dashicons-admin-appearance"></span> Marque Blanche</h3>
+
+                <h3><span class="dashicons dashicons-admin-appearance"></span> <?php echo esc_html__('Marque blanche', 'backup-jlg'); ?></h3>
                 <table class="form-table">
                     <tr>
-                        <th scope="row">Nom du plugin</th>
+                        <th scope="row"><?php echo esc_html__('Nom du plugin', 'backup-jlg'); ?></th>
                         <td>
-                            <input type="text" name="plugin_name" value="<?php echo esc_attr(isset($wl_settings['plugin_name']) ? $wl_settings['plugin_name'] : ''); ?>" class="regular-text" placeholder="Backup - JLG">
-                            <p class="description">Laissez vide pour utiliser le nom par défaut</p>
+                            <input type="text" name="plugin_name" value="<?php echo esc_attr(isset($wl_settings['plugin_name']) ? $wl_settings['plugin_name'] : ''); ?>" class="regular-text" placeholder="<?php echo esc_attr__('Backup - JLG', 'backup-jlg'); ?>">
+                            <p class="description"><?php echo esc_html__('Laissez vide pour utiliser le nom par défaut', 'backup-jlg'); ?></p>
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row">Visibilité</th>
-                        <td><label><input type="checkbox" name="hide_from_non_admins" <?php checked(isset($wl_settings['hide_from_non_admins']) && $wl_settings['hide_from_non_admins']); ?>> Cacher le plugin pour les non-administrateurs</label></td>
+                        <th scope="row"><?php echo esc_html__('Visibilité', 'backup-jlg'); ?></th>
+                        <td><label><input type="checkbox" name="hide_from_non_admins" <?php checked(isset($wl_settings['hide_from_non_admins']) && $wl_settings['hide_from_non_admins']); ?>> <?php echo esc_html__('Cacher le plugin pour les non-administrateurs', 'backup-jlg'); ?></label></td>
                     </tr>
                 </table>
-                
-                <p class="submit"><button type="submit" class="button button-primary">Enregistrer les Réglages</button></p>
+
+                <p class="submit"><button type="submit" class="button button-primary"><?php echo esc_html__('Enregistrer les réglages', 'backup-jlg'); ?></button></p>
             </form>
         </div>
         <?php
@@ -520,37 +591,67 @@ class BJLG_Admin {
         $relative_backup_dir = str_replace(untrailingslashit(ABSPATH), '', BJLG_BACKUP_DIR);
         ?>
         <div class="bjlg-section">
-            <h2>Journaux et Outils de Diagnostic</h2>
-            
-            <h3>Emplacements des Fichiers</h3>
+            <h2><?php echo esc_html__('Journaux et outils de diagnostic', 'backup-jlg'); ?></h2>
+
+            <h3><?php echo esc_html__('Emplacements des fichiers', 'backup-jlg'); ?></h3>
             <p class="description">
-                <strong>Sauvegardes :</strong> <code><?php echo esc_html($relative_backup_dir); ?></code><br>
-                <strong>Journal du Plugin :</strong> <code>/wp-content/bjlg-debug.log</code> (si <code>BJLG_DEBUG</code> est activé)<br>
-                <strong>Journal d'erreurs WP :</strong> <code>/wp-content/debug.log</code> (si <code>WP_DEBUG_LOG</code> est activé)
+                <strong><?php echo esc_html__('Sauvegardes :', 'backup-jlg'); ?></strong> <code><?php echo esc_html($relative_backup_dir); ?></code><br>
+                <strong><?php echo esc_html__('Journal du plugin :', 'backup-jlg'); ?></strong> <code>/wp-content/bjlg-debug.log</code> (<?php
+                    printf(
+                        /* translators: %s: constant name. */
+                        esc_html__('si %s est activé', 'backup-jlg'),
+                        '<code>BJLG_DEBUG</code>'
+                    );
+                ?>)<br>
+                <strong><?php echo esc_html__('Journal d\'erreurs WP :', 'backup-jlg'); ?></strong> <code>/wp-content/debug.log</code> (<?php
+                    printf(
+                        /* translators: %s: constant name. */
+                        esc_html__('si %s est activé', 'backup-jlg'),
+                        '<code>WP_DEBUG_LOG</code>'
+                    );
+                ?>)
             </p>
             <hr>
-            
-            <h3>Journal d'activité du Plugin</h3>
-            <p class="description">
-                Pour activer : ajoutez <code>define('BJLG_DEBUG', true);</code> dans votre <code>wp-config.php</code>
-            </p>
-            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_plugin_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
 
-            <h3>Journal d'erreurs PHP de WordPress</h3>
+            <h3><?php echo esc_html__('Journal d\'activité du plugin', 'backup-jlg'); ?></h3>
             <p class="description">
-                Pour activer : ajoutez <code>define('WP_DEBUG_LOG', true);</code> dans votre <code>wp-config.php</code>
+                <?php
+                printf(
+                    /* translators: 1: opening code tag, 2: closing code tag, 3: opening wp-config code tag, 4: closing wp-config code tag. */
+                    esc_html__('Pour activer : ajoutez %1$sdefine(\'BJLG_DEBUG\', true);%2$s dans votre %3$swp-config.php%4$s', 'backup-jlg'),
+                    '<code>',
+                    '</code>',
+                    '<code>',
+                    '</code>'
+                );
+                ?>
             </p>
-            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_wp_error_log_content() : 'Classe BJLG_Debug non trouvée.'); ?></textarea>
-            
-            <h3>Outils de Support</h3>
-            <p>Générez un pack de support contenant les journaux et les informations système pour faciliter le diagnostic.</p>
+            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_plugin_log_content() : __('Classe BJLG_Debug non trouvée.', 'backup-jlg')); ?></textarea>
+
+            <h3><?php echo esc_html__('Journal d\'erreurs PHP de WordPress', 'backup-jlg'); ?></h3>
+            <p class="description">
+                <?php
+                printf(
+                    /* translators: 1: opening code tag, 2: closing code tag, 3: opening wp-config code tag, 4: closing wp-config code tag. */
+                    esc_html__('Pour activer : ajoutez %1$sdefine(\'WP_DEBUG_LOG\', true);%2$s dans votre %3$swp-config.php%4$s', 'backup-jlg'),
+                    '<code>',
+                    '</code>',
+                    '<code>',
+                    '</code>'
+                );
+                ?>
+            </p>
+            <textarea class="bjlg-log-textarea" readonly><?php echo esc_textarea(class_exists(BJLG_Debug::class) ? BJLG_Debug::get_wp_error_log_content() : __('Classe BJLG_Debug non trouvée.', 'backup-jlg')); ?></textarea>
+
+            <h3><?php echo esc_html__('Outils de support', 'backup-jlg'); ?></h3>
+            <p><?php echo esc_html__('Générez un pack de support contenant les journaux et les informations système pour faciliter le diagnostic.', 'backup-jlg'); ?></p>
             <p>
                 <button id="bjlg-generate-support-package" class="button button-primary">
-                    <span class="dashicons dashicons-download"></span> Créer un pack de support
+                    <span class="dashicons dashicons-download"></span> <?php echo esc_html__('Créer un pack de support', 'backup-jlg'); ?>
                 </button>
             </p>
             <div id="bjlg-support-package-status" style="display: none;">
-                <p class="description">Génération du pack de support en cours...</p>
+                <p class="description"><?php echo esc_html__('Génération du pack de support en cours...', 'backup-jlg'); ?></p>
             </div>
         </div>
         <?php

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1441,7 +1441,11 @@ class BJLG_REST_API {
                 default:
                     return new WP_Error(
                         'invalid_setting_key',
-                        sprintf(__('The "%s" setting cannot be updated via the REST API.', 'backup-jlg'), $key),
+                        sprintf(
+                            /* translators: %s: invalid settings key. */
+                            __('The "%s" setting cannot be updated via the REST API.', 'backup-jlg'),
+                            $key
+                        ),
                         ['status' => 400]
                     );
             }
@@ -1468,7 +1472,11 @@ class BJLG_REST_API {
         if (!is_array($value)) {
             return new WP_Error(
                 'invalid_setting_structure',
-                sprintf(__('The "%s" setting must be a JSON object.', 'backup-jlg'), $key),
+                sprintf(
+                    /* translators: %s: settings key. */
+                    __('The "%s" setting must be a JSON object.', 'backup-jlg'),
+                    $key
+                ),
                 ['status' => 400]
             );
         }
@@ -1533,7 +1541,11 @@ class BJLG_REST_API {
             if (!array_key_exists($required_key, $value)) {
                 return new WP_Error(
                     'invalid_cleanup_settings',
-                    sprintf(__('Missing cleanup setting "%s".', 'backup-jlg'), $required_key),
+                    sprintf(
+                        /* translators: %s: cleanup setting key. */
+                        __('Missing cleanup setting "%s".', 'backup-jlg'),
+                        $required_key
+                    ),
                     ['status' => 400]
                 );
             }
@@ -1571,7 +1583,11 @@ class BJLG_REST_API {
             if (!array_key_exists($required_key, $value)) {
                 return new WP_Error(
                     'invalid_schedule_settings',
-                    sprintf(__('Missing schedule setting "%s".', 'backup-jlg'), $required_key),
+                    sprintf(
+                        /* translators: %s: schedule setting key. */
+                        __('Missing schedule setting "%s".', 'backup-jlg'),
+                        $required_key
+                    ),
                     ['status' => 400]
                 );
             }

--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -115,7 +115,7 @@ class BJLG_Settings {
      */
     public function handle_save_settings() {
         if (!current_user_can(BJLG_CAPABILITY)) {
-            wp_send_json_error(['message' => 'Permission refusée.']);
+            wp_send_json_error(['message' => __('Permission refusée.', 'backup-jlg')]);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
         
@@ -130,7 +130,11 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_cleanup_settings', $cleanup_settings);
                 $saved_settings['cleanup'] = $cleanup_settings;
-                BJLG_Debug::log("Réglages de nettoyage sauvegardés : " . print_r($cleanup_settings, true));
+                BJLG_Debug::log(sprintf(
+                    /* translators: %s: serialized cleanup settings. */
+                    __('Réglages de nettoyage sauvegardés : %s', 'backup-jlg'),
+                    print_r($cleanup_settings, true)
+                ));
             }
 
             // --- Réglages de la Marque Blanche ---
@@ -141,7 +145,11 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_whitelabel_settings', $wl_settings);
                 $saved_settings['whitelabel'] = $wl_settings;
-                BJLG_Debug::log("Réglages de marque blanche sauvegardés : " . print_r($wl_settings, true));
+                BJLG_Debug::log(sprintf(
+                    /* translators: %s: serialized whitelabel settings. */
+                    __('Réglages de marque blanche sauvegardés : %s', 'backup-jlg'),
+                    print_r($wl_settings, true)
+                ));
             }
 
             // --- Réglages de Chiffrement ---
@@ -154,7 +162,7 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_encryption_settings', $encryption_settings);
                 $saved_settings['encryption'] = $encryption_settings;
-                BJLG_Debug::log("Réglages de chiffrement sauvegardés.");
+                BJLG_Debug::log(__('Réglages de chiffrement sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglages Google Drive ---
@@ -167,7 +175,7 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_gdrive_settings', $gdrive_settings);
                 $saved_settings['gdrive'] = $gdrive_settings;
-                BJLG_Debug::log("Identifiants Google Drive sauvegardés.");
+                BJLG_Debug::log(__('Identifiants Google Drive sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglages Amazon S3 ---
@@ -190,7 +198,7 @@ class BJLG_Settings {
 
                 update_option('bjlg_s3_settings', $s3_settings);
                 $saved_settings['s3'] = $s3_settings;
-                BJLG_Debug::log('Réglages Amazon S3 sauvegardés.');
+                BJLG_Debug::log(__('Réglages Amazon S3 sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglages de Notifications ---
@@ -220,7 +228,7 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_notification_settings', $notifications_settings);
                 $saved_settings['notifications'] = $notifications_settings;
-                BJLG_Debug::log("Réglages de notifications sauvegardés.");
+                BJLG_Debug::log(__('Réglages de notifications sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglages de Performance ---
@@ -232,7 +240,7 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_performance_settings', $performance_settings);
                 $saved_settings['performance'] = $performance_settings;
-                BJLG_Debug::log("Réglages de performance sauvegardés.");
+                BJLG_Debug::log(__('Réglages de performance sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglages Webhooks ---
@@ -248,7 +256,7 @@ class BJLG_Settings {
                 ];
                 update_option('bjlg_webhook_settings', $webhook_settings);
                 $saved_settings['webhooks'] = $webhook_settings;
-                BJLG_Debug::log("Réglages de webhooks sauvegardés.");
+                BJLG_Debug::log(__('Réglages de webhooks sauvegardés.', 'backup-jlg'));
             }
 
             // --- Réglage du débogueur AJAX ---
@@ -256,20 +264,24 @@ class BJLG_Settings {
                 $ajax_debug_enabled = $this->to_bool(wp_unslash($_POST['ajax_debug_enabled']));
                 update_option('bjlg_ajax_debug_enabled', $ajax_debug_enabled);
                 $saved_settings['ajax_debug'] = $ajax_debug_enabled;
-                BJLG_Debug::log("Réglage du débogueur AJAX mis à jour.");
+                BJLG_Debug::log(__('Réglage du débogueur AJAX mis à jour.', 'backup-jlg'));
             }
 
-            BJLG_History::log('settings_updated', 'success', 'Les réglages ont été mis à jour.');
-            
+            BJLG_History::log('settings_updated', 'success', __('Les réglages ont été mis à jour.', 'backup-jlg'));
+
             do_action('bjlg_settings_saved', $saved_settings);
-            
+
             wp_send_json_success([
-                'message' => 'Réglages sauvegardés avec succès !',
+                'message' => __('Réglages sauvegardés avec succès !', 'backup-jlg'),
                 'saved' => $saved_settings
             ]);
 
         } catch (Exception $e) {
-            BJLG_History::log('settings_updated', 'failure', 'Erreur : ' . $e->getMessage());
+            BJLG_History::log('settings_updated', 'failure', sprintf(
+                /* translators: %s: error message. */
+                __('Erreur : %s', 'backup-jlg'),
+                $e->getMessage()
+            ));
             wp_send_json_error(['message' => $e->getMessage()]);
         }
     }
@@ -279,7 +291,7 @@ class BJLG_Settings {
      */
     public function handle_get_settings() {
         if (!current_user_can(BJLG_CAPABILITY)) {
-            wp_send_json_error(['message' => 'Permission refusée.']);
+            wp_send_json_error(['message' => __('Permission refusée.', 'backup-jlg')]);
         }
         
         $settings = [
@@ -302,7 +314,7 @@ class BJLG_Settings {
      */
     public function handle_reset_settings() {
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Permission refusée.']);
+            wp_send_json_error(['message' => __('Permission refusée.', 'backup-jlg')]);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
         
@@ -315,18 +327,22 @@ class BJLG_Settings {
                 foreach ($this->default_settings as $key => $defaults) {
                     update_option('bjlg_' . $key . '_settings', $defaults);
                 }
-                BJLG_History::log('settings_reset', 'info', 'Tous les réglages ont été réinitialisés');
+                BJLG_History::log('settings_reset', 'info', __('Tous les réglages ont été réinitialisés', 'backup-jlg'));
             } else {
                 if (isset($this->default_settings[$section])) {
                     update_option('bjlg_' . $section . '_settings', $this->default_settings[$section]);
-                    BJLG_History::log('settings_reset', 'info', "Réglages '$section' réinitialisés");
+                    BJLG_History::log('settings_reset', 'info', sprintf(
+                        /* translators: %s: settings section key. */
+                        __("Réglages '%s' réinitialisés", 'backup-jlg'),
+                        $section
+                    ));
                 } else {
-                    throw new Exception("Section de réglages invalide.");
+                    throw new Exception(__('Section de réglages invalide.', 'backup-jlg'));
                 }
             }
-            
-            wp_send_json_success(['message' => 'Réglages réinitialisés avec succès.']);
-            
+
+            wp_send_json_success(['message' => __('Réglages réinitialisés avec succès.', 'backup-jlg')]);
+
         } catch (Exception $e) {
             wp_send_json_error(['message' => $e->getMessage()]);
         }
@@ -337,7 +353,7 @@ class BJLG_Settings {
      */
     public function handle_export_settings() {
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Permission refusée.']);
+            wp_send_json_error(['message' => __('Permission refusée.', 'backup-jlg')]);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
         
@@ -371,8 +387,8 @@ class BJLG_Settings {
             'settings' => $settings
         ];
         
-        BJLG_History::log('settings_exported', 'success', 'Paramètres exportés');
-        
+        BJLG_History::log('settings_exported', 'success', __('Paramètres exportés', 'backup-jlg'));
+
         wp_send_json_success([
             'filename' => 'bjlg-settings-' . date('Y-m-d-His') . '.json',
             'data' => base64_encode(json_encode($export_data, JSON_PRETTY_PRINT))
@@ -384,12 +400,12 @@ class BJLG_Settings {
      */
     public function handle_import_settings() {
         if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Permission refusée.']);
+            wp_send_json_error(['message' => __('Permission refusée.', 'backup-jlg')]);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
         
         if (empty($_POST['import_data'])) {
-            wp_send_json_error(['message' => 'Aucune donnée à importer.']);
+            wp_send_json_error(['message' => __('Aucune donnée à importer.', 'backup-jlg')]);
         }
 
         try {
@@ -397,14 +413,14 @@ class BJLG_Settings {
             $import_data = json_decode(base64_decode($raw_import), true);
 
             if (empty($import_data) || !isset($import_data['settings'])) {
-                throw new Exception("Format de données invalide.");
+                throw new Exception(__('Format de données invalide.', 'backup-jlg'));
             }
 
             // Vérifier la compatibilité de version
             if (isset($import_data['version'])) {
                 $import_version = $import_data['version'];
                 if (version_compare($import_version, BJLG_VERSION, '>')) {
-                    throw new Exception("Les paramètres proviennent d'une version plus récente du plugin.");
+                    throw new Exception(__('Les paramètres proviennent d\'une version plus récente du plugin.', 'backup-jlg'));
                 }
             }
             
@@ -412,19 +428,31 @@ class BJLG_Settings {
             $sanitized_settings = $this->sanitize_imported_settings((array) $import_data['settings']);
 
             if (empty($sanitized_settings)) {
-                throw new Exception("Aucun réglage valide à importer.");
+                throw new Exception(__('Aucun réglage valide à importer.', 'backup-jlg'));
             }
 
             foreach ($sanitized_settings as $key => $value) {
                 update_option($key, $value);
             }
             
-            BJLG_History::log('settings_imported', 'success', 'Paramètres importés depuis ' . ($import_data['site_url'] ?? 'inconnu'));
-            
-            wp_send_json_success(['message' => 'Paramètres importés avec succès.']);
+            BJLG_History::log(
+                'settings_imported',
+                'success',
+                sprintf(
+                    /* translators: %s: source site URL. */
+                    __('Paramètres importés depuis %s', 'backup-jlg'),
+                    $import_data['site_url'] ?? __('inconnu', 'backup-jlg')
+                )
+            );
+
+            wp_send_json_success(['message' => __('Paramètres importés avec succès.', 'backup-jlg')]);
             
         } catch (Exception $e) {
-            BJLG_History::log('settings_imported', 'failure', 'Erreur : ' . $e->getMessage());
+            BJLG_History::log('settings_imported', 'failure', sprintf(
+                /* translators: %s: error message. */
+                __('Erreur : %s', 'backup-jlg'),
+                $e->getMessage()
+            ));
             wp_send_json_error(['message' => $e->getMessage()]);
         }
     }

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -252,6 +252,7 @@ class BJLG_Webhooks {
 
                 wp_send_json_error([
                     'message' => sprintf(
+                        /* translators: %s: comma-separated list of allowed components. */
                         __('No valid components were requested. Allowed components are: %s.', 'backup-jlg'),
                         implode(', ', $allowed_components)
                     ),

--- a/backup-jlg/languages/backup-jlg.pot
+++ b/backup-jlg/languages/backup-jlg.pot
@@ -1,0 +1,934 @@
+# Copyright (C) 2025 JLG
+# This file is distributed under the GPL-2.0-or-later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Backup - JLG 2.0.3\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/backup-jlg\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-10-01T15:10:14+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: backup-jlg\n"
+
+#. Plugin Name of the plugin
+#: backup-jlg.php
+#: includes/class-bjlg-admin.php:51
+#: includes/class-bjlg-admin.php:571
+msgid "Backup - JLG"
+msgstr ""
+
+#. Plugin URI of the plugin
+#. Author URI of the plugin
+#: backup-jlg.php
+msgid "https://jlg.dev"
+msgstr ""
+
+#. Description of the plugin
+#: backup-jlg.php
+msgid "Sauvegarde & restauration pour WordPress avec chiffrement, API REST et intégrations."
+msgstr ""
+
+#. Author of the plugin
+#: backup-jlg.php
+msgid "JLG"
+msgstr ""
+
+#: includes/class-bjlg-actions.php:81
+#: includes/class-bjlg-rest-api.php:1791
+#: includes/class-bjlg-rest-api.php:1814
+msgid "Impossible de créer un token de téléchargement."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:38
+msgid "Sauvegarde & Restauration"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:39
+msgid "Historique"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:40
+msgid "Bilan de Santé"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:41
+msgid "Réglages"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:42
+msgid "Logs & Outils"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:123
+msgid "Créer une sauvegarde"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:125
+msgid "Choisissez les composants à inclure dans votre sauvegarde."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:129
+msgid "Contenu de la sauvegarde"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:132
+msgid "Base de données"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:132
+msgid "Toutes les tables WordPress"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:133
+msgid "Extensions"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:134
+msgid "Thèmes"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:135
+msgid "Médias"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:140
+#: includes/class-bjlg-admin.php:313
+msgid "Options"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:145
+msgid "Chiffrer la sauvegarde (AES-256)"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:148
+msgid "Sécurise votre fichier de sauvegarde avec un chiffrement robuste. Indispensable si vous stockez vos sauvegardes sur un service cloud tiers."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:153
+msgid "Sauvegarde incrémentale"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:156
+msgid "Ne sauvegarde que les fichiers modifiés depuis la dernière sauvegarde complète. Plus rapide et utilise moins d'espace disque."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:165
+msgid "Lancer la création de la sauvegarde"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:170
+msgid "Progression"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:172
+msgid "Initialisation..."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:175
+#: includes/class-bjlg-admin.php:329
+msgid "Détails techniques"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:189
+msgid "Sauvegardes disponibles"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:196
+#: includes/class-bjlg-admin.php:209
+msgid "Nom du fichier"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:197
+#: includes/class-bjlg-admin.php:213
+msgid "Type"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:198
+#: includes/class-bjlg-admin.php:233
+msgid "Taille"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:199
+#: includes/class-bjlg-admin.php:234
+#: includes/class-bjlg-admin.php:348
+#: includes/class-bjlg-admin.php:376
+msgid "Date"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:200
+#: includes/class-bjlg-admin.php:235
+msgid "Actions"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:211
+msgid "Chiffré"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:218
+msgid "Complète"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:223
+msgid "Incrémentale"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:228
+msgid "Standard"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:237
+msgid "Restaurer"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:238
+msgid "Télécharger"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:239
+msgid "Supprimer"
+msgstr ""
+
+#. translators: %d: number of backups
+#: includes/class-bjlg-admin.php:252
+#, php-format
+msgid "Total : %d sauvegarde(s)"
+msgstr ""
+
+#. translators: %s: total backup size
+#: includes/class-bjlg-admin.php:258
+#, php-format
+msgid "Espace utilisé : %s"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:266
+msgid "Aucune sauvegarde locale trouvée. Créez votre première sauvegarde ci-dessus."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:278
+msgid "Restaurer depuis un fichier"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:279
+msgid "Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:284
+msgid "Fichier de sauvegarde"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:287
+msgid "Formats acceptés : .zip, .zip.enc (chiffré)"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:291
+msgid "Mot de passe"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:299
+msgid "Requis pour les archives .zip.enc"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:302
+msgid "Requis pour restaurer les sauvegardes chiffrées (.zip.enc). Laissez vide pour les archives non chiffrées."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:303
+msgid "Mot de passe obligatoire : renseignez-le pour déchiffrer l'archive (.zip.enc)."
+msgstr ""
+
+#. translators: %s: file extension
+#: includes/class-bjlg-admin.php:306
+#, php-format
+msgid "Requis pour restaurer les sauvegardes chiffrées (%s). Laissez vide pour les archives non chiffrées."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:314
+msgid "Créer une sauvegarde de sécurité avant la restauration"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:320
+msgid "Téléverser et restaurer"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:324
+msgid "Statut de la restauration"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:326
+msgid "Préparation..."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:343
+msgid "Historique des 50 dernières actions"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:349
+#: includes/class-bjlg-admin.php:377
+msgid "Action"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:350
+#: includes/class-bjlg-admin.php:378
+msgid "Statut"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:351
+#: includes/class-bjlg-admin.php:379
+msgid "Détails"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:361
+msgid "Succès"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:366
+msgid "Échec"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:372
+msgid "Information"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:385
+msgid "Aucun historique trouvé."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:387
+msgid "L'historique est conservé pendant 30 jours. Les entrées plus anciennes sont automatiquement supprimées."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:399
+msgid "Mode Débogage"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:400
+msgid "Tâches planifiées (Cron)"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:403
+msgid "Dossier de sauvegarde"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:404
+msgid "Espace disque"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:405
+msgid "Limite Mémoire PHP"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:406
+msgid "Temps d'exécution PHP"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:410
+msgid "Bilan de santé du système"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:411
+msgid "État du plugin"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:423
+msgid "Configuration serveur"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:435
+msgid "Relancer les vérifications"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:450
+msgid "Configuration du plugin"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:452
+msgid "Destinations cloud"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:461
+msgid "Aucune destination cloud configurée. Activez Google Drive ou Amazon S3 en complétant leurs réglages."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:466
+msgid "Planification des sauvegardes"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:470
+msgid "Fréquence"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:473
+msgid "Désactivée"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:474
+msgid "Toutes les heures"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:475
+msgid "Journalière"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:476
+msgid "Hebdomadaire"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:477
+msgid "Mensuelle"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:482
+msgid "Jour de la semaine"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:486
+msgid "Lundi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:487
+msgid "Mardi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:488
+msgid "Mercredi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:489
+msgid "Jeudi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:490
+msgid "Vendredi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:491
+msgid "Samedi"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:492
+msgid "Dimanche"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:501
+msgid "Heure"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:504
+msgid "Heure locale du serveur"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:508
+msgid "Enregistrer la planification"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:511
+msgid "Webhook"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:512
+msgid "Utilisez ce point de terminaison pour déclencher une sauvegarde à distance en toute sécurité :"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:514
+msgid "Point de terminaison"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:517
+msgid "Copier l'URL"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:521
+msgid "Clé secrète"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:524
+msgid "Copier la clé"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:525
+msgid "Régénérer"
+msgstr ""
+
+#. translators: %s: HTTP header name
+#: includes/class-bjlg-admin.php:531
+#, php-format
+msgid "Envoyez une requête %1$sPOST%2$s à l'URL ci-dessus en ajoutant l'en-tête %3$s (ou %4$sAuthorization: Bearer &lt;clé&gt;%5$s) contenant votre clé."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:540
+msgid "Compatibilité :"
+msgstr ""
+
+#. translators: %s: legacy webhook URL
+#: includes/class-bjlg-admin.php:542
+#, php-format
+msgid "L'ancien format %s reste supporté provisoirement mais sera retiré après la période de transition."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:548
+msgid "Rétention des sauvegardes"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:551
+msgid "Conserver par nombre"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:553
+msgid "sauvegardes"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:554
+#: includes/class-bjlg-admin.php:561
+msgid "0 = illimité"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:558
+msgid "Conserver par ancienneté"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:560
+msgid "jours"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:566
+msgid "Marque blanche"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:569
+msgid "Nom du plugin"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:572
+msgid "Laissez vide pour utiliser le nom par défaut"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:576
+msgid "Visibilité"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:577
+msgid "Cacher le plugin pour les non-administrateurs"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:581
+msgid "Enregistrer les réglages"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:594
+msgid "Journaux et outils de diagnostic"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:596
+msgid "Emplacements des fichiers"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:598
+msgid "Sauvegardes :"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:599
+msgid "Journal du plugin :"
+msgstr ""
+
+#. translators: %s: constant name.
+#: includes/class-bjlg-admin.php:602
+#: includes/class-bjlg-admin.php:609
+#, php-format
+msgid "si %s est activé"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:606
+msgid "Journal d'erreurs WP :"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:616
+msgid "Journal d'activité du plugin"
+msgstr ""
+
+#. translators: 1: opening code tag, 2: closing code tag, 3: opening wp-config code tag, 4: closing wp-config code tag.
+#: includes/class-bjlg-admin.php:621
+#, php-format
+msgid "Pour activer : ajoutez %1$sdefine('BJLG_DEBUG', true);%2$s dans votre %3$swp-config.php%4$s"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:629
+#: includes/class-bjlg-admin.php:644
+msgid "Classe BJLG_Debug non trouvée."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:631
+msgid "Journal d'erreurs PHP de WordPress"
+msgstr ""
+
+#. translators: 1: opening code tag, 2: closing code tag, 3: opening wp-config code tag, 4: closing wp-config code tag.
+#: includes/class-bjlg-admin.php:636
+#, php-format
+msgid "Pour activer : ajoutez %1$sdefine('WP_DEBUG_LOG', true);%2$s dans votre %3$swp-config.php%4$s"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:646
+msgid "Outils de support"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:647
+msgid "Générez un pack de support contenant les journaux et les informations système pour faciliter le diagnostic."
+msgstr ""
+
+#: includes/class-bjlg-admin.php:650
+msgid "Créer un pack de support"
+msgstr ""
+
+#: includes/class-bjlg-admin.php:654
+msgid "Génération du pack de support en cours..."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:111
+msgid "Le paramètre per_page doit être un entier compris entre 1 et 100."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:261
+msgid "Le paramètre limit doit être un entier compris entre 1 et 500."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:321
+msgid "Trop de requêtes. Veuillez patienter."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:447
+#: includes/class-bjlg-rest-api.php:1036
+msgid "Cette clé API n'est associée à aucun utilisateur."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:460
+msgid "L'utilisateur associé à cette clé API est introuvable."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:471
+msgid "Les permissions de l'utilisateur lié à cette clé API sont insuffisantes."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:879
+msgid "Token JWT invalide."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:892
+msgid "Le token JWT est mal formé."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:901
+msgid "Impossible de décoder le token JWT."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:909
+msgid "Le token JWT est invalide."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:917
+msgid "Le token JWT a expiré."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:925
+msgid "Clé d’authentification WordPress manquante."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:936
+msgid "La signature du token JWT est invalide."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:947
+msgid "Les informations utilisateur sont manquantes dans le token."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:965
+msgid "Utilisateur introuvable pour ce token."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:975
+msgid "Les permissions de cet utilisateur ne sont plus valides."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1054
+msgid "Cette clé API ne peut pas être utilisée pour cet utilisateur."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1135
+msgid "La clé AUTH_KEY est manquante; impossible de générer un token JWT."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1294
+msgid "Aucun composant valide fourni pour la sauvegarde."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1349
+#: includes/class-bjlg-webhooks.php:295
+msgid "Une sauvegarde est déjà en cours. Réessayez ultérieurement."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1361
+#: includes/class-bjlg-webhooks.php:317
+msgid "Impossible d'initialiser la sauvegarde. Veuillez réessayer."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1375
+#: includes/class-bjlg-webhooks.php:335
+msgid "Impossible de planifier la tâche de sauvegarde en arrière-plan."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1403
+#: includes/class-bjlg-rest-api.php:2052
+msgid "Format de composant invalide."
+msgstr ""
+
+#. translators: %s: invalid settings key.
+#: includes/class-bjlg-rest-api.php:1446
+#: includes/class-bjlg-rest-api.php:1509
+#, php-format
+msgid "The \"%s\" setting cannot be updated via the REST API."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1463
+msgid "No valid settings were provided."
+msgstr ""
+
+#. translators: %s: settings key.
+#: includes/class-bjlg-rest-api.php:1477
+#, php-format
+msgid "The \"%s\" setting must be a JSON object."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1499
+msgid "The settings sanitizer is not available."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1535
+msgid "Cleanup settings must be provided as a JSON object."
+msgstr ""
+
+#. translators: %s: cleanup setting key.
+#: includes/class-bjlg-rest-api.php:1546
+#, php-format
+msgid "Missing cleanup setting \"%s\"."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1560
+msgid "Cleanup settings must contain valid integers."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1575
+msgid "Schedule settings must be provided as a JSON object."
+msgstr ""
+
+#. translators: %s: schedule setting key.
+#: includes/class-bjlg-rest-api.php:1588
+#, php-format
+msgid "Missing schedule setting \"%s\"."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1602
+msgid "Invalid schedule recurrence value."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1613
+msgid "Invalid schedule day value."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1623
+msgid "Invalid schedule time format. Expected HH:MM."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1637
+msgid "At least one valid component must be provided for the schedule."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1648
+msgid "Schedule boolean settings must be true or false."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1761
+msgid "Le token de téléchargement fourni est invalide ou expiré."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1774
+msgid "Le token fourni ne correspond pas à cette sauvegarde."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1830
+msgid "La sauvegarde demandée est introuvable."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1831
+msgid "Impossible de déterminer la taille de la sauvegarde."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1894
+msgid "Aucun composant valide fourni pour la restauration."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1964
+msgid "Impossible de sécuriser le mot de passe fourni."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:1992
+msgid "Impossible d'initialiser la tâche de restauration."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:2023
+msgid "Impossible de planifier la tâche de restauration en arrière-plan."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:2218
+msgid "The request payload must be a JSON object with settings data."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:2280
+msgid "The request payload must be a JSON object with schedule data."
+msgstr ""
+
+#: includes/class-bjlg-rest-api.php:2313
+msgid "Invalid task identifier."
+msgstr ""
+
+#: includes/class-bjlg-scheduler.php:63
+msgid "Une fois par semaine"
+msgstr ""
+
+#: includes/class-bjlg-scheduler.php:68
+msgid "Une fois par mois"
+msgstr ""
+
+#: includes/class-bjlg-scheduler.php:73
+msgid "Deux fois par jour"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:118
+#: includes/class-bjlg-settings.php:294
+#: includes/class-bjlg-settings.php:317
+#: includes/class-bjlg-settings.php:356
+#: includes/class-bjlg-settings.php:403
+msgid "Permission refusée."
+msgstr ""
+
+#. translators: %s: serialized cleanup settings.
+#: includes/class-bjlg-settings.php:135
+#, php-format
+msgid "Réglages de nettoyage sauvegardés : %s"
+msgstr ""
+
+#. translators: %s: serialized whitelabel settings.
+#: includes/class-bjlg-settings.php:150
+#, php-format
+msgid "Réglages de marque blanche sauvegardés : %s"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:165
+msgid "Réglages de chiffrement sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:178
+msgid "Identifiants Google Drive sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:201
+msgid "Réglages Amazon S3 sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:231
+msgid "Réglages de notifications sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:243
+msgid "Réglages de performance sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:259
+msgid "Réglages de webhooks sauvegardés."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:267
+msgid "Réglage du débogueur AJAX mis à jour."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:270
+msgid "Les réglages ont été mis à jour."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:275
+msgid "Réglages sauvegardés avec succès !"
+msgstr ""
+
+#. translators: %s: error message.
+#: includes/class-bjlg-settings.php:282
+#: includes/class-bjlg-settings.php:453
+#, php-format
+msgid "Erreur : %s"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:330
+msgid "Tous les réglages ont été réinitialisés"
+msgstr ""
+
+#. translators: %s: settings section key.
+#: includes/class-bjlg-settings.php:336
+#, php-format
+msgid "Réglages '%s' réinitialisés"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:340
+msgid "Section de réglages invalide."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:344
+msgid "Réglages réinitialisés avec succès."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:390
+msgid "Paramètres exportés"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:408
+msgid "Aucune donnée à importer."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:416
+msgid "Format de données invalide."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:423
+msgid "Les paramètres proviennent d'une version plus récente du plugin."
+msgstr ""
+
+#: includes/class-bjlg-settings.php:431
+msgid "Aucun réglage valide à importer."
+msgstr ""
+
+#. translators: %s: source site URL.
+#: includes/class-bjlg-settings.php:443
+#, php-format
+msgid "Paramètres importés depuis %s"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:444
+msgid "inconnu"
+msgstr ""
+
+#: includes/class-bjlg-settings.php:448
+msgid "Paramètres importés avec succès."
+msgstr ""
+
+#: includes/class-bjlg-webhooks.php:185
+msgid "Missing webhook key. Provide it via the X-BJLG-Webhook-Key header or POST body."
+msgstr ""
+
+#. translators: %s: comma-separated list of allowed components.
+#: includes/class-bjlg-webhooks.php:256
+#, php-format
+msgid "No valid components were requested. Allowed components are: %s."
+msgstr ""
+
+#: includes/class-bjlg-webhooks.php:274
+msgid "Too many webhook requests. Please slow down."
+msgstr ""


### PR DESCRIPTION
## Summary
- replace hardcoded admin UI labels with translation functions and escaping helpers
- translate settings API feedback and add translator comments for placeholder strings
- generate an updated `backup-jlg.pot` containing the new strings

## Testing
- php wp-cli.phar i18n make-pot backup-jlg backup-jlg/languages/backup-jlg.pot --slug=backup-jlg --allow-root

------
https://chatgpt.com/codex/tasks/task_e_68dd42550578832e82e4996878ce0e84