### PR TITLE
Add dynamic status block for backup overview

### DIFF
--- a/backup-jlg/assets/css/block-status.css
+++ b/backup-jlg/assets/css/block-status.css
@@ -1,0 +1,226 @@
+.bjlg-block-status {
+    background: #ffffff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    color: #1d2327;
+    font-family: inherit;
+}
+
+.bjlg-block-status--editor {
+    min-height: 160px;
+}
+
+.bjlg-block-status__header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    gap: 12px;
+}
+
+.bjlg-block-status__title {
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.bjlg-block-status__timestamp {
+    font-size: 0.875rem;
+    color: #50575e;
+}
+
+.bjlg-block-status__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.bjlg-block-status__stat {
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.bjlg-block-status__stat-label {
+    font-size: 0.875rem;
+    color: #50575e;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.bjlg-block-status__stat-value {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.bjlg-block-status__stat-meta {
+    font-size: 0.875rem;
+    color: #646970;
+}
+
+.bjlg-block-status__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.bjlg-block-status__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 4px;
+    font-weight: 600;
+    background: #2271b1;
+    color: #ffffff;
+    text-decoration: none;
+}
+
+.bjlg-block-status__button:hover,
+.bjlg-block-status__button:focus {
+    background: #135e96;
+    color: #ffffff;
+}
+
+.bjlg-block-status__button--secondary {
+    background: #f3f4f5;
+    color: #1d2327;
+}
+
+.bjlg-block-status__button--secondary:hover,
+.bjlg-block-status__button--secondary:focus {
+    background: #e2e4e7;
+}
+
+.bjlg-block-status__alerts {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.bjlg-block-status__alert {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 6px;
+    padding: 16px;
+    gap: 12px;
+}
+
+.bjlg-block-status__alert--info {
+    background: #f0f6fc;
+    border: 1px solid #8fbdf0;
+}
+
+.bjlg-block-status__alert--warning {
+    background: #fff4e5;
+    border: 1px solid #f0c88b;
+}
+
+.bjlg-block-status__alert--error {
+    background: #fdecea;
+    border: 1px solid #f18f81;
+}
+
+.bjlg-block-status__alert--success {
+    background: #edf7ed;
+    border: 1px solid #9fd89f;
+}
+
+.bjlg-block-status__alert-body {
+    flex: 1 1 auto;
+}
+
+.bjlg-block-status__alert-body strong {
+    display: block;
+    font-size: 1rem;
+    margin-bottom: 4px;
+}
+
+.bjlg-block-status__alert-link {
+    font-weight: 600;
+    color: #1d2327;
+    text-decoration: none;
+}
+
+.bjlg-block-status__alert-link:hover,
+.bjlg-block-status__alert-link:focus {
+    text-decoration: underline;
+}
+
+.bjlg-block-status__recent {
+    margin-top: 8px;
+}
+
+.bjlg-block-status__section-title {
+    margin: 0 0 12px 0;
+    font-size: 1.1rem;
+}
+
+.bjlg-block-status__backup-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.bjlg-block-status__backup-item {
+    display: flex;
+    flex-direction: column;
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 12px 16px;
+}
+
+.bjlg-block-status__backup-name {
+    font-weight: 600;
+}
+
+.bjlg-block-status__backup-meta {
+    font-size: 0.875rem;
+    color: #646970;
+}
+
+.bjlg-block-status__placeholder,
+.bjlg-block-status__error,
+.bjlg-block-status__notice,
+.bjlg-block-status__empty {
+    text-align: center;
+    color: #50575e;
+}
+
+.bjlg-block-status__placeholder {
+    display: grid;
+    gap: 12px;
+    justify-content: center;
+    align-items: center;
+    min-height: 140px;
+}
+
+.bjlg-block-status__error {
+    display: grid;
+    gap: 16px;
+    justify-items: center;
+}
+
+.bjlg-block-status__notice {
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 16px;
+}
+
+@media (max-width: 600px) {
+    .bjlg-block-status {
+        padding: 16px;
+    }
+}

--- a/backup-jlg/assets/js/block-status.asset.php
+++ b/backup-jlg/assets/js/block-status.asset.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'dependencies' => [
+        'wp-blocks',
+        'wp-i18n',
+        'wp-element',
+        'wp-components',
+        'wp-block-editor',
+        'wp-data',
+        'wp-api-fetch',
+    ],
+    'version' => defined('BJLG_VERSION') ? BJLG_VERSION : '1.0.0',
+];

--- a/backup-jlg/assets/js/block-status.js
+++ b/backup-jlg/assets/js/block-status.js
@@ -1,0 +1,335 @@
+/* global wp, BJLGBlockStatusSettings */
+(function(wp) {
+    if (!wp || !wp.blocks) {
+        return;
+    }
+
+    const { registerBlockType } = wp.blocks;
+    const { __ } = wp.i18n;
+    const { useState, useEffect, Fragment, useCallback } = wp.element;
+    const { PanelBody, ToggleControl, Spinner, Button, Notice } = wp.components;
+    const { InspectorControls, useBlockProps } = wp.blockEditor || wp.editor;
+    const apiFetch = wp.apiFetch;
+
+    const settings = window.BJLGBlockStatusSettings || {};
+
+    if (apiFetch) {
+        if (settings.root && apiFetch.createRootURLMiddleware && !window.__BJLGBlockStatusRootMiddleware) {
+            window.__BJLGBlockStatusRootMiddleware = true;
+            apiFetch.use(apiFetch.createRootURLMiddleware(settings.root));
+        }
+
+        if (settings.nonce && apiFetch.createNonceMiddleware && !window.__BJLGBlockStatusNonceMiddleware) {
+            window.__BJLGBlockStatusNonceMiddleware = true;
+            apiFetch.use(apiFetch.createNonceMiddleware(settings.nonce));
+        }
+    }
+
+    const getInitialState = () => {
+        const snapshot = settings.snapshot || null;
+        if (snapshot && snapshot.ok) {
+            return {
+                status: 'ready',
+                data: snapshot,
+                error: null,
+            };
+        }
+
+        if (snapshot && snapshot.error) {
+            return {
+                status: 'error',
+                data: null,
+                error: snapshot.error,
+            };
+        }
+
+        return {
+            status: 'idle',
+            data: null,
+            error: null,
+        };
+    };
+
+    const formatAlertType = (type) => {
+        switch (type) {
+            case 'warning':
+                return 'warning';
+            case 'error':
+            case 'danger':
+                return 'error';
+            case 'success':
+                return 'success';
+            default:
+                return 'info';
+        }
+    };
+
+    const SummaryStat = ({ label, value, meta }) => {
+        let displayValue = value;
+        if (typeof value === 'number') {
+            displayValue = value.toLocaleString();
+        }
+        if (!displayValue && displayValue !== 0) {
+            displayValue = __('N/A', 'backup-jlg');
+        }
+
+        return wp.element.createElement('div', { className: 'bjlg-block-status__stat' },
+            wp.element.createElement('span', { className: 'bjlg-block-status__stat-label' }, label),
+            wp.element.createElement('span', { className: 'bjlg-block-status__stat-value' }, displayValue),
+            meta ? wp.element.createElement('span', { className: 'bjlg-block-status__stat-meta' }, meta) : null
+        );
+    };
+
+    const Alerts = ({ alerts }) => {
+        if (!alerts || alerts.length === 0) {
+            return null;
+        }
+
+        return wp.element.createElement('div', { className: 'bjlg-block-status__alerts' },
+            alerts.map((alert, index) => wp.element.createElement('div', {
+                key: alert.id || index,
+                className: 'bjlg-block-status__alert bjlg-block-status__alert--' + formatAlertType(alert.type),
+            },
+            wp.element.createElement('div', { className: 'bjlg-block-status__alert-body' },
+                wp.element.createElement('strong', null, alert.title || ''),
+                alert.message ? wp.element.createElement('p', null, alert.message) : null
+            ),
+            alert.action && alert.action.url && alert.action.label
+                ? wp.element.createElement('a', {
+                    className: 'bjlg-block-status__alert-link',
+                    href: alert.action.url,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                }, alert.action.label)
+                : null
+            ))
+        );
+    };
+
+    const RecentBackups = ({ backups }) => {
+        if (!backups) {
+            return null;
+        }
+
+        if (!backups.length) {
+            return wp.element.createElement('p', { className: 'bjlg-block-status__empty' }, __('Aucune sauvegarde récente disponible.', 'backup-jlg'));
+        }
+
+        return wp.element.createElement('ul', { className: 'bjlg-block-status__backup-list' },
+            backups.map((backup) => wp.element.createElement('li', {
+                key: backup.id || backup.filename,
+                className: 'bjlg-block-status__backup-item',
+            },
+            wp.element.createElement('span', { className: 'bjlg-block-status__backup-name' }, backup.filename),
+            wp.element.createElement('span', { className: 'bjlg-block-status__backup-meta' },
+                [backup.created_at_relative, backup.size].filter(Boolean).join(' · ')
+            )
+        ))
+        );
+    };
+
+    const Actions = ({ actions }) => {
+        if (!actions || !actions.backup) {
+            return null;
+        }
+
+        const buttons = [];
+
+        if (actions.backup && actions.backup.url) {
+            buttons.push(
+                wp.element.createElement('a', {
+                    key: 'backup',
+                    className: 'bjlg-block-status__button',
+                    href: actions.backup.url,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                }, actions.backup.label || __('Lancer une sauvegarde', 'backup-jlg'))
+            );
+        }
+
+        if (actions.restore && actions.restore.url) {
+            buttons.push(
+                wp.element.createElement('a', {
+                    key: 'restore',
+                    className: 'bjlg-block-status__button bjlg-block-status__button--secondary',
+                    href: actions.restore.url,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                }, actions.restore.label || __('Restaurer une archive', 'backup-jlg'))
+            );
+        }
+
+        if (!buttons.length) {
+            return null;
+        }
+
+        return wp.element.createElement('div', { className: 'bjlg-block-status__actions' }, buttons);
+    };
+
+    const StatusPreview = ({ data, attributes }) => {
+        const summary = data.summary || {};
+
+        return wp.element.createElement(Fragment, null,
+            wp.element.createElement('header', { className: 'bjlg-block-status__header' },
+                wp.element.createElement('h3', { className: 'bjlg-block-status__title' }, __('Vue d’ensemble des sauvegardes', 'backup-jlg')),
+                data.generated_at ? wp.element.createElement('span', { className: 'bjlg-block-status__timestamp' },
+                    wp.i18n.sprintf(__('Actualisé le %s', 'backup-jlg'), data.generated_at)
+                ) : null
+            ),
+            wp.element.createElement('div', { className: 'bjlg-block-status__summary' },
+                wp.element.createElement(SummaryStat, {
+                    label: __('Dernière sauvegarde', 'backup-jlg'),
+                    value: summary.history_last_backup,
+                    meta: summary.history_last_backup_relative,
+                }),
+                wp.element.createElement(SummaryStat, {
+                    label: __('Prochaine sauvegarde planifiée', 'backup-jlg'),
+                    value: summary.scheduler_next_run,
+                    meta: summary.scheduler_next_run_relative,
+                }),
+                wp.element.createElement(SummaryStat, {
+                    label: __('Archives stockées', 'backup-jlg'),
+                    value: typeof summary.storage_backup_count !== 'undefined' ? summary.storage_backup_count : null,
+                    meta: summary.storage_total_size_human,
+                })
+            ),
+            attributes.showLaunchButton ? wp.element.createElement(Actions, { actions: data.actions }) : null,
+            attributes.showAlerts ? wp.element.createElement(Alerts, { alerts: data.alerts }) : null,
+            attributes.showRecentBackups ? wp.element.createElement('div', { className: 'bjlg-block-status__recent' },
+                wp.element.createElement('h4', { className: 'bjlg-block-status__section-title' }, __('Dernières archives', 'backup-jlg')),
+                wp.element.createElement(RecentBackups, { backups: data.backups })
+            ) : null
+        );
+    };
+
+    registerBlockType('backup-jlg/status', {
+        edit: function Edit(props) {
+            const { attributes, setAttributes } = props;
+            const [state, setState] = useState(getInitialState);
+
+            const blockProps = useBlockProps({
+                className: 'bjlg-block-status bjlg-block-status--editor',
+            });
+
+            if (state.data && state.data.ok) {
+                blockProps['data-bjlg-status'] = JSON.stringify(state.data);
+            }
+
+            const fetchSnapshot = useCallback(() => {
+                if (!apiFetch || !settings.endpoint) {
+                    setState({
+                        status: 'error',
+                        data: null,
+                        error: { message: settings.i18n ? settings.i18n.error : __('Impossible de charger les données.', 'backup-jlg') },
+                    });
+                    return;
+                }
+
+                setState((prev) => ({ ...prev, status: 'loading', error: null }));
+
+                const controller = typeof AbortController === 'function' ? new AbortController() : null;
+                const request = { path: settings.endpoint };
+                if (controller) {
+                    request.signal = controller.signal;
+                }
+
+                apiFetch(request)
+                    .then((response) => {
+                        if (!response) {
+                            throw new Error('empty_response');
+                        }
+                        if (response.ok === false && response.error) {
+                            setState({ status: 'error', data: null, error: response.error });
+                            return;
+                        }
+                        setState({ status: 'ready', data: response, error: null });
+                    })
+                    .catch((error) => {
+                        if (error && error.name === 'AbortError') {
+                            return;
+                        }
+                        setState({
+                            status: 'error',
+                            data: null,
+                            error: {
+                                message: settings.i18n ? settings.i18n.error : __('Une erreur est survenue lors du chargement.', 'backup-jlg'),
+                                details: error && error.message ? error.message : undefined,
+                            },
+                        });
+                    });
+
+                return () => {
+                    if (controller) {
+                        controller.abort();
+                    }
+                };
+            }, []);
+
+            useEffect(() => {
+                if (state.status === 'idle') {
+                    return fetchSnapshot();
+                }
+                return undefined;
+            }, [state.status, fetchSnapshot]);
+
+            const inspector = wp.element.createElement(InspectorControls, null,
+                wp.element.createElement(PanelBody, { title: __('Options du bloc', 'backup-jlg'), initialOpen: true },
+                    wp.element.createElement(ToggleControl, {
+                        label: __('Afficher le bouton “Lancer une sauvegarde”', 'backup-jlg'),
+                        checked: attributes.showLaunchButton,
+                        onChange: (value) => setAttributes({ showLaunchButton: !!value }),
+                    }),
+                    wp.element.createElement(ToggleControl, {
+                        label: __('Afficher les alertes', 'backup-jlg'),
+                        checked: attributes.showAlerts,
+                        onChange: (value) => setAttributes({ showAlerts: !!value }),
+                    }),
+                    wp.element.createElement(ToggleControl, {
+                        label: __('Afficher les dernières archives', 'backup-jlg'),
+                        checked: attributes.showRecentBackups,
+                        onChange: (value) => setAttributes({ showRecentBackups: !!value }),
+                    })
+                )
+            );
+
+            let content;
+
+            if (state.status === 'loading') {
+                content = wp.element.createElement('div', { className: 'bjlg-block-status__placeholder' },
+                    wp.element.createElement(Spinner, null),
+                    wp.element.createElement('p', null, settings.i18n ? settings.i18n.loading : __('Chargement…', 'backup-jlg'))
+                );
+            } else if (state.status === 'error') {
+                const message = state.error && state.error.message
+                    ? state.error.message
+                    : (settings.i18n ? settings.i18n.error : __('Impossible de charger les données.', 'backup-jlg'));
+
+                content = wp.element.createElement('div', { className: 'bjlg-block-status__error' },
+                    wp.element.createElement(Notice, { status: 'error', isDismissible: false }, message),
+                    wp.element.createElement(Button, {
+                        variant: 'secondary',
+                        onClick: fetchSnapshot,
+                    }, __('Réessayer', 'backup-jlg'))
+                );
+            } else if (state.data && state.data.ok) {
+                content = wp.element.createElement(StatusPreview, { data: state.data, attributes });
+            } else if (state.data && state.data.error) {
+                const message = state.data.error.message
+                    ? state.data.error.message
+                    : (settings.i18n ? settings.i18n.forbidden : __('Accès refusé.', 'backup-jlg'));
+                content = wp.element.createElement('div', { className: 'bjlg-block-status__notice' }, message);
+            } else {
+                content = wp.element.createElement('div', { className: 'bjlg-block-status__placeholder' },
+                    wp.element.createElement(Button, { variant: 'secondary', onClick: fetchSnapshot }, __('Charger les données', 'backup-jlg'))
+                );
+            }
+
+            return wp.element.createElement(Fragment, null, inspector,
+                wp.element.createElement('div', blockProps, content)
+            );
+        },
+        save: function Save() {
+            return null;
+        },
+    });
+})(window.wp);

--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -194,7 +194,7 @@ final class BJLG_Plugin {
             'class-bjlg-backup.php', 'class-bjlg-restore.php', 'class-bjlg-scheduler.php',
             'class-bjlg-cleanup.php', 'class-bjlg-encryption.php', 'class-bjlg-health-check.php',
             'class-bjlg-diagnostics.php', 'class-bjlg-webhooks.php', 'class-bjlg-incremental.php',
-            'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php',
+            'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php', 'class-bjlg-blocks.php',
             'class-bjlg-api-keys.php', 'class-bjlg-admin-advanced.php', 'class-bjlg-admin.php', 'class-bjlg-actions.php',
             'destinations/interface-bjlg-destination.php', 'destinations/class-bjlg-google-drive.php', 'destinations/class-bjlg-aws-s3.php', 'destinations/class-bjlg-sftp.php',
         ];
@@ -225,6 +225,7 @@ final class BJLG_Plugin {
         new BJLG\BJLG_REST_API();
         new BJLG\BJLG_Settings();
         new BJLG\BJLG_API_Keys();
+        new BJLG\BJLG_Blocks();
     }
 
     public function enqueue_admin_assets($hook) {

--- a/backup-jlg/block.json
+++ b/backup-jlg/block.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 2,
+    "name": "backup-jlg/status",
+    "title": "État des sauvegardes JLG",
+    "category": "widgets",
+    "icon": "database",
+    "description": "Affiche un résumé des dernières sauvegardes JLG et les prochaines actions recommandées.",
+    "keywords": ["backup", "sauvegarde", "jlg"],
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "attributes": {
+        "showAlerts": {
+            "type": "boolean",
+            "default": true
+        },
+        "showRecentBackups": {
+            "type": "boolean",
+            "default": true
+        },
+        "showLaunchButton": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "editorScript": "bjlg-block-status-editor",
+    "style": "bjlg-block-status-style",
+    "editorStyle": "bjlg-block-status-style"
+}

--- a/backup-jlg/includes/class-bjlg-blocks.php
+++ b/backup-jlg/includes/class-bjlg-blocks.php
@@ -1,0 +1,379 @@
+<?php
+namespace BJLG;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handles the registration of the block editor features for Backup JLG.
+ */
+class BJLG_Blocks {
+    private const BLOCK_METADATA_PATH = BJLG_PLUGIN_DIR;
+    private const RECENT_BACKUPS_LIMIT = 3;
+
+    private static $snapshot = null;
+
+    public function __construct() {
+        add_action('init', [$this, 'register_blocks']);
+        add_action('rest_api_init', [$this, 'register_rest_routes']);
+        add_action('enqueue_block_editor_assets', [$this, 'enqueue_block_editor_assets']);
+        add_action('enqueue_block_assets', [$this, 'enqueue_block_assets']);
+    }
+
+    public function register_blocks() {
+        if (!function_exists('register_block_type_from_metadata')) {
+            return;
+        }
+
+        $this->register_assets();
+
+        register_block_type_from_metadata(
+            self::BLOCK_METADATA_PATH,
+            [
+                'render_callback' => [$this, 'render_status_block'],
+            ]
+        );
+    }
+
+    public function register_rest_routes() {
+        register_rest_route(
+            'backup-jlg/v1',
+            '/block-status',
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'rest_get_status_snapshot'],
+                'permission_callback' => function() {
+                    return function_exists('bjlg_can_manage_plugin') ? bjlg_can_manage_plugin() : current_user_can('manage_options');
+                },
+            ]
+        );
+    }
+
+    public function enqueue_block_editor_assets() {
+        $this->register_assets();
+
+        wp_enqueue_script('bjlg-block-status-editor');
+        wp_enqueue_style('bjlg-block-status-style');
+
+        wp_localize_script(
+            'bjlg-block-status-editor',
+            'BJLGBlockStatusSettings',
+            [
+                'endpoint' => '/backup-jlg/v1/block-status',
+                'root' => esc_url_raw(rest_url()),
+                'nonce' => wp_create_nonce('wp_rest'),
+                'snapshot' => $this->get_status_snapshot(),
+                'i18n' => [
+                    'loading' => __('Chargement des métriques…', 'backup-jlg'),
+                    'error' => __('Impossible de charger l’état des sauvegardes.', 'backup-jlg'),
+                    'forbidden' => __('Vous n’avez pas les droits suffisants pour afficher ce bloc.', 'backup-jlg'),
+                ],
+            ]
+        );
+    }
+
+    public function enqueue_block_assets() {
+        $this->register_assets();
+        wp_enqueue_style('bjlg-block-status-style');
+    }
+
+    public function render_status_block($attributes, $content, $block) {
+        if (!function_exists('bjlg_can_manage_plugin') || !bjlg_can_manage_plugin()) {
+            return $this->render_notice(__('Vous n’avez pas l’autorisation d’afficher ce bloc.', 'backup-jlg'));
+        }
+
+        $snapshot = $this->get_status_snapshot();
+
+        if (!is_array($snapshot) || empty($snapshot['ok'])) {
+            $message = isset($snapshot['error']['message']) ? $snapshot['error']['message'] : __('Aucune donnée de sauvegarde disponible pour le moment.', 'backup-jlg');
+            return $this->render_notice($message);
+        }
+
+        $attributes = wp_parse_args(
+            is_array($attributes) ? $attributes : [],
+            [
+                'showAlerts' => true,
+                'showRecentBackups' => true,
+                'showLaunchButton' => true,
+            ]
+        );
+
+        $snapshot_attr = wp_json_encode($snapshot);
+
+        $wrapper_attributes = function_exists('get_block_wrapper_attributes')
+            ? get_block_wrapper_attributes([
+                'class' => 'bjlg-block-status',
+                'data-bjlg-status' => $snapshot_attr,
+            ])
+            : sprintf('class="bjlg-block-status" data-bjlg-status="%s"', esc_attr($snapshot_attr));
+
+        ob_start();
+        ?>
+        <section <?php echo $wrapper_attributes; ?>>
+            <header class="bjlg-block-status__header">
+                <h3 class="bjlg-block-status__title"><?php esc_html_e('Vue d’ensemble des sauvegardes', 'backup-jlg'); ?></h3>
+                <?php if (!empty($snapshot['generated_at'])): ?>
+                    <span class="bjlg-block-status__timestamp"><?php echo esc_html(sprintf(__('Actualisé le %s', 'backup-jlg'), $snapshot['generated_at'])); ?></span>
+                <?php endif; ?>
+            </header>
+
+            <div class="bjlg-block-status__summary">
+                <div class="bjlg-block-status__stat">
+                    <span class="bjlg-block-status__stat-label"><?php esc_html_e('Dernière sauvegarde', 'backup-jlg'); ?></span>
+                    <span class="bjlg-block-status__stat-value"><?php echo esc_html($snapshot['summary']['history_last_backup'] ?? __('N/A', 'backup-jlg')); ?></span>
+                    <?php if (!empty($snapshot['summary']['history_last_backup_relative'])): ?>
+                        <span class="bjlg-block-status__stat-meta"><?php echo esc_html($snapshot['summary']['history_last_backup_relative']); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="bjlg-block-status__stat">
+                    <span class="bjlg-block-status__stat-label"><?php esc_html_e('Prochaine sauvegarde planifiée', 'backup-jlg'); ?></span>
+                    <span class="bjlg-block-status__stat-value"><?php echo esc_html($snapshot['summary']['scheduler_next_run'] ?? __('N/A', 'backup-jlg')); ?></span>
+                    <?php if (!empty($snapshot['summary']['scheduler_next_run_relative'])): ?>
+                        <span class="bjlg-block-status__stat-meta"><?php echo esc_html($snapshot['summary']['scheduler_next_run_relative']); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="bjlg-block-status__stat">
+                    <span class="bjlg-block-status__stat-label"><?php esc_html_e('Archives stockées', 'backup-jlg'); ?></span>
+                    <span class="bjlg-block-status__stat-value"><?php echo esc_html(number_format_i18n($snapshot['summary']['storage_backup_count'] ?? 0)); ?></span>
+                    <?php if (!empty($snapshot['summary']['storage_total_size_human'])): ?>
+                        <span class="bjlg-block-status__stat-meta"><?php echo esc_html($snapshot['summary']['storage_total_size_human']); ?></span>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <?php if (!empty($attributes['showLaunchButton']) && !empty($snapshot['actions']['backup']['url'])): ?>
+                <div class="bjlg-block-status__actions">
+                    <a class="bjlg-block-status__button" href="<?php echo esc_url($snapshot['actions']['backup']['url']); ?>">
+                        <?php echo esc_html($snapshot['actions']['backup']['label']); ?>
+                    </a>
+                    <?php if (!empty($snapshot['actions']['restore']['url'])): ?>
+                        <a class="bjlg-block-status__button bjlg-block-status__button--secondary" href="<?php echo esc_url($snapshot['actions']['restore']['url']); ?>">
+                            <?php echo esc_html($snapshot['actions']['restore']['label']); ?>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($attributes['showAlerts']) && !empty($snapshot['alerts'])): ?>
+                <div class="bjlg-block-status__alerts">
+                    <?php foreach ($snapshot['alerts'] as $alert): ?>
+                        <div class="bjlg-block-status__alert bjlg-block-status__alert--<?php echo esc_attr($alert['type'] ?? 'info'); ?>">
+                            <div class="bjlg-block-status__alert-body">
+                                <strong><?php echo esc_html($alert['title'] ?? ''); ?></strong>
+                                <?php if (!empty($alert['message'])): ?>
+                                    <p><?php echo esc_html($alert['message']); ?></p>
+                                <?php endif; ?>
+                            </div>
+                            <?php if (!empty($alert['action']['url']) && !empty($alert['action']['label'])): ?>
+                                <a class="bjlg-block-status__alert-link" href="<?php echo esc_url($alert['action']['url']); ?>"><?php echo esc_html($alert['action']['label']); ?></a>
+                            <?php endif; ?>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($attributes['showRecentBackups'])): ?>
+                <div class="bjlg-block-status__recent">
+                    <h4 class="bjlg-block-status__section-title"><?php esc_html_e('Dernières archives', 'backup-jlg'); ?></h4>
+                    <?php if (!empty($snapshot['backups'])): ?>
+                        <ul class="bjlg-block-status__backup-list">
+                            <?php foreach ($snapshot['backups'] as $backup): ?>
+                                <li class="bjlg-block-status__backup-item">
+                                    <span class="bjlg-block-status__backup-name"><?php echo esc_html($backup['filename']); ?></span>
+                                    <span class="bjlg-block-status__backup-meta">
+                                        <?php echo esc_html($backup['created_at_relative'] ?? ''); ?>
+                                        <?php if (!empty($backup['size'])): ?>
+                                            · <?php echo esc_html($backup['size']); ?>
+                                        <?php endif; ?>
+                                    </span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p class="bjlg-block-status__empty"><?php esc_html_e('Aucune sauvegarde récente disponible.', 'backup-jlg'); ?></p>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+        </section>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    public function rest_get_status_snapshot(WP_REST_Request $request) {
+        $snapshot = $this->get_status_snapshot();
+
+        if (!is_array($snapshot)) {
+            return new WP_Error('bjlg_block_snapshot_error', __('Impossible de récupérer les données du bloc.', 'backup-jlg'), ['status' => 500]);
+        }
+
+        if (empty($snapshot['ok'])) {
+            return new WP_REST_Response($snapshot, 200);
+        }
+
+        return rest_ensure_response($snapshot);
+    }
+
+    private function register_assets() {
+        if (!wp_script_is('bjlg-block-status-editor', 'registered')) {
+            $deps = ['wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-block-editor', 'wp-data', 'wp-api-fetch'];
+            $version = BJLG_VERSION;
+            $asset_path = BJLG_PLUGIN_DIR . 'assets/js/block-status.asset.php';
+            if (file_exists($asset_path)) {
+                $asset = include $asset_path;
+                if (is_array($asset)) {
+                    $deps = $asset['dependencies'] ?? $deps;
+                    $version = $asset['version'] ?? $version;
+                }
+            }
+
+            wp_register_script(
+                'bjlg-block-status-editor',
+                BJLG_PLUGIN_URL . 'assets/js/block-status.js',
+                $deps,
+                $version,
+                true
+            );
+            if (function_exists('wp_set_script_translations')) {
+                wp_set_script_translations('bjlg-block-status-editor', 'backup-jlg', BJLG_PLUGIN_DIR . 'languages');
+            }
+        }
+
+        if (!wp_style_is('bjlg-block-status-style', 'registered')) {
+            $style_path = BJLG_PLUGIN_DIR . 'assets/css/block-status.css';
+            $version = file_exists($style_path) ? filemtime($style_path) : BJLG_VERSION;
+            wp_register_style(
+                'bjlg-block-status-style',
+                BJLG_PLUGIN_URL . 'assets/css/block-status.css',
+                [],
+                $version
+            );
+        }
+    }
+
+    private function get_status_snapshot() {
+        if (self::$snapshot !== null) {
+            return self::$snapshot;
+        }
+
+        if (!function_exists('bjlg_can_manage_plugin') || !bjlg_can_manage_plugin()) {
+            self::$snapshot = [
+                'ok' => false,
+                'error' => [
+                    'code' => 'forbidden',
+                    'message' => __('Vous n’avez pas l’autorisation de consulter ces informations.', 'backup-jlg'),
+                ],
+            ];
+            return self::$snapshot;
+        }
+
+        if (!class_exists(BJLG_Admin_Advanced::class)) {
+            self::$snapshot = [
+                'ok' => false,
+                'error' => [
+                    'code' => 'missing_metrics',
+                    'message' => __('Les métriques du tableau de bord ne sont pas disponibles.', 'backup-jlg'),
+                ],
+            ];
+            return self::$snapshot;
+        }
+
+        $advanced = new BJLG_Admin_Advanced();
+        $metrics = $advanced->get_dashboard_metrics();
+
+        $summary = $metrics['summary'] ?? [];
+        $alerts = $metrics['alerts'] ?? [];
+        $generated_at = $metrics['generated_at'] ?? '';
+        $backups = $this->get_recent_backups();
+
+        $actions = $this->get_actions_links();
+
+        self::$snapshot = [
+            'ok' => true,
+            'generated_at' => $generated_at,
+            'summary' => $summary,
+            'alerts' => $alerts,
+            'backups' => $backups,
+            'actions' => $actions,
+        ];
+
+        return self::$snapshot;
+    }
+
+    private function get_actions_links(): array {
+        $backup_tab_url = add_query_arg(
+            [
+                'page' => 'backup-jlg',
+                'tab' => 'backup_restore',
+            ],
+            admin_url('admin.php')
+        );
+
+        return [
+            'backup' => [
+                'label' => __('Lancer une sauvegarde', 'backup-jlg'),
+                'url' => $backup_tab_url . '#bjlg-backup-creation-form',
+            ],
+            'restore' => [
+                'label' => __('Restaurer une archive', 'backup-jlg'),
+                'url' => $backup_tab_url . '#bjlg-restore-form',
+            ],
+        ];
+    }
+
+    private function get_recent_backups(): array {
+        if (!function_exists('rest_do_request')) {
+            return [];
+        }
+
+        $request = new WP_REST_Request('GET', '/backup-jlg/v1/backups');
+        $request->set_param('per_page', self::RECENT_BACKUPS_LIMIT);
+        $response = rest_do_request($request);
+
+        if (!($response instanceof WP_REST_Response)) {
+            return [];
+        }
+
+        $data = $response->get_data();
+        if (!is_array($data) || empty($data['backups']) || !is_array($data['backups'])) {
+            return [];
+        }
+
+        $now = current_time('timestamp');
+        $prepared = [];
+
+        foreach ($data['backups'] as $backup) {
+            if (!is_array($backup)) {
+                continue;
+            }
+
+            $created_at = isset($backup['created_at']) ? strtotime((string) $backup['created_at']) : false;
+            $prepared[] = [
+                'id' => $backup['id'] ?? '',
+                'filename' => $backup['filename'] ?? '',
+                'type' => $backup['type'] ?? '',
+                'size' => $backup['size_formatted'] ?? '',
+                'created_at' => $created_at ? $this->format_datetime($created_at) : '',
+                'created_at_relative' => $created_at ? sprintf(__('il y a %s', 'backup-jlg'), human_time_diff($created_at, $now)) : '',
+            ];
+        }
+
+        return $prepared;
+    }
+
+    private function format_datetime(int $timestamp): string {
+        if (function_exists('wp_date')) {
+            return wp_date(get_option('date_format') . ' ' . get_option('time_format'), $timestamp);
+        }
+
+        return date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $timestamp);
+    }
+
+    private function render_notice(string $message): string {
+        return sprintf('<div class="bjlg-block-status__notice">%s</div>', esc_html($message));
+    }
+}

