### PR TITLE
Add AWS KMS configuration support for S3 destination

### DIFF
--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -178,12 +178,17 @@ class BJLG_Settings {
                     'region' => isset($_POST['s3_region']) ? sanitize_text_field(wp_unslash($_POST['s3_region'])) : '',
                     'bucket' => isset($_POST['s3_bucket']) ? sanitize_text_field(wp_unslash($_POST['s3_bucket'])) : '',
                     'server_side_encryption' => isset($_POST['s3_server_side_encryption']) ? sanitize_text_field(wp_unslash($_POST['s3_server_side_encryption'])) : '',
+                    'kms_key_id' => isset($_POST['s3_kms_key_id']) ? sanitize_text_field(wp_unslash($_POST['s3_kms_key_id'])) : '',
                     'object_prefix' => isset($_POST['s3_object_prefix']) ? sanitize_text_field(wp_unslash($_POST['s3_object_prefix'])) : '',
                     'enabled' => isset($_POST['s3_enabled']) ? $this->to_bool(wp_unslash($_POST['s3_enabled'])) : false,
                 ];
 
                 if (!in_array($s3_settings['server_side_encryption'], ['AES256', 'aws:kms'], true)) {
                     $s3_settings['server_side_encryption'] = '';
+                }
+
+                if ($s3_settings['server_side_encryption'] !== 'aws:kms') {
+                    $s3_settings['kms_key_id'] = '';
                 }
 
                 $s3_settings['object_prefix'] = trim($s3_settings['object_prefix']);

--- a/backup-jlg/tests/BJLG_AdminDestinationsUITest.php
+++ b/backup-jlg/tests/BJLG_AdminDestinationsUITest.php
@@ -32,5 +32,6 @@ final class BJLG_AdminDestinationsUITest extends TestCase
         $this->assertStringContainsString('Amazon S3', $html);
         $this->assertStringContainsString("name='s3_access_key'", $html);
         $this->assertStringContainsString('bjlg-s3-test-connection', $html);
+        $this->assertStringContainsString("name='s3_kms_key_id'", $html);
     }
 }


### PR DESCRIPTION
## Summary
- add an AWS KMS key field to the Amazon S3 destination form and include the key in signed requests when using SSE-KMS
- persist and sanitise the new KMS identifier through settings saving and connection testing flows
- extend the S3 destination unit tests and admin UI test to cover the new encryption option

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd429b50b0832eb165786bf99c56b6