### PR TITLE
Add Dropbox, OneDrive, and pCloud destinations

### DIFF
--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -39,6 +39,9 @@ class BJLG_Admin {
         if (class_exists(BJLG_OneDrive::class)) {
             $this->destinations['onedrive'] = new BJLG_OneDrive();
         }
+        if (class_exists(BJLG_pCloud::class)) {
+            $this->destinations['pcloud'] = new BJLG_pCloud();
+        }
         if (class_exists(BJLG_SFTP::class)) {
             $this->destinations['sftp'] = new BJLG_SFTP();
         }
@@ -1795,7 +1798,11 @@ class BJLG_Admin {
             $choices = [
                 'google_drive' => 'Google Drive',
                 'aws_s3' => 'Amazon S3',
+                'dropbox' => 'Dropbox',
+                'onedrive' => 'Microsoft OneDrive',
+                'pcloud' => 'pCloud',
                 'sftp' => 'Serveur SFTP',
+                'wasabi' => 'Wasabi',
             ];
         }
 

--- a/backup-jlg/includes/class-bjlg-backup.php
+++ b/backup-jlg/includes/class-bjlg-backup.php
@@ -1823,6 +1823,11 @@ class BJLG_Backup {
                     return new BJLG_OneDrive();
                 }
                 break;
+            case 'pcloud':
+                if (class_exists(BJLG_pCloud::class)) {
+                    return new BJLG_pCloud();
+                }
+                break;
             case 'sftp':
                 if (!class_exists(BJLG_SFTP::class)) {
                     break;

--- a/backup-jlg/includes/class-bjlg-cleanup.php
+++ b/backup-jlg/includes/class-bjlg-cleanup.php
@@ -414,6 +414,11 @@ class BJLG_Cleanup {
                     return new BJLG_OneDrive();
                 }
                 break;
+            case 'pcloud':
+                if (class_exists(BJLG_pCloud::class)) {
+                    return new BJLG_pCloud();
+                }
+                break;
             case 'sftp':
                 if (class_exists(BJLG_SFTP::class)) {
                     return new BJLG_SFTP();

--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -74,6 +74,21 @@ class BJLG_Settings {
             'object_prefix' => '',
             'enabled' => false,
         ],
+        'dropbox' => [
+            'access_token' => '',
+            'folder' => '',
+            'enabled' => false,
+        ],
+        'onedrive' => [
+            'access_token' => '',
+            'folder' => '',
+            'enabled' => false,
+        ],
+        'pcloud' => [
+            'access_token' => '',
+            'folder' => '',
+            'enabled' => false,
+        ],
         'azure_blob' => [
             'account_name' => '',
             'account_key' => '',
@@ -387,6 +402,19 @@ class BJLG_Settings {
                 update_option('bjlg_onedrive_settings', $onedrive_settings);
                 $saved_settings['onedrive'] = $onedrive_settings;
                 BJLG_Debug::log('Réglages OneDrive sauvegardés.');
+            }
+
+            // --- Réglages pCloud ---
+            if (isset($_POST['pcloud_access_token']) || isset($_POST['pcloud_folder'])) {
+                $pcloud_settings = [
+                    'access_token' => isset($_POST['pcloud_access_token']) ? sanitize_text_field(wp_unslash($_POST['pcloud_access_token'])) : '',
+                    'folder' => isset($_POST['pcloud_folder']) ? sanitize_text_field(wp_unslash($_POST['pcloud_folder'])) : '',
+                    'enabled' => isset($_POST['pcloud_enabled']) ? $this->to_bool(wp_unslash($_POST['pcloud_enabled'])) : false,
+                ];
+
+                update_option('bjlg_pcloud_settings', $pcloud_settings);
+                $saved_settings['pcloud'] = $pcloud_settings;
+                BJLG_Debug::log('Réglages pCloud sauvegardés.');
             }
 
 
@@ -1765,7 +1793,7 @@ class BJLG_Settings {
     }
 
     public static function get_known_destination_ids() {
-        $destinations = ['google_drive', 'aws_s3', 'sftp', 'dropbox', 'onedrive', 'wasabi'];
+        $destinations = ['google_drive', 'aws_s3', 'sftp', 'dropbox', 'onedrive', 'pcloud', 'wasabi'];
 
         /** @var array<int, string> $filtered */
         $filtered = apply_filters('bjlg_known_destination_ids', $destinations);

--- a/backup-jlg/tests/BJLG_DropboxDestinationTest.php
+++ b/backup-jlg/tests/BJLG_DropboxDestinationTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+use BJLG\BJLG_Dropbox;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/destinations/interface-bjlg-destination.php';
+require_once __DIR__ . '/../includes/destinations/class-bjlg-dropbox.php';
+
+final class BJLG_DropboxDestinationTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $requests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requests = [];
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    public function test_upload_file_sends_archive_to_dropbox(): void
+    {
+        $handler = function (string $url, array $args) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            return [
+                'response' => ['code' => 200],
+                'body' => json_encode(['name' => 'uploaded.zip']),
+            ];
+        };
+
+        $destination = new BJLG_Dropbox($handler, static function (): int {
+            return 1_700_000_000;
+        });
+
+        update_option('bjlg_dropbox_settings', [
+            'access_token' => 'token-123',
+            'folder' => '/Backups',
+            'enabled' => true,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        self::assertIsString($file);
+        file_put_contents($file, 'dropbox-archive');
+
+        $destination->upload_file($file, 'task-123');
+
+        $this->assertCount(1, $this->requests);
+        $request = $this->requests[0];
+
+        $this->assertSame('https://content.dropboxapi.com/2/files/upload', $request['url']);
+        $this->assertSame('POST', $request['args']['method']);
+        $this->assertSame('dropbox-archive', $request['args']['body']);
+
+        $headers = $request['args']['headers'];
+        $this->assertArrayHasKey('Authorization', $headers);
+        $this->assertSame('Bearer token-123', $headers['Authorization']);
+        $this->assertArrayHasKey('Dropbox-API-Arg', $headers);
+
+        $apiArgs = json_decode((string) $headers['Dropbox-API-Arg'], true);
+        $this->assertSame('/Backups/' . basename($file), $apiArgs['path']);
+        $this->assertSame('application/octet-stream', $headers['Content-Type']);
+
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    public function test_prune_remote_backups_deletes_old_archives(): void
+    {
+        $now = 1_700_000_000;
+
+        $handler = function (string $url, array $args) use ($now) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            if (strpos($url, 'list_folder') !== false) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'entries' => [
+                            [
+                                '.tag' => 'file',
+                                'id' => 'id-old',
+                                'path_display' => '/Backups/backup-old.zip',
+                                'server_modified' => gmdate('c', $now - 10 * DAY_IN_SECONDS),
+                                'size' => 123,
+                            ],
+                            [
+                                '.tag' => 'file',
+                                'id' => 'id-new',
+                                'path_display' => '/Backups/backup-new.zip',
+                                'server_modified' => gmdate('c', $now - DAY_IN_SECONDS),
+                                'size' => 456,
+                            ],
+                        ],
+                    ]),
+                ];
+            }
+
+            if (strpos($url, 'delete_v2') !== false) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode(['metadata' => ['id' => 'deleted']]),
+                ];
+            }
+
+            return [
+                'response' => ['code' => 200],
+                'body' => '{}',
+            ];
+        };
+
+        $destination = new BJLG_Dropbox($handler, static function () use ($now): int {
+            return $now;
+        });
+
+        update_option('bjlg_dropbox_settings', [
+            'access_token' => 'token-123',
+            'folder' => '/Backups',
+            'enabled' => true,
+        ]);
+
+        $result = $destination->prune_remote_backups(1, 5);
+
+        $this->assertSame(1, $result['deleted']);
+        $this->assertContains('backup-old.zip', $result['deleted_items']);
+        $this->assertSame(2, $result['inspected']);
+
+        $this->assertGreaterThanOrEqual(2, count($this->requests));
+
+        $deleteRequest = $this->requests[1];
+        $payload = json_decode((string) $deleteRequest['args']['body'], true);
+        $this->assertSame('/Backups/backup-old.zip', $payload['path']);
+    }
+}