--- a/backup-jlg/readme.md
+++ b/backup-jlg/readme.md
@@ -131,6 +131,23 @@ Une fois l'autorisation OAuth terminée, rendez-vous dans **Backup JLG → Régl
    - Pour les sauvegardes chiffrées (`.enc`), fournissez le mot de passe exact (minimum 4 caractères). Les champs vides sont refusés
      afin de garantir la protection des archives.
 
+### Bloc éditeur « État des sauvegardes »
+
+> 💡 Ce bloc dynamique s’appuie sur les métriques du tableau de bord et l’API REST `backup-jlg/v1/backups` pour présenter un résumé "front-office" fidèle.
+
+1. Dans l’éditeur de blocs, ajoutez **Backup JLG → État des sauvegardes JLG**.
+2. Utilisez le panneau **Options du bloc** pour choisir :
+   - l’affichage du bouton **« Lancer une sauvegarde »** (ouvre la page d’administration correspondante),
+   - l’affichage des alertes (échecs récents, absence d’archives, etc.),
+   - l’affichage de la liste des **dernières archives générées**.
+3. Le bloc montre automatiquement :
+   - la dernière sauvegarde réussie et la prochaine exécution planifiée,
+   - la taille totale du stockage et le nombre d’archives,
+   - un CTA secondaire vers l’assistant de restauration.
+4. En cas d’erreur ou d’accès interdit, un message dédié apparaît et un bouton « Réessayer » permet de relancer le chargement.
+
+👉 Conseil : placez ce bloc sur une page interne destinée aux administrateurs afin qu’ils puissent lancer rapidement une sauvegarde ou consulter l’état du stockage sans ouvrir tout le tableau de bord.
+
 ### API REST
 
 #### Authentification


### PR DESCRIPTION
## Summary
- register the BJLG_Blocks service to expose a dynamic `backup-jlg/status` block and REST endpoint
- add block metadata, editor assets, and styling to surface backup metrics with loading and error states in the editor
- document how to configure the new status block from the block editor

## Testing
- php -l backup-jlg/includes/class-bjlg-blocks.php
- php -l backup-jlg/backup-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68e2684353c8832eb35f0132ffaab686