### PR TITLE
Fix advanced admin metric card styles

### DIFF
--- a/backup-jlg/assets/css/admin-advanced.css
+++ b/backup-jlg/assets/css/admin-advanced.css
@@ -728,49 +728,85 @@ pre.code-block {
     .chart-container {
         height: 250px;
     }
-}card {
+}
+
+/* ========================================
+   METRIC CARDS
+   ======================================== */
+
+.metric-root {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.metric-card {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border-radius: 12px;
-    padding: 25px;
-    text-align: center;
+    color: #ffffff;
+    border-radius: 14px;
+    padding: 24px;
     position: relative;
     overflow: hidden;
-    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 10px 30px rgba(102, 126, 234, 0.2);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .metric-card:hover {
-    transform: translateY(-5px);
+    transform: translateY(-6px);
+    box-shadow: 0 16px 40px rgba(118, 75, 162, 0.3);
 }
 
 .metric-card::before {
     content: '';
     position: absolute;
-    top: -50%;
-    right: -50%;
-    width: 200%;
-    height: 200%;
-    background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
-    animation: pulse 3s ease-in-out infinite;
+    top: -45%;
+    right: -45%;
+    width: 190%;
+    height: 190%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.18) 0%, transparent 65%);
+    animation: metricPulse 6s ease-in-out infinite;
+    pointer-events: none;
 }
 
-@keyframes pulse {
-    0%, 100% { transform: scale(1); opacity: 0.5; }
-    50% { transform: scale(1.1); opacity: 0.3; }
+@keyframes metricPulse {
+    0%, 100% { transform: scale(1); opacity: 0.6; }
+    50% { transform: scale(1.05); opacity: 0.3; }
+}
+
+.metric-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
+    z-index: 1;
 }
 
 .metric-icon {
-    font-size: 2.5rem;
-    margin-bottom: 15px;
+    font-size: 2rem;
+    opacity: 0.85;
+}
+
+.metric-title {
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.85;
+    margin: 0;
 }
 
 .metric-value {
-    font-size: 2rem;
-    font-weight: bold;
-    margin-bottom: 10px;
+    font-size: 2.4rem;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.2;
     position: relative;
     z-index: 1;
-    transition: all 0.3s ease;
+    transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .metric-value.updating {
@@ -779,13 +815,60 @@ pre.code-block {
 }
 
 .metric-value.updated {
-    animation: valueUpdate 0.5s ease;
+    animation: metricValueUpdate 0.4s ease;
 }
 
-@keyframes valueUpdate {
+@keyframes metricValueUpdate {
     0% { transform: scale(1); }
     50% { transform: scale(1.1); }
     100% { transform: scale(1); }
 }
 
-.metric-
+.metric-meta {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    font-size: 0.85rem;
+    position: relative;
+    z-index: 1;
+}
+
+.metric-trend {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.metric-trend.positive {
+    color: #bbf7d0;
+}
+
+.metric-trend.negative {
+    color: #fecaca;
+}
+
+.metric-footer {
+    font-size: 0.8rem;
+    opacity: 0.75;
+    margin-top: auto;
+    position: relative;
+    z-index: 1;
+}
+
+@media (max-width: 480px) {
+    .metric-root {
+        grid-template-columns: 1fr;
+    }
+
+    .metric-card {
+        padding: 20px;
+    }
+
+    .metric-value {
+        font-size: 2rem;
+    }
+}


### PR DESCRIPTION
## Summary
- restore the responsive media query closure and reintroduce the metric card styles for the advanced admin view
- define refreshed `.metric-card` design with gradient background, hover feedback, and supporting layout classes
- normalize the stylesheet to UTF-8 with consistent LF line endings to prevent truncation issues

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68debe342550832e9297a56adee38669