### PR TITLE
Add admin notification and performance configuration forms

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -2209,15 +2209,20 @@ jQuery(document).ready(function($) {
         $.post(bjlg_ajax.ajax_url, payload)
             .done(function(response) {
                 const normalized = normalizeSettingsResponse(response);
+                const successMessage = $form.data('successMessage');
+                const errorMessage = $form.data('errorMessage');
+
                 if (normalized.success) {
-                    showFeedback($feedback, 'success', normalized.message || 'Réglages sauvegardés avec succès !');
+                    const message = successMessage || normalized.message || 'Réglages sauvegardés avec succès !';
+                    showFeedback($feedback, 'success', message);
                 } else {
-                    const message = normalized.message || 'Une erreur est survenue lors de la sauvegarde des réglages.';
+                    const message = normalized.message || errorMessage || 'Une erreur est survenue lors de la sauvegarde des réglages.';
                     showFeedback($feedback, 'error', message);
                 }
             })
             .fail(function(xhr) {
-                let message = 'Impossible de sauvegarder les réglages.';
+                const errorMessage = $form.data('errorMessage');
+                let message = errorMessage || 'Impossible de sauvegarder les réglages.';
 
                 if (xhr && xhr.responseJSON) {
                     if (xhr.responseJSON.data && xhr.responseJSON.data.message) {


### PR DESCRIPTION
## Summary
- add dedicated notifications, channels, and performance sections to the admin settings UI
- extend the settings save handler to validate notification emails and webhook URLs before persisting
- improve admin JavaScript feedback to surface contextual success and error messages per form

## Testing
- php -l backup-jlg/includes/class-bjlg-admin.php
- php -l backup-jlg/includes/class-bjlg-settings.php
- composer test *(fails: phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deedb4e57c832e90189a2a0ecfc2fe