### PR TITLE
Ensure SFTP destinations are instantiated and covered by tests

### DIFF
--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -1791,10 +1791,11 @@ class BJLG_Backup {
                 }
                 break;
             case 'sftp':
-                if (class_exists(BJLG_SFTP::class)) {
-                    return new BJLG_SFTP();
+                if (!class_exists(BJLG_SFTP::class)) {
+                    break;
                 }
-                break;
+
+                return new BJLG_SFTP();
         }
 
         return null;

--- a/backup-jlg/tests/BJLG_BackupTest.php
+++ b/backup-jlg/tests/BJLG_BackupTest.php
@@ -434,6 +434,8 @@ final class BJLG_BackupTest extends TestCase
 
         \phpseclib3\Net\SFTP::$uploaded = [];
 
+        $previous_settings = get_option('bjlg_sftp_settings');
+
         update_option('bjlg_sftp_settings', [
             'enabled' => true,
             'host' => 'sftp.example.org',
@@ -458,7 +460,7 @@ final class BJLG_BackupTest extends TestCase
             $results = $method->invoke($backup, $file, ['sftp'], 'task-sftp-1');
         } finally {
             @unlink($file);
-            update_option('bjlg_sftp_settings', []);
+            update_option('bjlg_sftp_settings', $previous_settings);
         }
 
         $this->assertSame(['sftp'], $results['success']);


### PR DESCRIPTION
## Summary
- ensure the backup destination factory returns an SFTP destination when the class is available
- keep SFTP option settings intact after the dispatch test runs

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e148fd6980832e9f77e91fcd146617