### PR TITLE
Fix post-check sanitization and update test scaffolding

### DIFF
--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -864,8 +864,16 @@ class BJLG_Settings {
         ];
 
         if (is_array($checks)) {
-            foreach ($checks as $check) {
-                $key = sanitize_key((string) $check);
+            foreach ($checks as $maybe_key => $value) {
+                if (is_string($maybe_key)) {
+                    $key = sanitize_key($maybe_key);
+                    if (array_key_exists($key, $normalized)) {
+                        $normalized[$key] = (bool) $value;
+                    }
+                    continue;
+                }
+
+                $key = sanitize_key((string) $value);
                 if (array_key_exists($key, $normalized)) {
                     $normalized[$key] = true;
                 }

--- a/backup-jlg/tests/BJLG_RestoreSecurityTest.php
+++ b/backup-jlg/tests/BJLG_RestoreSecurityTest.php
@@ -284,7 +284,15 @@ final class BJLG_RestoreSecurityTest extends TestCase
                 file_put_contents($filepath, 'SQL-DUMP');
             }
 
-            public function add_folder_to_zip(&$zip, $folder, $zip_path, $exclude = [], $incremental = false, $modified_files = [])
+            public function add_folder_to_zip(
+                &$zip,
+                $folder,
+                $zip_path,
+                $exclude = [],
+                $incremental = false,
+                $modified_files = [],
+                array $include = []
+            )
             {
                 if ($zip instanceof \ZipArchive) {
                     $zip->addFromString(rtrim($zip_path, '/') . '/placeholder.txt', 'placeholder');

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -31,6 +31,30 @@ if (!function_exists('esc_url')) {
     }
 }
 
+if (!function_exists('esc_textarea')) {
+    function esc_textarea($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = []) {
+        if (is_object($args)) {
+            $args = get_object_vars($args);
+        }
+
+        if (!is_array($args)) {
+            $args = [];
+        }
+
+        if (!is_array($defaults)) {
+            $defaults = [];
+        }
+
+        return array_merge($defaults, $args);
+    }
+}
+
 if (!defined('WP_CONTENT_DIR')) {
     $wp_content_dir = sys_get_temp_dir() . '/bjlg-wp-content';
     if (!is_dir($wp_content_dir)) {


### PR DESCRIPTION
## Summary
- handle associative post-check arrays when sanitizing saved settings so scheduled backups keep checksum checks enabled
- extend the PHPUnit bootstrap with esc_textarea/wp_parse_args stubs and update the restore backup stub to match the production signature

## Testing
- ./vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de9f1981d8832e9ba25719b862a084