### PR TITLE
Add accessible captions to backup and history tables

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -22,6 +22,21 @@
     margin-top: 25px;
 }
 
+.bjlg-responsive-table caption,
+.bjlg-history-table caption,
+.bjlg-health-check-table caption {
+    caption-side: top;
+    text-align: left;
+    font-weight: 600;
+    color: #1d2327;
+    padding: 0 0 10px;
+}
+
+.bjlg-table-caption {
+    font-size: 1em;
+    line-height: 1.4;
+}
+
 /* Tableau de bord rapide
 --------------------------------------------- */
 

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -533,7 +533,14 @@ class BJLG_Admin {
                 </div>
             </div>
             <div id="bjlg-backup-list-feedback" class="notice notice-error" role="alert" style="display:none;"></div>
-            <table class="wp-list-table widefat striped bjlg-responsive-table bjlg-backup-table">
+            <table
+                class="wp-list-table widefat striped bjlg-responsive-table bjlg-backup-table"
+                aria-describedby="bjlg-backup-summary bjlg-backup-list-caption"
+            >
+                <caption id="bjlg-backup-list-caption" class="bjlg-table-caption">
+                    Tableau listant les sauvegardes disponibles avec leurs composants, tailles,
+                    dates et actions possibles.
+                </caption>
                 <thead>
                     <tr>
                         <th scope="col">Nom du fichier</th>
@@ -654,6 +661,10 @@ class BJLG_Admin {
             <h2>Historique des 50 dernières actions</h2>
             <?php if (!empty($history)): ?>
                 <table class="wp-list-table widefat striped bjlg-responsive-table bjlg-history-table">
+                    <caption class="bjlg-table-caption">
+                        Historique des 50 dernières actions liées aux sauvegardes et restaurations,
+                        incluant leur date, statut et détails.
+                    </caption>
                     <thead>
                         <tr>
                             <th scope="col" style="width: 180px;">Date</th>


### PR DESCRIPTION
## Summary
- add descriptive captions to the backup list and history tables
- link the backup table to its dynamic summary for assistive technologies
- style admin captions so that they remain visible and readable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e034b72200832eb850bb85f11ae12c