### PR TITLE
Secure API key storage and update admin UI

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -2865,7 +2865,10 @@ jQuery(document).ready(function($) {
             const label = key && typeof key.label === 'string' && key.label.trim() !== ''
                 ? key.label
                 : 'Sans nom';
-            const secret = key && key.secret ? key.secret : '';
+            const displaySecret = key && typeof key.display_secret === 'string'
+                ? key.display_secret
+                : '';
+            const isSecretHidden = !!(key && (key.is_secret_hidden || key.secret_hidden));
             const createdAt = key && typeof key.created_at !== 'undefined' ? key.created_at : '';
             const createdHuman = key && key.created_at_human ? key.created_at_human : '';
             const createdIso = key && key.created_at_iso ? key.created_at_iso : '';
@@ -2878,7 +2881,8 @@ jQuery(document).ready(function($) {
             const $row = $('<tr/>', {
                 'data-key-id': id,
                 'data-created-at': createdAt,
-                'data-last-rotated-at': rotatedAt
+                'data-last-rotated-at': rotatedAt,
+                'data-secret-hidden': isSecretHidden ? '1' : '0'
             });
 
             $('<td/>').append(
@@ -2888,13 +2892,25 @@ jQuery(document).ready(function($) {
                 })
             ).appendTo($row);
 
-            $('<td/>').append(
-                $('<code/>', {
-                    'class': 'bjlg-api-key-value',
-                    'aria-label': 'Clé API',
-                    text: secret
-                })
-            ).appendTo($row);
+            const $secretCell = $('<td/>').appendTo($row);
+            const secretClasses = ['bjlg-api-key-value'];
+
+            if (isSecretHidden) {
+                secretClasses.push('bjlg-api-key-value--hidden');
+            }
+
+            $('<code/>', {
+                'class': secretClasses.join(' '),
+                'aria-label': 'Clé API',
+                text: displaySecret
+            }).appendTo($secretCell);
+
+            if (isSecretHidden) {
+                $('<span/>', {
+                    'class': 'bjlg-api-key-hidden-note',
+                    text: 'Secret masqué. Régénérez la clé pour obtenir un nouveau secret.'
+                }).appendTo($secretCell);
+            }
 
             $('<td/>').append(
                 $('<time/>', {

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -1282,12 +1282,29 @@ class BJLG_Admin {
                 </thead>
                 <tbody>
                 <?php foreach ($keys as $key): ?>
-                    <tr data-key-id="<?php echo esc_attr($key['id']); ?>" data-created-at="<?php echo esc_attr($key['created_at']); ?>" data-last-rotated-at="<?php echo esc_attr($key['last_rotated_at']); ?>">
+                    <?php
+                    $is_hidden = !empty($key['is_secret_hidden']);
+                    $secret_value = isset($key['display_secret']) ? (string) $key['display_secret'] : '';
+                    $secret_classes = 'bjlg-api-key-value';
+
+                    if ($is_hidden) {
+                        $secret_classes .= ' bjlg-api-key-value--hidden';
+                    }
+                    ?>
+                    <tr data-key-id="<?php echo esc_attr($key['id']); ?>"
+                        data-created-at="<?php echo esc_attr($key['created_at']); ?>"
+                        data-last-rotated-at="<?php echo esc_attr($key['last_rotated_at']); ?>"
+                        data-secret-hidden="<?php echo $is_hidden ? '1' : '0'; ?>">
                         <td>
                             <strong class="bjlg-api-key-label"><?php echo esc_html($key['label']); ?></strong>
                         </td>
                         <td>
-                            <code class="bjlg-api-key-value" aria-label="Clé API"><?php echo esc_html($key['secret']); ?></code>
+                            <code class="<?php echo esc_attr($secret_classes); ?>" aria-label="Clé API">
+                                <?php echo esc_html($secret_value); ?>
+                            </code>
+                            <?php if ($is_hidden): ?>
+                                <span class="bjlg-api-key-hidden-note"><?php esc_html_e('Secret masqué. Régénérez la clé pour obtenir un nouveau secret.', 'backup-jlg'); ?></span>
+                            <?php endif; ?>
                         </td>
                         <td>
                             <time class="bjlg-api-key-created" datetime="<?php echo esc_attr($key['created_at_iso']); ?>">

--- a/backup-jlg/tests/BJLG_AdminApiTabTest.php
+++ b/backup-jlg/tests/BJLG_AdminApiTabTest.php
@@ -31,9 +31,12 @@ final class BJLG_AdminApiTabTest extends TestCase
             'demo' => [
                 'id' => 'demo',
                 'label' => 'Mon intégration',
-                'secret' => 'SECRETXYZ',
+                'key' => wp_hash_password('SECRETXYZ'),
                 'created_at' => $timestamp,
                 'last_rotated_at' => $timestamp,
+                'user_id' => 42,
+                'user_login' => 'editor',
+                'user_email' => 'editor@example.com',
             ],
         ];
 
@@ -50,6 +53,7 @@ final class BJLG_AdminApiTabTest extends TestCase
         $this->assertStringContainsString('API &amp; Intégrations', $output);
         $this->assertStringContainsString('bjlg-api-keys-table', $output);
         $this->assertStringContainsString('Mon intégration', $output);
-        $this->assertStringContainsString('SECRETXYZ', $output);
+        $this->assertStringContainsString('bjlg-api-key-value--hidden', $output);
+        $this->assertStringContainsString('Secret masqué. Régénérez la clé pour obtenir un nouveau secret.', $output);
     }
 }

--- a/backup-jlg/tests/bootstrap.php
+++ b/backup-jlg/tests/bootstrap.php
@@ -19,6 +19,12 @@ if (!function_exists('esc_html')) {
     }
 }
 
+if (!function_exists('esc_html_e')) {
+    function esc_html_e($text, $domain = 'default') {
+        echo esc_html($text);
+    }
+}
+
 if (!function_exists('esc_attr')) {
     function esc_attr($text) {
         return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
@@ -706,6 +712,32 @@ if (!function_exists('sanitize_text_field')) {
         $str = strip_tags($str);
         $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
         return trim($str);
+    }
+}
+
+if (!function_exists('sanitize_email')) {
+    function sanitize_email($email) {
+        $email = trim((string) $email);
+
+        if ($email === '') {
+            return '';
+        }
+
+        $sanitized = filter_var($email, FILTER_SANITIZE_EMAIL);
+
+        return is_string($sanitized) ? $sanitized : '';
+    }
+}
+
+if (!function_exists('is_email')) {
+    function is_email($email) {
+        $email = sanitize_email($email);
+
+        if ($email === '') {
+            return false;
+        }
+
+        return $email;
     }
 }
 


### PR DESCRIPTION
## Summary
- hash API secrets on creation/rotation, persist current user metadata, and expose newly generated values through a dedicated display field
- update the admin API table and JavaScript to handle masked keys, track hidden-state rows, and surface regeneration guidance
- extend PHPUnit coverage for API key workflows, add helpers for email sanitisation in the test bootstrap, and verify REST usage of freshly generated keys

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfc1b9b0bc832ea56794041947a4d7