### PR TITLE
Improve focus management for schedule cards

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -819,6 +819,23 @@ jQuery(document).ready(function($) {
             return schedules;
         }
 
+        function focusScheduleItemCard($item) {
+            if (!$item || !$item.length) {
+                return;
+            }
+
+            const $labelField = $item.find('[data-field="label"]').first();
+            if ($labelField.length) {
+                $labelField.focus();
+                return;
+            }
+
+            if (!$item.is('[tabindex]')) {
+                $item.attr('tabindex', '-1');
+            }
+            $item.focus();
+        }
+
         // Initialisation des planifications existantes
         scheduleItems().each(function(index) {
             const $item = $(this);
@@ -852,6 +869,7 @@ jQuery(document).ready(function($) {
             setScheduleId($item, '');
             populateScheduleItem($item, defaultScheduleData, defaultNextRunSummary, scheduleItems().length);
             $item.insertBefore($template);
+            focusScheduleItemCard($item);
             renderScheduleFeedback('info', 'Nouvelle planification ajoutée. Enregistrez pour la synchroniser.', []);
         });
 
@@ -867,8 +885,19 @@ jQuery(document).ready(function($) {
                 renderScheduleFeedback('error', 'Vous devez conserver au moins une planification active.', []);
                 return;
             }
+            const $addButton = $scheduleForm.find('.bjlg-add-schedule').first();
+            const $items = scheduleItems();
+            const currentIndex = $items.index($item);
             $item.slideUp(150, function() {
                 $(this).remove();
+                const $remainingItems = scheduleItems();
+                if ($remainingItems.length) {
+                    const fallbackIndex = currentIndex < 0 ? 0 : Math.min(currentIndex, $remainingItems.length - 1);
+                    const $targetItem = $($remainingItems.get(fallbackIndex));
+                    focusScheduleItemCard($targetItem);
+                } else if ($addButton.length) {
+                    $addButton.focus();
+                }
             });
         });
 

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -1605,6 +1605,7 @@ class BJLG_Admin {
         ob_start();
         ?>
         <div class="<?php echo esc_attr(implode(' ', $classes)); ?>"
+             tabindex="-1"
              data-schedule-id="<?php echo esc_attr($schedule_id); ?>"
              <?php echo $is_template ? "data-template='true' style='display:none;'" : ''; ?>>
             <input type="hidden" data-field="id" value="<?php echo esc_attr($schedule_id); ?>">


### PR DESCRIPTION
## Summary
- focus the label field on newly inserted schedule cards for better keyboard flow
- keep focus within the schedule manager when a card is removed to avoid losing the active element
- make schedule card containers programmatically focusable as a fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e034b6b1cc832ea1ce914ad7ac4669