### PR TITLE
Improve accessibility of backup progress UI

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -99,6 +99,18 @@
     transition: width 0.4s ease;
 }
 
+.bjlg-inline-notice.notice {
+    margin-top: 12px;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.bjlg-inline-notice.notice p {
+    margin: 0;
+}
+
 @media screen and (max-width: 782px) {
     .bjlg-responsive-table {
         border: 0;
@@ -176,5 +188,10 @@
 
     .bjlg-responsive-table .bjlg-card-actions .button .dashicons {
         margin-right: 6px;
+    }
+
+    .bjlg-inline-notice.notice {
+        flex-direction: column;
+        align-items: stretch;
     }
 }

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -168,8 +168,12 @@ class BJLG_Admin {
             </form>
             <div id="bjlg-backup-progress-area" style="display: none;">
                 <h3>Progression</h3>
-                <div class="bjlg-progress-bar"><div class="bjlg-progress-bar-inner" id="bjlg-backup-progress-bar">0%</div></div>
-                <p id="bjlg-backup-status-text">Initialisation...</p>
+                <div class="bjlg-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="bjlg-progress-bar-inner" id="bjlg-backup-progress-bar">0%</div>
+                </div>
+                <div id="bjlg-backup-status" class="notice notice-info bjlg-inline-notice" role="status" aria-live="polite">
+                    <p id="bjlg-backup-status-text">Initialisation...</p>
+                </div>
             </div>
             <div id="bjlg-backup-debug-wrapper" style="display: none;">
                 <h3><span class="dashicons dashicons-info"></span> Détails techniques</h3>


### PR DESCRIPTION
## Summary
- add aria roles to the backup progress area and surface status updates in an inline notice
- update the admin script to remove window alerts, report errors inline, and keep aria progress values in sync
- introduce responsive styles so the inline status notice remains readable on narrow viewports

## Testing
- Manual viewport check at 600px (Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68dd4256da24832e9a4ff1226ea05fc8