### PR TITLE
Add configurable incremental rotation with synthetic merging

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -953,6 +953,16 @@ class BJLG_Admin {
      */
     private function render_settings_section() {
         $cleanup_settings = get_option('bjlg_cleanup_settings', ['by_number' => 3, 'by_age' => 0]);
+        $incremental_defaults = [
+            'max_incrementals' => 10,
+            'max_full_age_days' => 30,
+            'rotation_enabled' => true,
+        ];
+        $incremental_settings = get_option('bjlg_incremental_settings', []);
+        if (!is_array($incremental_settings)) {
+            $incremental_settings = [];
+        }
+        $incremental_settings = wp_parse_args($incremental_settings, $incremental_defaults);
         $schedule_collection = $this->get_schedule_settings_for_display();
         $schedules = isset($schedule_collection['schedules']) && is_array($schedule_collection['schedules'])
             ? array_values($schedule_collection['schedules'])
@@ -1212,7 +1222,76 @@ class BJLG_Admin {
                         </td>
                     </tr>
                 </table>
-                
+
+                <h3><span class="dashicons dashicons-update" aria-hidden="true"></span> Sauvegardes incrémentales</h3>
+                <table class="form-table">
+                    <tr>
+                        <th scope="row"><label for="bjlg-incremental-max-age">Age maximal de la sauvegarde complète</label></th>
+                        <td>
+                            <div class="bjlg-field-control">
+                                <div class="bjlg-form-field-group">
+                                    <div class="bjlg-form-field-control">
+                                        <input
+                                            id="bjlg-incremental-max-age"
+                                            name="incremental_max_age"
+                                            type="number"
+                                            class="small-text"
+                                            value="<?php echo esc_attr($incremental_settings['max_full_age_days']); ?>"
+                                            min="0"
+                                            aria-describedby="bjlg-incremental-max-age-description"
+                                        >
+                                    </div>
+                                    <div class="bjlg-form-field-actions">
+                                        <span class="bjlg-form-field-unit">jours</span>
+                                    </div>
+                                </div>
+                                <p id="bjlg-incremental-max-age-description" class="description">Au-delà de cette limite, une nouvelle sauvegarde complète est forcée. 0 = illimité.</p>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="bjlg-incremental-max-count">Nombre d'incréments consécutifs</label></th>
+                        <td>
+                            <div class="bjlg-field-control">
+                                <div class="bjlg-form-field-group">
+                                    <div class="bjlg-form-field-control">
+                                        <input
+                                            id="bjlg-incremental-max-count"
+                                            name="incremental_max_incrementals"
+                                            type="number"
+                                            class="small-text"
+                                            value="<?php echo esc_attr($incremental_settings['max_incrementals']); ?>"
+                                            min="0"
+                                            aria-describedby="bjlg-incremental-max-count-description"
+                                        >
+                                    </div>
+                                    <div class="bjlg-form-field-actions">
+                                        <span class="bjlg-form-field-unit">incréments</span>
+                                    </div>
+                                </div>
+                                <p id="bjlg-incremental-max-count-description" class="description">0 = illimité. Au-delà, les incréments les plus anciens sont fusionnés automatiquement.</p>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Rotation automatique</th>
+                        <td>
+                            <div class="bjlg-field-control">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        name="incremental_rotation_enabled"
+                                        value="1"
+                                        <?php checked(!empty($incremental_settings['rotation_enabled'])); ?>
+                                    >
+                                    Activer la fusion automatique en sauvegarde synthétique («&nbsp;synth full&nbsp;»)
+                                </label>
+                                <p class="description">Lorsque la limite d'incréments est atteinte, les plus anciens sont fusionnés dans la dernière complète sans lancer un nouvel export complet.</p>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
                 <h3><span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span> Marque Blanche</h3>
                 <table class="form-table">
                     <tr>

--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -33,6 +33,11 @@ class BJLG_Settings {
             'password_protect' => false,
             'compression_level' => 6
         ],
+        'incremental' => [
+            'max_incrementals' => 10,
+            'max_full_age_days' => 30,
+            'rotation_enabled' => true,
+        ],
         'notifications' => [
             'enabled' => false,
             'email_recipients' => '',
@@ -170,6 +175,34 @@ class BJLG_Settings {
                 update_option('bjlg_cleanup_settings', $cleanup_settings);
                 $saved_settings['cleanup'] = $cleanup_settings;
                 BJLG_Debug::log("Réglages de nettoyage sauvegardés : " . print_r($cleanup_settings, true));
+            }
+
+            // --- Réglages des sauvegardes incrémentales ---
+            if (
+                isset($_POST['incremental_max_incrementals'])
+                || isset($_POST['incremental_max_age'])
+                || array_key_exists('incremental_rotation_enabled', $_POST)
+            ) {
+                $max_incrementals = isset($_POST['incremental_max_incrementals'])
+                    ? max(0, intval(wp_unslash($_POST['incremental_max_incrementals'])))
+                    : 10;
+                $max_age_days = isset($_POST['incremental_max_age'])
+                    ? max(0, intval(wp_unslash($_POST['incremental_max_age'])))
+                    : 30;
+                $rotation_enabled = array_key_exists('incremental_rotation_enabled', $_POST)
+                    ? $this->to_bool(wp_unslash($_POST['incremental_rotation_enabled']))
+                    : false;
+
+                $incremental_settings = [
+                    'max_incrementals' => $max_incrementals,
+                    'max_full_age_days' => $max_age_days,
+                    'rotation_enabled' => $rotation_enabled,
+                ];
+
+                update_option('bjlg_incremental_settings', $incremental_settings);
+                $saved_settings['incremental'] = $incremental_settings;
+
+                BJLG_Debug::log('Réglages incrémentaux sauvegardés : ' . print_r($incremental_settings, true));
             }
 
             // --- Réglages de la Marque Blanche ---


### PR DESCRIPTION
## Summary
- expose incremental backup thresholds and rotation toggle in the settings UI and persist them as WordPress options
- extend the incremental manifest with destination tracking, synthetic-full rotation, and a remote purge queue
- cover the new rotation behaviour with unit tests in BJLG_IncrementalManifestTest

## Testing
- `composer test` *(fails: phpunit binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26c16f614832e82e264947b7ca29a