### PR TITLE
Refine advanced admin metric card styles

### DIFF
--- a/backup-jlg/assets/css/admin-advanced.css
+++ b/backup-jlg/assets/css/admin-advanced.css
@@ -736,96 +736,112 @@ pre.code-block {
 
 .metric-root {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 20px;
-    margin-top: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
 }
 
 .metric-card {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
     color: #ffffff;
-    border-radius: 14px;
-    padding: 24px;
+    border-radius: 16px;
+    padding: 28px;
     position: relative;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    box-shadow: 0 10px 30px rgba(102, 126, 234, 0.2);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    gap: 14px;
+    min-height: 180px;
+    box-shadow: 0 12px 32px rgba(79, 70, 229, 0.25);
+    transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.metric-card::before,
+.metric-card::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    filter: blur(0);
+    transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+.metric-card::before {
+    width: 280px;
+    height: 280px;
+    top: -140px;
+    right: -120px;
+}
+
+.metric-card::after {
+    width: 200px;
+    height: 200px;
+    bottom: -130px;
+    left: -90px;
+    background: rgba(255, 255, 255, 0.12);
 }
 
 .metric-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(118, 75, 162, 0.3);
+    box-shadow: 0 18px 45px rgba(124, 58, 237, 0.35);
 }
 
-.metric-card::before {
-    content: '';
-    position: absolute;
-    top: -45%;
-    right: -45%;
-    width: 190%;
-    height: 190%;
-    background: radial-gradient(circle, rgba(255, 255, 255, 0.18) 0%, transparent 65%);
-    animation: metricPulse 6s ease-in-out infinite;
-    pointer-events: none;
-}
-
-@keyframes metricPulse {
-    0%, 100% { transform: scale(1); opacity: 0.6; }
-    50% { transform: scale(1.05); opacity: 0.3; }
+.metric-card:hover::before,
+.metric-card:hover::after {
+    opacity: 0.9;
+    transform: scale(1.05);
 }
 
 .metric-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
-    width: 100%;
     position: relative;
     z-index: 1;
 }
 
 .metric-icon {
-    font-size: 2rem;
-    opacity: 0.85;
+    font-size: 2.25rem;
+    opacity: 0.9;
+    line-height: 1;
 }
 
 .metric-title {
+    margin: 0;
     font-size: 0.95rem;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     opacity: 0.85;
-    margin: 0;
 }
 
 .metric-value {
-    font-size: 2.4rem;
-    font-weight: 700;
     margin: 0;
-    line-height: 1.2;
+    font-size: 2.6rem;
+    font-weight: 700;
+    line-height: 1.1;
     position: relative;
     z-index: 1;
     transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .metric-value.updating {
-    opacity: 0.5;
-    transform: scale(0.95);
+    opacity: 0.55;
+    transform: scale(0.94);
 }
 
 .metric-value.updated {
-    animation: metricValueUpdate 0.4s ease;
+    animation: metricValueUpdate 0.45s ease;
 }
 
 @keyframes metricValueUpdate {
     0% { transform: scale(1); }
-    50% { transform: scale(1.1); }
+    45% { transform: scale(1.12); }
     100% { transform: scale(1); }
 }
 
 .metric-meta {
     display: flex;
+    flex-wrap: wrap;
     gap: 10px;
     align-items: center;
     font-size: 0.85rem;
@@ -837,10 +853,10 @@ pre.code-block {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 10px;
+    padding: 5px 12px;
     border-radius: 999px;
     font-weight: 600;
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.2);
 }
 
 .metric-trend.positive {
@@ -851,24 +867,56 @@ pre.code-block {
     color: #fecaca;
 }
 
+.metric-delta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: rgba(15, 23, 42, 0.25);
+    border-radius: 999px;
+    font-weight: 500;
+}
+
+.metric-delta.positive {
+    color: #bbf7d0;
+}
+
+.metric-delta.negative {
+    color: #fecaca;
+}
+
 .metric-footer {
-    font-size: 0.8rem;
-    opacity: 0.75;
     margin-top: auto;
+    font-size: 0.82rem;
+    opacity: 0.78;
     position: relative;
     z-index: 1;
 }
 
-@media (max-width: 480px) {
+.metric-sparkline {
+    position: absolute;
+    inset: 18px;
+    opacity: 0.25;
+    pointer-events: none;
+}
+
+@media (max-width: 1024px) {
+    .metric-root {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
     .metric-root {
         grid-template-columns: 1fr;
     }
 
     .metric-card {
-        padding: 20px;
+        padding: 24px;
+        min-height: 160px;
     }
 
     .metric-value {
-        font-size: 2rem;
+        font-size: 2.2rem;
     }
 }


### PR DESCRIPTION
## Summary
- redesign the advanced metrics card selector to use the intended gradient background, spacing, and hover treatments
- restore the missing metric layout helpers and responsive tweaks so the stylesheet closes correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee24ba140832ebaa6324bdcef7876