### PR TITLE
Add SFTP destination and multi-schedule support

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -89,7 +89,7 @@ final class BJLG_Plugin {
             'class-bjlg-diagnostics.php', 'class-bjlg-webhooks.php', 'class-bjlg-incremental.php',
             'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php',
             'class-bjlg-api-keys.php', 'class-bjlg-admin.php', 'class-bjlg-actions.php',
-            'destinations/interface-bjlg-destination.php', 'destinations/class-bjlg-google-drive.php', 'destinations/class-bjlg-aws-s3.php',
+            'destinations/interface-bjlg-destination.php', 'destinations/class-bjlg-google-drive.php', 'destinations/class-bjlg-aws-s3.php', 'destinations/class-bjlg-sftp.php',
         ];
         foreach ($files_to_load as $file) {
             $path = BJLG_INCLUDES_DIR . $file;

--- a/backup-jlg/tests/BJLG_AdminDestinationsUITest.php
+++ b/backup-jlg/tests/BJLG_AdminDestinationsUITest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../includes/destinations/interface-bjlg-destination.php';
 require_once __DIR__ . '/../includes/destinations/class-bjlg-aws-s3.php';
 require_once __DIR__ . '/../includes/destinations/class-bjlg-google-drive.php';
+require_once __DIR__ . '/../includes/destinations/class-bjlg-sftp.php';
 require_once __DIR__ . '/../includes/class-bjlg-webhooks.php';
 require_once __DIR__ . '/../includes/class-bjlg-admin.php';
 


### PR DESCRIPTION
## Summary
- add an SFTP destination connector with settings UI, testing hooks, and option storage
- register the SFTP connector in the plugin bootstrap and admin UI tests
- refactor scheduling admin, settings validation, scheduler, and JS to support multiple schedules with repeater UI and next-run summaries

## Testing
- php -l backup-jlg/includes/class-bjlg-admin.php
- php -l backup-jlg/includes/class-bjlg-scheduler.php
- php -l backup-jlg/includes/class-bjlg-settings.php
- php -l backup-jlg/includes/destinations/class-bjlg-sftp.php


------
https://chatgpt.com/codex/tasks/task_e_68dee50c5f20832e9871a10374f4fc58