### PR TITLE
Allow configuring plugin access permissions

### DIFF
--- a/backup-jlg/includes/class-bjlg-actions.php
+++ b/backup-jlg/includes/class-bjlg-actions.php
@@ -26,7 +26,7 @@ class BJLG_Actions {
      * Génère un token de téléchargement à la demande pour un fichier spécifique.
      */
     public function prepare_download() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 
@@ -95,7 +95,7 @@ class BJLG_Actions {
      * Supprime un fichier de sauvegarde via AJAX.
      */
     public function handle_delete_backup() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 
@@ -318,11 +318,12 @@ class BJLG_Actions {
      * Construit la charge utile stockée avec un token de téléchargement.
      *
      * @param string $filepath
-     * @param string $required_capability
+     * @param string|null $required_capability
      * @return array
      */
-    public static function build_download_token_payload($filepath, $required_capability = BJLG_CAPABILITY) {
+    public static function build_download_token_payload($filepath, $required_capability = null) {
         $issued_by = function_exists('get_current_user_id') ? get_current_user_id() : 0;
+        $required_capability = $required_capability ?: \bjlg_get_required_capability();
 
         return [
             'file' => $filepath,

--- a/backup-jlg/includes/class-bjlg-api-keys.php
+++ b/backup-jlg/includes/class-bjlg-api-keys.php
@@ -162,7 +162,7 @@ class BJLG_API_Keys {
      * Valide la requête AJAX.
      */
     private function validate_request() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error([
                 'message' => __('Permission refusée.', 'backup-jlg'),
             ], 403);

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -561,7 +561,7 @@ class BJLG_Backup {
      * Gère la requête AJAX pour démarrer une tâche de sauvegarde
      */
     public function handle_start_backup_task() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -701,7 +701,7 @@ class BJLG_Backup {
      * Vérifie la progression d'une tâche
      */
     public function handle_check_backup_progress() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');

--- a/backup-jlg/includes/class-bjlg-cleanup.php
+++ b/backup-jlg/includes/class-bjlg-cleanup.php
@@ -97,7 +97,7 @@ class BJLG_Cleanup {
      * Gère le nettoyage manuel déclenché par l'utilisateur
      */
     public function handle_manual_cleanup() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');

--- a/backup-jlg/includes/class-bjlg-diagnostics.php
+++ b/backup-jlg/includes/class-bjlg-diagnostics.php
@@ -23,7 +23,7 @@ class BJLG_Diagnostics {
      * Gère la requête AJAX pour créer et fournir le pack de support.
      */
     public function handle_generate_support_package() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -99,7 +99,7 @@ class BJLG_Diagnostics {
 
             $download_token = wp_generate_password(32, false);
             $transient_key = 'bjlg_download_' . $download_token;
-            $payload = BJLG_Actions::build_download_token_payload($real_zip_path, BJLG_CAPABILITY);
+            $payload = BJLG_Actions::build_download_token_payload($real_zip_path, \bjlg_get_required_capability());
             $payload['delete_after_download'] = true;
             $ttl = BJLG_Actions::get_download_token_ttl($real_zip_path);
 
@@ -132,7 +132,7 @@ class BJLG_Diagnostics {
      * Exécute un test de diagnostic spécifique
      */
     public function handle_run_diagnostic_test() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -178,7 +178,7 @@ class BJLG_Diagnostics {
      * Obtient les informations système
      */
     public function handle_get_system_info() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         

--- a/backup-jlg/includes/class-bjlg-encryption.php
+++ b/backup-jlg/includes/class-bjlg-encryption.php
@@ -776,7 +776,7 @@ class BJLG_Encryption {
      * AJAX: Génère une nouvelle clé
      */
     public function ajax_generate_key() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -799,7 +799,7 @@ class BJLG_Encryption {
      * AJAX: Test du chiffrement
      */
     public function ajax_test_encryption() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -853,7 +853,7 @@ class BJLG_Encryption {
      * AJAX: Vérifie si un mot de passe peut déchiffrer un fichier donné.
      */
     public function ajax_verify_password() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
 

--- a/backup-jlg/includes/class-bjlg-incremental.php
+++ b/backup-jlg/includes/class-bjlg-incremental.php
@@ -491,7 +491,7 @@ class BJLG_Incremental {
      * AJAX : Obtient les informations sur l'état incrémental
      */
     public function ajax_get_info() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         
@@ -550,7 +550,7 @@ class BJLG_Incremental {
      * AJAX : Réinitialise l'état incrémental
      */
     public function ajax_reset() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -566,7 +566,7 @@ class BJLG_Incremental {
      * AJAX : Analyse les changements depuis la dernière sauvegarde
      */
     public function ajax_analyze_changes() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');

--- a/backup-jlg/includes/class-bjlg-performance.php
+++ b/backup-jlg/includes/class-bjlg-performance.php
@@ -740,7 +740,7 @@ class BJLG_Performance {
      * AJAX: Lance un benchmark
      */
     public function ajax_run_benchmark() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -792,7 +792,7 @@ class BJLG_Performance {
      * AJAX: Obtient les statistiques
      */
     public function ajax_get_stats() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         

--- a/backup-jlg/includes/class-bjlg-rest-api.php
+++ b/backup-jlg/includes/class-bjlg-rest-api.php
@@ -373,7 +373,7 @@ class BJLG_REST_API {
         }
 
         // Vérifier l'authentification WordPress standard
-        return current_user_can(BJLG_CAPABILITY);
+        return \bjlg_can_manage_plugin();
     }
     
     /**
@@ -462,7 +462,7 @@ class BJLG_REST_API {
                 );
             }
 
-            if (!user_can($user, BJLG_CAPABILITY)) {
+            if (!\bjlg_can_manage_plugin($user)) {
                 $this->remove_api_key_entry($stored_keys, $index, true);
                 unset($key_data);
 
@@ -995,7 +995,7 @@ class BJLG_REST_API {
             );
         }
 
-        $has_capability = function_exists('user_can') ? user_can($user, BJLG_CAPABILITY) : false;
+        $has_capability = \bjlg_can_manage_plugin($user);
 
         if (!$has_capability) {
             return new WP_Error(
@@ -1084,7 +1084,7 @@ class BJLG_REST_API {
                 );
             }
 
-            if (!user_can($user, BJLG_CAPABILITY)) {
+            if (!\bjlg_can_manage_plugin($user)) {
                 return new WP_Error(
                     'insufficient_permissions',
                     'User does not have backup permissions',
@@ -1121,7 +1121,7 @@ class BJLG_REST_API {
             );
         }
         
-        if (!user_can($user, BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin($user)) {
             return new WP_Error(
                 'insufficient_permissions',
                 'User does not have backup permissions',

--- a/backup-jlg/includes/class-bjlg-restore.php
+++ b/backup-jlg/includes/class-bjlg-restore.php
@@ -49,7 +49,7 @@ class BJLG_Restore {
      * Crée une sauvegarde de sécurité complète avant de lancer une restauration.
      */
     public function handle_create_pre_restore_backup() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -244,7 +244,7 @@ class BJLG_Restore {
      * Gère l'upload d'un fichier de restauration
      */
     public function handle_upload_restore_file() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -487,7 +487,7 @@ class BJLG_Restore {
      * Exécute la restauration granulaire à partir d'un fichier de sauvegarde.
      */
     public function handle_run_restore() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -642,7 +642,7 @@ class BJLG_Restore {
      * Vérifie la progression de la restauration
      */
     public function handle_check_restore_progress() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');

--- a/backup-jlg/includes/class-bjlg-scheduler.php
+++ b/backup-jlg/includes/class-bjlg-scheduler.php
@@ -90,7 +90,7 @@ class BJLG_Scheduler {
      * Gère la requête AJAX pour enregistrer les paramètres de planification.
      */
     public function handle_save_schedule() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -294,7 +294,7 @@ class BJLG_Scheduler {
      * Obtient la prochaine exécution planifiée
      */
     public function handle_get_next_scheduled() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
 
@@ -317,7 +317,7 @@ class BJLG_Scheduler {
      * Exécute immédiatement une sauvegarde planifiée
      */
     public function handle_run_scheduled_now() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');
@@ -631,7 +631,7 @@ class BJLG_Scheduler {
     }
 
     public function handle_toggle_schedule_state() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 
@@ -700,7 +700,7 @@ class BJLG_Scheduler {
     }
 
     public function handle_duplicate_schedule() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 

--- a/backup-jlg/includes/class-bjlg-webhooks.php
+++ b/backup-jlg/includes/class-bjlg-webhooks.php
@@ -69,7 +69,7 @@ class BJLG_Webhooks {
      * Gère l'appel AJAX pour régénérer la clé.
      */
     public function handle_regenerate_key_ajax() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée']);
         }
         check_ajax_referer('bjlg_nonce', 'nonce');

--- a/backup-jlg/includes/destinations/class-bjlg-aws-s3.php
+++ b/backup-jlg/includes/destinations/class-bjlg-aws-s3.php
@@ -252,7 +252,7 @@ class BJLG_AWS_S3 implements BJLG_Destination_Interface {
      * Gère la requête AJAX de test de connexion.
      */
     public function handle_test_connection() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 
@@ -292,7 +292,7 @@ class BJLG_AWS_S3 implements BJLG_Destination_Interface {
      * Gère la demande de déconnexion depuis l'administration.
      */
     public function handle_disconnect_request() {
-        if (function_exists('current_user_can') && !current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             return;
         }
 

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -415,7 +415,7 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
             wp_send_json_error(['message' => 'Le SDK Google n\'est pas disponible.'], 500);
         }
 
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.'], 403);
         }
 
@@ -478,7 +478,7 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
             return;
         }
 
-        if (function_exists('current_user_can') && !current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             return;
         }
 
@@ -520,7 +520,7 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
      * Gère la requête de déconnexion.
      */
     public function handle_disconnect_request() {
-        if (function_exists('current_user_can') && !current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             return;
         }
 

--- a/backup-jlg/includes/destinations/class-bjlg-sftp.php
+++ b/backup-jlg/includes/destinations/class-bjlg-sftp.php
@@ -191,7 +191,7 @@ class BJLG_SFTP implements BJLG_Destination_Interface {
     }
 
     public function handle_test_connection() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_send_json_error(['message' => 'Permission refusée.']);
         }
 
@@ -240,7 +240,7 @@ class BJLG_SFTP implements BJLG_Destination_Interface {
     }
 
     public function handle_disconnect_request() {
-        if (!current_user_can(BJLG_CAPABILITY)) {
+        if (!\bjlg_can_manage_plugin()) {
             wp_die('Permission refusée.');
         }
 

--- a/backup-jlg/tests/BJLG_API_KeysTest.php
+++ b/backup-jlg/tests/BJLG_API_KeysTest.php
@@ -15,7 +15,7 @@ final class BJLG_API_KeysTest extends TestCase
             'ID' => 1,
             'user_login' => 'admin',
             'user_email' => 'admin@example.com',
-            'allcaps' => [BJLG_CAPABILITY => true],
+            'allcaps' => [bjlg_get_required_capability() => true],
             'roles' => ['administrator'],
         ];
         $GLOBALS['bjlg_test_users'] = [$user->ID => $user];

--- a/backup-jlg/tests/BJLG_ActionsDownloadTest.php
+++ b/backup-jlg/tests/BJLG_ActionsDownloadTest.php
@@ -157,8 +157,8 @@ final class BJLG_ActionsDownloadTest extends TestCase
         $GLOBALS['bjlg_test_users'] = [
             $user_id => (object) [
                 'ID' => $user_id,
-                'caps' => [BJLG_CAPABILITY => true],
-                'allcaps' => [BJLG_CAPABILITY => true],
+                'caps' => [bjlg_get_required_capability() => true],
+                'allcaps' => [bjlg_get_required_capability() => true],
             ],
         ];
         $GLOBALS['current_user'] = null;
@@ -166,7 +166,7 @@ final class BJLG_ActionsDownloadTest extends TestCase
 
         set_transient('bjlg_download_' . $token, [
             'file' => $realpath,
-            'requires_cap' => BJLG_CAPABILITY,
+            'requires_cap' => bjlg_get_required_capability(),
             'issued_at' => time(),
             'issued_by' => $user_id,
         ], 3600);

--- a/backup-jlg/tests/BJLG_ActionsTest.php
+++ b/backup-jlg/tests/BJLG_ActionsTest.php
@@ -173,7 +173,7 @@ final class BJLG_ActionsTest extends TestCase
                 $this->assertArrayHasKey('issued_by', $payload);
 
                 $this->assertSame($real_filepath, $payload['file']);
-                $this->assertSame(BJLG_CAPABILITY, $payload['requires_cap']);
+                $this->assertSame(bjlg_get_required_capability(), $payload['requires_cap']);
                 $this->assertIsInt($payload['issued_at']);
                 $this->assertGreaterThan(0, $payload['issued_at']);
                 $this->assertSame(0, $payload['issued_by']);
@@ -294,8 +294,8 @@ final class BJLG_ActionsTest extends TestCase
         $user_id = 123;
         $user = (object) [
             'ID' => $user_id,
-            'caps' => [BJLG_CAPABILITY => true],
-            'allcaps' => [BJLG_CAPABILITY => true],
+            'caps' => [bjlg_get_required_capability() => true],
+            'allcaps' => [bjlg_get_required_capability() => true],
         ];
 
         $GLOBALS['bjlg_test_users'] = [$user_id => $user];
@@ -305,7 +305,7 @@ final class BJLG_ActionsTest extends TestCase
 
         set_transient('bjlg_download_' . $token, [
             'file' => $filepath,
-            'requires_cap' => BJLG_CAPABILITY,
+            'requires_cap' => bjlg_get_required_capability(),
             'issued_at' => time(),
             'issued_by' => $user_id,
         ], defined('HOUR_IN_SECONDS') ? HOUR_IN_SECONDS : 3600);

--- a/backup-jlg/tests/BJLG_REST_APITest.php
+++ b/backup-jlg/tests/BJLG_REST_APITest.php
@@ -228,7 +228,7 @@ namespace {
 
         private function makeUser(int $id, string $login, ?array $caps = null, ?array $roles = null): object
         {
-            $caps = $caps ?? [BJLG_CAPABILITY => true];
+            $caps = $caps ?? [bjlg_get_required_capability() => true];
             $roles = $roles ?? ['administrator'];
 
             return (object) [
@@ -1603,7 +1603,7 @@ namespace {
             $this->assertArrayHasKey('file', $stored_payload);
             $this->assertSame($filepath, $stored_payload['file']);
             $this->assertArrayHasKey('requires_cap', $stored_payload);
-            $this->assertSame(BJLG_CAPABILITY, $stored_payload['requires_cap']);
+            $this->assertSame(bjlg_get_required_capability(), $stored_payload['requires_cap']);
             $this->assertArrayHasKey('issued_at', $stored_payload);
             $this->assertIsInt($stored_payload['issued_at']);
             $this->assertArrayHasKey('issued_by', $stored_payload);
@@ -1867,7 +1867,7 @@ namespace {
             $stored_payload = $GLOBALS['bjlg_test_transients']['bjlg_download_' . $token] ?? null;
             $this->assertIsArray($stored_payload);
             $this->assertSame($filepath, $stored_payload['file'] ?? null);
-            $this->assertSame(BJLG_CAPABILITY, $stored_payload['requires_cap'] ?? null);
+            $this->assertSame(bjlg_get_required_capability(), $stored_payload['requires_cap'] ?? null);
             $this->assertArrayHasKey('issued_at', $stored_payload);
             $this->assertArrayHasKey('issued_by', $stored_payload);
             $this->assertSame(0, $stored_payload['issued_by']);
@@ -3169,7 +3169,7 @@ namespace {
         $payload = get_transient('bjlg_download_' . $data['download_token']);
         $this->assertIsArray($payload);
         $this->assertSame($tempFile, $payload['file'] ?? null);
-        $this->assertSame(BJLG_CAPABILITY, $payload['requires_cap'] ?? null);
+        $this->assertSame(bjlg_get_required_capability(), $payload['requires_cap'] ?? null);
 
         if (file_exists($tempFile)) {
             unlink($tempFile);

--- a/backup-jlg/uninstall.php
+++ b/backup-jlg/uninstall.php
@@ -77,6 +77,7 @@ if ( ! function_exists( 'bjlg_uninstall_site' ) ) {
             'bjlg_webhook_settings',
             'bjlg_webhook_key',
             'bjlg_ajax_debug_enabled',
+            'bjlg_required_capability',
         );
 
         foreach ( $options as $option_name ) {


### PR DESCRIPTION
## Summary
- add helpers to read the configured capability/role and map it to a dedicated meta capability for menu checks
- expose a permissions selector in the admin settings and surface available roles/capabilities
- persist, validate, and export the required permission with supporting tests for the new behaviour

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e03bbb4548832e9c72bb805f540126