--- a/backup-jlg/tests/BJLG_OneDriveDestinationTest.php
+++ b/backup-jlg/tests/BJLG_OneDriveDestinationTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+use BJLG\BJLG_OneDrive;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/destinations/interface-bjlg-destination.php';
+require_once __DIR__ . '/../includes/destinations/class-bjlg-onedrive.php';
+
+final class BJLG_OneDriveDestinationTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $requests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requests = [];
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    public function test_upload_file_puts_archive_in_onedrive(): void
+    {
+        $handler = function (string $url, array $args) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            return [
+                'response' => ['code' => 201],
+                'body' => json_encode(['id' => 'item-id']),
+            ];
+        };
+
+        $destination = new BJLG_OneDrive($handler, static function (): int {
+            return 1_700_000_000;
+        });
+
+        update_option('bjlg_onedrive_settings', [
+            'access_token' => 'access-token',
+            'folder' => '/Archives',
+            'enabled' => true,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        self::assertIsString($file);
+        file_put_contents($file, 'onedrive-data');
+
+        $destination->upload_file($file, 'task-456');
+
+        $this->assertCount(1, $this->requests);
+        $request = $this->requests[0];
+
+        $this->assertSame('PUT', $request['args']['method']);
+        $this->assertStringContainsString('/me/drive/root:/Archives/' . basename($file) . ':/content', $request['url']);
+        $this->assertSame('onedrive-data', $request['args']['body']);
+
+        $headers = $request['args']['headers'];
+        $this->assertSame('Bearer access-token', $headers['Authorization']);
+        $this->assertSame('application/octet-stream', $headers['Content-Type']);
+
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    public function test_prune_remote_backups_removes_extra_items(): void
+    {
+        $now = 1_700_000_000;
+
+        $handler = function (string $url, array $args) use ($now) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            if (strpos($url, '/children') !== false) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'value' => [
+                            [
+                                'id' => 'id-old',
+                                'name' => 'backup-old.zip',
+                                'file' => ['mimeType' => 'application/zip'],
+                                'lastModifiedDateTime' => gmdate('c', $now - 9 * DAY_IN_SECONDS),
+                                'size' => 123,
+                            ],
+                            [
+                                'id' => 'id-new',
+                                'name' => 'backup-new.zip',
+                                'file' => ['mimeType' => 'application/zip'],
+                                'lastModifiedDateTime' => gmdate('c', $now - 2 * DAY_IN_SECONDS),
+                                'size' => 456,
+                            ],
+                        ],
+                    ]),
+                ];
+            }
+
+            if (strpos($url, '/drive/items/') !== false && strtoupper($args['method']) === 'DELETE') {
+                return [
+                    'response' => ['code' => 204],
+                    'body' => '',
+                ];
+            }
+
+            return [
+                'response' => ['code' => 200],
+                'body' => '{}',
+            ];
+        };
+
+        $destination = new BJLG_OneDrive($handler, static function () use ($now): int {
+            return $now;
+        });
+
+        update_option('bjlg_onedrive_settings', [
+            'access_token' => 'access-token',
+            'folder' => '/Archives',
+            'enabled' => true,
+        ]);
+
+        $result = $destination->prune_remote_backups(1, 5);
+
+        $this->assertSame(1, $result['deleted']);
+        $this->assertContains('backup-old.zip', $result['deleted_items']);
+        $this->assertSame(2, $result['inspected']);
+
+        $this->assertGreaterThanOrEqual(2, count($this->requests));
+
+        $deleteRequest = $this->requests[1];
+        $this->assertSame('DELETE', strtoupper($deleteRequest['args']['method']));
+        $this->assertStringContainsString('id-old', $deleteRequest['url']);
+    }
+}

