### PR TITLE
Add configurable backup filters, post-checks, and destination fallback

### DIFF
--- a/backup-jlg/tests/BJLG_SchedulerTest.php
+++ b/backup-jlg/tests/BJLG_SchedulerTest.php
@@ -163,6 +163,10 @@ final class BJLG_SchedulerTest extends TestCase
             'components' => ['db', 'plugins'],
             'encrypt' => 'true',
             'incremental' => 'true',
+            'include_patterns' => "wp-content/uploads/*\ncustom/*",
+            'exclude_patterns' => "*/cache/*\n*.tmp",
+            'post_checks' => ['checksum'],
+            'secondary_destinations' => ['google_drive', 'aws_s3'],
         ];
 
         $scheduler = BJLG\BJLG_Scheduler::instance();
@@ -185,6 +189,19 @@ final class BJLG_SchedulerTest extends TestCase
         $this->assertSame(['db', 'plugins'], $settings['components']);
         $this->assertTrue($settings['encrypt']);
         $this->assertTrue($settings['incremental']);
+        $this->assertSame(['wp-content/uploads/*', 'custom/*'], $settings['include_patterns']);
+        $this->assertSame(['*/cache/*', '*.tmp'], $settings['exclude_patterns']);
+        $this->assertTrue($settings['post_checks']['checksum']);
+        $this->assertFalse($settings['post_checks']['dry_run']);
+        $this->assertSame(['google_drive', 'aws_s3'], $settings['secondary_destinations']);
+
+        $this->assertSame(['wp-content/uploads/*', 'custom/*'], get_option('bjlg_backup_include_patterns'));
+        $this->assertSame(['*/cache/*', '*.tmp'], get_option('bjlg_backup_exclude_patterns'));
+        $this->assertSame(['google_drive', 'aws_s3'], get_option('bjlg_backup_secondary_destinations'));
+        $this->assertSame(
+            ['checksum' => true, 'dry_run' => false],
+            get_option('bjlg_backup_post_checks')
+        );
 
         $this->assertArrayHasKey(
             BJLG\BJLG_Scheduler::SCHEDULE_HOOK,


### PR DESCRIPTION
## Summary
- expose custom include/exclude patterns, post-backup checks, and secondary destination pickers in the manual backup and scheduling forms, with matching JavaScript serialization and summaries
- persist the new backup preferences through BJLG_Settings/BJLG_Scheduler and honour them in BJLG_Backup, including checksum/dry-run verification and destination fallback handling
- update Google Drive and Amazon S3 destinations to accept batches, log failures, and add PHPUnit coverage for the new scheduler, backup, and destination flows

## Testing
- `composer test` *(fails: phpunit not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8acd5738832ea5f535fc86511795