### PR TITLE
Refactor schedule section styles into reusable classes

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -93,6 +93,10 @@
     margin-bottom: 10px;
 }
 
+.bjlg-fw-600 {
+    font-weight: 600;
+}
+
 .bjlg-description-offset {
     margin-top: -4px;
 }

--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -1764,7 +1764,7 @@ jQuery(document).ready(function($) {
         const $lastTest = $container.find('.bjlg-gdrive-last-test');
 
         if ($feedback.length) {
-            $feedback.removeClass('notice-success notice-error').hide().empty();
+            $feedback.removeClass('notice-success notice-error').hide().addClass('bjlg-hidden').empty();
         }
 
         const payload = {
@@ -1880,7 +1880,7 @@ jQuery(document).ready(function($) {
 
         const $feedback = $container.find('.bjlg-s3-test-feedback');
         if ($feedback.length) {
-            $feedback.removeClass('notice-success notice-error').hide().empty();
+            $feedback.removeClass('notice-success notice-error').hide().addClass('bjlg-hidden').empty();
         }
 
         const payload = {
@@ -1936,7 +1936,7 @@ jQuery(document).ready(function($) {
         const $feedback = ensureFeedbackElement($form);
 
         if ($feedback.length) {
-            $feedback.removeClass('notice-success notice-error').hide().empty();
+            $feedback.removeClass('notice-success notice-error').hide().addClass('bjlg-hidden').empty();
         }
 
         const payload = collectFormData($form);
@@ -2007,7 +2007,7 @@ jQuery(document).ready(function($) {
         let $feedback = $form.find('.bjlg-settings-feedback');
 
         if (!$feedback.length) {
-            $feedback = $('<div class="bjlg-settings-feedback notice" role="status" aria-live="polite" style="display:none;"></div>');
+            $feedback = $('<div class="bjlg-settings-feedback notice bjlg-hidden" role="status" aria-live="polite"></div>');
             $form.prepend($feedback);
         }
 
@@ -2022,7 +2022,7 @@ jQuery(document).ready(function($) {
         const isSuccess = type === 'success';
 
         $feedback
-            .removeClass('notice-success notice-error')
+            .removeClass('notice-success notice-error bjlg-hidden')
             .addClass(isSuccess ? 'notice-success' : 'notice-error')
             .text(message)
             .show();

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -599,7 +599,7 @@ class BJLG_Admin {
             
             <h3><span class="dashicons dashicons-cloud"></span> Destinations Cloud</h3>
             <form class="bjlg-settings-form">
-                <div class="bjlg-settings-feedback notice" role="status" aria-live="polite" style="display:none;"></div>
+                <div class="bjlg-settings-feedback notice bjlg-hidden" role="status" aria-live="polite"></div>
                 <?php
                 if (!empty($this->destinations)) {
                     foreach ($this->destinations as $destination) {
@@ -823,8 +823,8 @@ class BJLG_Admin {
             
             <h3><span class="dashicons dashicons-admin-links"></span> Webhook</h3>
             <p>Utilisez ce point de terminaison pour déclencher une sauvegarde à distance en toute sécurité :</p>
-            <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
-                <label for="bjlg-webhook-endpoint" style="display:block; font-weight:600;">Point de terminaison</label>
+            <div class="bjlg-webhook-url bjlg-mb-10">
+                <label for="bjlg-webhook-endpoint" class="bjlg-label-block bjlg-fw-600">Point de terminaison</label>
                 <div class="bjlg-form-field-group">
                     <div class="bjlg-form-field-control">
                         <input type="text" id="bjlg-webhook-endpoint" readonly value="<?php echo esc_url(BJLG_Webhooks::get_webhook_endpoint()); ?>" class="regular-text code">
@@ -834,8 +834,8 @@ class BJLG_Admin {
                     </div>
                 </div>
             </div>
-            <div class="bjlg-webhook-url" style="margin-bottom: 10px;">
-                <label for="bjlg-webhook-key" style="display:block; font-weight:600;">Clé secrète</label>
+            <div class="bjlg-webhook-url bjlg-mb-10">
+                <label for="bjlg-webhook-key" class="bjlg-label-block bjlg-fw-600">Clé secrète</label>
                 <div class="bjlg-form-field-group">
                     <div class="bjlg-form-field-control">
                         <input type="text" id="bjlg-webhook-key" readonly value="<?php echo esc_attr($webhook_key); ?>" class="regular-text code">
@@ -851,7 +851,7 @@ class BJLG_Admin {
             <p class="description"><strong>Compatibilité :</strong> L'ancien format <code><?php echo esc_html(add_query_arg(BJLG_Webhooks::WEBHOOK_QUERY_VAR, 'VOTRE_CLE', home_url('/'))); ?></code> reste supporté provisoirement mais sera retiré après la période de transition.</p>
 
             <form class="bjlg-settings-form">
-                <div class="bjlg-settings-feedback notice" role="status" aria-live="polite" style="display:none;"></div>
+                <div class="bjlg-settings-feedback notice bjlg-hidden" role="status" aria-live="polite"></div>
                 <h3><span class="dashicons dashicons-trash"></span> Rétention des Sauvegardes</h3>
                 <table class="form-table">
                     <tr>

--- a/backup-jlg/includes/destinations/class-bjlg-aws-s3.php
+++ b/backup-jlg/includes/destinations/class-bjlg-aws-s3.php
@@ -105,7 +105,7 @@ class BJLG_AWS_S3 implements BJLG_Destination_Interface {
         echo "<tr><th scope='row'>Activer Amazon S3</th><td><label><input type='checkbox' name='s3_enabled' value='true'{$enabled_attr}> Activer l'envoi automatique vers Amazon S3.</label></td></tr>";
         echo "</table>";
 
-        echo "<div class='notice bjlg-s3-test-feedback' role='status' aria-live='polite' style='display:none;'></div>";
+        echo "<div class='notice bjlg-s3-test-feedback bjlg-hidden' role='status' aria-live='polite'></div>";
         echo "<p><button type='button' class='button bjlg-s3-test-connection'>Tester la connexion</button></p>";
 
         if ($status['last_result'] === 'success' && $status['tested_at'] > 0) {

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -126,7 +126,7 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
         echo "<tr><th scope='row'>Activer Google Drive</th><td><label><input type='checkbox' name='gdrive_enabled' value='true'{$enabled_attr}> Activer l'envoi automatique vers Google Drive.</label></td></tr>";
         echo "</table>";
 
-        echo "<div class='notice bjlg-gdrive-test-feedback' role='status' aria-live='polite' style='display:none;'></div>";
+        echo "<div class='notice bjlg-gdrive-test-feedback bjlg-hidden' role='status' aria-live='polite'></div>";
         echo "<p class='bjlg-gdrive-test-actions'><button type='button' class='button bjlg-gdrive-test-connection'>Tester la connexion</button> <span class='spinner bjlg-gdrive-test-spinner' style='float:none;margin:0 0 0 8px;display:none;'></span></p>";
 
         $last_test_style = '';


### PR DESCRIPTION
## Summary
- add utility classes to admin stylesheet to replace inline styles in the scheduling area
- update admin markup and JavaScript to rely on the new helpers instead of style attributes
- align cloud destination notices with the shared hidden state helper

## Testing
- php -l backup-jlg/includes/class-bjlg-admin.php
- php -l backup-jlg/includes/destinations/class-bjlg-google-drive.php
- php -l backup-jlg/includes/destinations/class-bjlg-aws-s3.php

------
https://chatgpt.com/codex/tasks/task_e_68dee3f0b6e4832ea47c6311c173c8a9