--- a/backup-jlg/tests/BJLG_pCloudDestinationTest.php
+++ b/backup-jlg/tests/BJLG_pCloudDestinationTest.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+use BJLG\BJLG_pCloud;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/destinations/interface-bjlg-destination.php';
+require_once __DIR__ . '/../includes/destinations/class-bjlg-pcloud.php';
+
+final class BJLG_pCloudDestinationTest extends TestCase
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $requests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requests = [];
+        $GLOBALS['bjlg_test_options'] = [];
+    }
+
+    public function test_upload_file_streams_archive_to_pcloud(): void
+    {
+        $handler = function (string $url, array $args) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            return [
+                'response' => ['code' => 200],
+                'body' => json_encode(['result' => 0]),
+            ];
+        };
+
+        $destination = new BJLG_pCloud($handler, static function (): int {
+            return 1_700_000_000;
+        });
+
+        update_option('bjlg_pcloud_settings', [
+            'access_token' => 'pc-token',
+            'folder' => '/Archives',
+            'enabled' => true,
+        ]);
+
+        $file = tempnam(sys_get_temp_dir(), 'bjlg');
+        self::assertIsString($file);
+        file_put_contents($file, 'pcloud-content');
+
+        $destination->upload_file($file, 'task-789');
+
+        $this->assertCount(1, $this->requests);
+        $request = $this->requests[0];
+
+        $this->assertSame('https://api.pcloud.com/uploadfile', $request['url']);
+        $this->assertSame('POST', strtoupper($request['args']['method']));
+        $this->assertSame('pcloud-content', $request['args']['body']);
+
+        $headers = $request['args']['headers'];
+        $this->assertSame('Bearer pc-token', $headers['Authorization']);
+        $this->assertSame('/Archives/' . basename($file), $headers['X-PCloud-Path']);
+        $this->assertSame('1', $headers['X-PCloud-Overwrite']);
+
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    public function test_prune_remote_backups_removes_expired_files(): void
+    {
+        $now = 1_700_000_000;
+
+        $handler = function (string $url, array $args) use ($now) {
+            $this->requests[] = ['url' => $url, 'args' => $args];
+
+            if (strpos($url, 'listfolder') !== false) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode([
+                        'metadata' => [
+                            'contents' => [
+                                [
+                                    'fileid' => '1001',
+                                    'name' => 'backup-old.zip',
+                                    'path' => '/Archives/backup-old.zip',
+                                    'modified' => gmdate('c', $now - 12 * DAY_IN_SECONDS),
+                                    'size' => 100,
+                                ],
+                                [
+                                    'fileid' => '1002',
+                                    'name' => 'backup-new.zip',
+                                    'path' => '/Archives/backup-new.zip',
+                                    'modified' => gmdate('c', $now - 2 * DAY_IN_SECONDS),
+                                    'size' => 200,
+                                ],
+                            ],
+                        ],
+                    ]),
+                ];
+            }
+
+            if (strpos($url, 'deletefile') !== false) {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode(['result' => 0]),
+                ];
+            }
+
+            return [
+                'response' => ['code' => 200],
+                'body' => '{}',
+            ];
+        };
+
+        $destination = new BJLG_pCloud($handler, static function () use ($now): int {
+            return $now;
+        });
+
+        update_option('bjlg_pcloud_settings', [
+            'access_token' => 'pc-token',
+            'folder' => '/Archives',
+            'enabled' => true,
+        ]);
+
+        $result = $destination->prune_remote_backups(1, 5);
+
+        $this->assertSame(1, $result['deleted']);
+        $this->assertContains('backup-old.zip', $result['deleted_items']);
+        $this->assertSame(2, $result['inspected']);
+
+        $this->assertGreaterThanOrEqual(2, count($this->requests));
+
+        $deleteRequest = $this->requests[1];
+        $payload = json_decode((string) $deleteRequest['args']['body'], true);
+        $this->assertSame('1001', $payload['fileid']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a first-class pCloud destination with connection handling, upload/list/prune logic, and admin UI wiring
- enhance Dropbox and OneDrive destinations with connection test/disconnect flows and register them in settings, cleanup, and backup factories
- surface the new providers in admin choices/assets and cover Dropbox, OneDrive, and pCloud behaviours with PHPUnit tests

## Testing
- `vendor-bjlg/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68e27617fb2c832e848b03855a4f7990