### PR TITLE
Improve backup toolbar layout responsiveness

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -22,6 +22,54 @@
     margin-top: 25px;
 }
 
+.bjlg-backup-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.bjlg-toolbar-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.bjlg-toolbar-controls label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bjlg-toolbar-controls select {
+    min-width: 180px;
+}
+
+.bjlg-toolbar-controls .button {
+    align-self: flex-start;
+}
+
+.bjlg-toolbar-summary {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+    margin-left: auto;
+    align-self: flex-end;
+}
+
+.bjlg-summary-label {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.bjlg-summary-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: flex-end;
+}
+
 /* Navigation par onglets
 --------------------------------------------- */
 
@@ -100,6 +148,39 @@
 }
 
 @media screen and (max-width: 782px) {
+    .bjlg-backup-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 20px;
+    }
+
+    .bjlg-toolbar-controls {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 16px;
+    }
+
+    .bjlg-toolbar-controls label,
+    .bjlg-toolbar-controls select,
+    .bjlg-toolbar-controls .button {
+        width: 100%;
+    }
+
+    .bjlg-toolbar-controls select {
+        min-width: 0;
+    }
+
+    .bjlg-toolbar-summary {
+        flex-direction: column;
+        align-items: flex-start;
+        align-self: stretch;
+        gap: 6px;
+    }
+
+    .bjlg-summary-content {
+        width: 100%;
+    }
+
     .bjlg-responsive-table {
         border: 0;
         width: 100%;

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -275,7 +275,7 @@ class BJLG_Admin {
         <div class="bjlg-section" id="bjlg-backup-list-section" data-default-page="1" data-default-per-page="10">
             <h2>Sauvegardes Disponibles</h2>
             <div class="bjlg-backup-toolbar">
-                <div class="alignleft actions">
+                <div class="bjlg-toolbar-controls actions">
                     <label for="bjlg-backup-filter-type">
                         <span class="screen-reader-text">Filtrer par type</span>
                         <select id="bjlg-backup-filter-type" aria-label="Filtrer les sauvegardes par type">
@@ -300,7 +300,10 @@ class BJLG_Admin {
                         Actualiser
                     </button>
                 </div>
-                <div class="alignright" id="bjlg-backup-summary" aria-live="polite"></div>
+                <div class="bjlg-toolbar-summary">
+                    <span class="bjlg-summary-label">Résumé :</span>
+                    <div class="bjlg-summary-content" id="bjlg-backup-summary" aria-live="polite"></div>
+                </div>
             </div>
             <div id="bjlg-backup-list-feedback" class="notice notice-error" role="alert" style="display:none;"></div>
             <table class="wp-list-table widefat striped bjlg-responsive-table bjlg-backup-table">


### PR DESCRIPTION
## Summary
- refactor the backup toolbar markup to use explicit flexbox-friendly wrappers and add a visible summary label
- style the toolbar with flexbox spacing and introduce a responsive column layout for narrow screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9f672324832e9101b08590c6e447