### PR TITLE
Improve Google Drive connection test feedback

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -1717,6 +1717,7 @@ jQuery(document).ready(function($) {
             }
 
             const testedAtFormatted = data && data.tested_at_formatted ? String(data.tested_at_formatted) : '';
+            const testedAtRaw = data && typeof data.tested_at !== 'undefined' ? Number(data.tested_at) : null;
             const statusMessage = data && data.status_message ? String(data.status_message) : (fallbackMessage ? String(fallbackMessage) : '');
             const parts = [];
 
@@ -1745,6 +1746,14 @@ jQuery(document).ready(function($) {
                 .append($('<span/>', { class: iconClass, 'aria-hidden': 'true' }))
                 .append(document.createTextNode(' ' + parts.join(' ')))
                 .show();
+
+            if (testedAtRaw && Number.isFinite(testedAtRaw)) {
+                $lastTest.attr('data-bjlg-tested-at', testedAtRaw);
+                $container.attr('data-bjlg-tested-at', testedAtRaw);
+            } else {
+                $lastTest.removeAttr('data-bjlg-tested-at');
+                $container.removeAttr('data-bjlg-tested-at');
+            }
         }
 
         $.post(bjlg_ajax.ajax_url, payload)

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -150,7 +150,8 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
             $last_test_style = " style='display:none;'";
         }
 
-        echo "<p class='{$last_test_classes}'{$last_test_style}>{$last_test_content}</p>";
+        $last_test_aria = " role='status' aria-live='polite'";
+        echo "<p class='{$last_test_classes}'{$last_test_style}{$last_test_aria}>{$last_test_content}</p>";
 
         if (!$settings['enabled']) {
             echo "<p class='description'>Enregistrez vos identifiants puis activez Google Drive pour poursuivre la connexion.</p>";
@@ -437,6 +438,10 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
                 'folder_name' => $result['folder_name'],
             ];
 
+            if (class_exists(BJLG_Debug::class)) {
+                BJLG_Debug::log('Test de connexion Google Drive réussi. ' . $result['message']);
+            }
+
             wp_send_json_success($response);
         } catch (Exception $exception) {
             $tested_at = time();
@@ -453,7 +458,11 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
                 'tested_at_formatted' => gmdate('d/m/Y H:i:s', $tested_at),
             ];
 
-            wp_send_json_error($response);
+            if (class_exists(BJLG_Debug::class)) {
+                BJLG_Debug::log('ERREUR test connexion Google Drive : ' . $exception->getMessage());
+            }
+
+            wp_send_json_error($response, 400);
         }
     }
 


### PR DESCRIPTION
## Summary
- add aria-live feedback container and debug logging around Google Drive connection checks
- return explicit HTTP errors on failed Drive tests and capture success diagnostics
- persist the last Drive test timestamp in the admin UI when AJAX requests complete

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f642ed8832e9ce1a8e10d47c792