### PR TITLE
Update API documentation link

### DIFF
--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -1010,7 +1010,7 @@ class BJLG_REST_API {
                 'requests_per_minute' => 60,
                 'requests_per_hour' => 1000
             ],
-            'documentation' => get_site_url() . '/wp-admin/admin.php?page=backup-jlg&tab=api_docs'
+            'documentation' => admin_url('admin.php?page=backup-jlg&tab=api')
         ]);
     }
     

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -125,6 +125,7 @@ namespace {
         private static $tests_without_auth_key = [
             'test_a_authenticate_returns_error_when_auth_key_missing',
             'test_client_ip_helper_ignores_untrusted_forwarded_for',
+            'test_api_info_documentation_points_to_api_tab',
         ];
 
         public function runBare(): void
@@ -207,6 +208,21 @@ namespace {
                     'user_id' => $user_id,
                 ];
             }, 10, 4);
+        }
+
+        public function test_api_info_documentation_points_to_api_tab(): void
+        {
+            $api = new BJLG\BJLG_REST_API();
+
+            $response = $api->get_api_info(new class() {
+            });
+
+            $this->assertIsArray($response);
+            $this->assertArrayHasKey('documentation', $response);
+            $this->assertSame(
+                admin_url('admin.php?page=backup-jlg&tab=api'),
+                $response['documentation']
+            );
         }
 
         private function makeUser(int $id, string $login, ?array $caps = null, ?array $roles = null): object


### PR DESCRIPTION
## Summary
- update the API info endpoint to build the documentation URL with the API tab
- add a PHPUnit test that ensures the documentation link targets the API tab

## Testing
- ./vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dda1d5a7d4832ea6c18b663e4da076