### PR TITLE
Add dashboard actions panel and trend charts

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -108,6 +108,52 @@
     color: #a00;
 }
 
+.bjlg-dashboard-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.bjlg-action-card {
+    background: #ffffff;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 16px;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+    position: relative;
+}
+
+.bjlg-action-card__title {
+    margin: 0;
+    font-size: 1.2em;
+}
+
+.bjlg-action-card__meta {
+    margin: 0;
+    color: #50575e;
+}
+
+.bjlg-action-card__cta {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bjlg-action-card--disabled {
+    opacity: 0.65;
+}
+
+.bjlg-action-card--disabled .bjlg-action-card__cta.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
 .bjlg-cards-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -196,6 +242,77 @@
 
 .bjlg-onboarding__label {
     margin: 0 0 4px;
+}
+
+.bjlg-dashboard-charts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 20px;
+}
+
+.bjlg-chart-card {
+    background: #ffffff;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    padding: 16px;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 260px;
+}
+
+.bjlg-chart-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bjlg-chart-card__title {
+    margin: 0;
+    font-size: 1.1em;
+}
+
+.bjlg-chart-card__subtitle {
+    margin: 0;
+    color: #50575e;
+    font-size: 0.9em;
+}
+
+.bjlg-chart-card__canvas {
+    width: 100%;
+    height: 220px;
+}
+
+.bjlg-chart-card__empty {
+    margin: auto 0;
+    text-align: center;
+    color: #6c7781;
+    display: none;
+}
+
+.bjlg-chart-card--empty .bjlg-chart-card__canvas {
+    display: none;
+}
+
+.bjlg-chart-card--empty .bjlg-chart-card__empty {
+    display: block;
+}
+
+@media (max-width: 782px) {
+    .bjlg-action-card {
+        padding: 16px;
+    }
+
+    .bjlg-action-card__cta.button-hero {
+        font-size: 14px;
+        padding: 12px 16px;
+    }
+
+    .bjlg-chart-card__canvas {
+        height: 200px;
+    }
 }
 
 .bjlg-onboarding__description {

--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -125,7 +125,8 @@ final class BJLG_Plugin {
 
         wp_enqueue_style('bjlg-admin', BJLG_PLUGIN_URL . 'assets/css/admin.css', [], BJLG_VERSION);
         wp_enqueue_style('bjlg-admin-advanced', BJLG_PLUGIN_URL . 'assets/css/admin-advanced.css', [], BJLG_VERSION);
-        wp_enqueue_script('bjlg-admin', BJLG_PLUGIN_URL . 'assets/js/admin.js', ['jquery'], BJLG_VERSION, true);
+        wp_enqueue_script('bjlg-chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js', [], '4.4.4', true);
+        wp_enqueue_script('bjlg-admin', BJLG_PLUGIN_URL . 'assets/js/admin.js', ['jquery', 'bjlg-chartjs'], BJLG_VERSION, true);
         wp_localize_script('bjlg-admin', 'bjlg_ajax', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce'    => wp_create_nonce('bjlg_nonce'),

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -141,6 +141,17 @@ class BJLG_Admin {
         $onboarding = $metrics['onboarding'] ?? [];
         $data_attr = !empty($metrics) ? wp_json_encode($metrics) : '';
 
+        $backup_tab_url = add_query_arg(
+            [
+                'page' => 'backup-jlg',
+                'tab' => 'backup_restore',
+            ],
+            admin_url('admin.php')
+        );
+
+        $backup_cta_url = $backup_tab_url . '#bjlg-backup-creation-form';
+        $restore_cta_url = $backup_tab_url . '#bjlg-restore-form';
+
         ?>
         <section class="bjlg-dashboard-overview" <?php echo $data_attr ? 'data-bjlg-dashboard="' . esc_attr($data_attr) . '"' : ''; ?>>
             <header class="bjlg-dashboard-overview__header">
@@ -151,6 +162,41 @@ class BJLG_Admin {
                     </span>
                 <?php endif; ?>
             </header>
+
+            <div class="bjlg-dashboard-actions" data-role="actions">
+                <article class="bjlg-action-card" data-action="backup">
+                    <div class="bjlg-action-card__content">
+                        <h3 class="bjlg-action-card__title"><?php esc_html_e('Lancer une sauvegarde', 'backup-jlg'); ?></h3>
+                        <p class="bjlg-action-card__meta" data-field="cta_backup_last_backup">
+                            <?php echo esc_html($summary['history_last_backup_relative'] ?? __('Aucune sauvegarde récente.', 'backup-jlg')); ?>
+                        </p>
+                        <p class="bjlg-action-card__meta" data-field="cta_backup_next_run">
+                            <?php echo esc_html($summary['scheduler_next_run_relative'] ?? __('Aucune planification active.', 'backup-jlg')); ?>
+                        </p>
+                    </div>
+                    <a class="button button-primary button-hero bjlg-action-card__cta" href="<?php echo esc_url($backup_cta_url); ?>">
+                        <span class="dashicons dashicons-backup" aria-hidden="true"></span>
+                        <?php esc_html_e('Créer une sauvegarde', 'backup-jlg'); ?>
+                    </a>
+                </article>
+
+                <article class="bjlg-action-card" data-action="restore">
+                    <div class="bjlg-action-card__content">
+                        <h3 class="bjlg-action-card__title"><?php esc_html_e('Restaurer une sauvegarde', 'backup-jlg'); ?></h3>
+                        <p class="bjlg-action-card__meta" data-field="cta_restore_last_backup">
+                            <?php echo esc_html($summary['history_last_backup'] ?? __('Aucune sauvegarde disponible.', 'backup-jlg')); ?>
+                        </p>
+                        <p class="bjlg-action-card__meta">
+                            <?php esc_html_e('Archives stockées :', 'backup-jlg'); ?>
+                            <span data-field="cta_restore_backup_count"><?php echo esc_html(number_format_i18n($summary['storage_backup_count'] ?? 0)); ?></span>
+                        </p>
+                    </div>
+                    <a class="button button-secondary button-hero bjlg-action-card__cta" data-action-target="restore" href="<?php echo esc_url($restore_cta_url); ?>">
+                        <span class="dashicons dashicons-update" aria-hidden="true"></span>
+                        <?php esc_html_e('Ouvrir l’assistant de restauration', 'backup-jlg'); ?>
+                    </a>
+                </article>
+            </div>
 
             <div class="bjlg-alerts" data-role="alerts">
                 <?php foreach ($alerts as $alert): ?>
@@ -236,6 +282,30 @@ class BJLG_Admin {
                         </li>
                     <?php endforeach; ?>
                 </ul>
+            </div>
+
+            <div class="bjlg-dashboard-charts" data-role="charts">
+                <article class="bjlg-chart-card" data-chart="history-trend">
+                    <header class="bjlg-chart-card__header">
+                        <h3 class="bjlg-chart-card__title"><?php esc_html_e('Tendance des sauvegardes', 'backup-jlg'); ?></h3>
+                        <p class="bjlg-chart-card__subtitle" data-field="chart_history_subtitle">
+                            <?php esc_html_e('Actions réussies et échouées sur 30 jours.', 'backup-jlg'); ?>
+                        </p>
+                    </header>
+                    <canvas class="bjlg-chart-card__canvas" id="bjlg-history-trend" aria-hidden="true"></canvas>
+                    <p class="bjlg-chart-card__empty" data-role="empty-message"><?php esc_html_e('Données de tendance indisponibles pour le moment.', 'backup-jlg'); ?></p>
+                </article>
+
+                <article class="bjlg-chart-card" data-chart="storage-trend">
+                    <header class="bjlg-chart-card__header">
+                        <h3 class="bjlg-chart-card__title"><?php esc_html_e('Evolution du stockage', 'backup-jlg'); ?></h3>
+                        <p class="bjlg-chart-card__subtitle" data-field="chart_storage_subtitle">
+                            <?php esc_html_e('Capacité utilisée par vos archives.', 'backup-jlg'); ?>
+                        </p>
+                    </header>
+                    <canvas class="bjlg-chart-card__canvas" id="bjlg-storage-trend" aria-hidden="true"></canvas>
+                    <p class="bjlg-chart-card__empty" data-role="empty-message"><?php esc_html_e('Aucune mesure d’utilisation disponible.', 'backup-jlg'); ?></p>
+                </article>
             </div>
         </section>
         <?php


### PR DESCRIPTION
## Summary
- add a dashboard actions panel and chart containers to the admin overview template
- enhance the admin dashboard script to power the new calls-to-action and render charts with Chart.js
- update dashboard styling for responsive actions/charts and enqueue Chart.js in the admin assets

## Testing
- php -l backup-jlg/includes/class-bjlg-admin.php
- php -l backup-jlg/backup-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68e034b1c698832e847d0642f23db3d7