### PR TITLE
Add sandbox restore workflow with UI controls

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -2990,6 +2990,8 @@ jQuery(document).ready(function($) {
         const fileInput = document.getElementById('bjlg-restore-file-input');
         const passwordInput = document.getElementById('bjlg-restore-password');
         const passwordHelp = document.getElementById('bjlg-restore-password-help');
+        const $sandboxToggle = $form.find('input[name="restore_to_sandbox"]');
+        const $sandboxPathInput = $form.find('input[name="sandbox_path"]');
         const passwordHelpDefaultText = passwordHelp
             ? (passwordHelp.getAttribute('data-default-text') || passwordHelp.textContent.trim())
             : '';
@@ -2998,6 +3000,29 @@ jQuery(document).ready(function($) {
             : '';
         const $errorNotice = $('#bjlg-restore-errors');
         const errorFieldClass = 'bjlg-input-error';
+
+        function syncSandboxState() {
+            if (!$sandboxPathInput.length) {
+                return;
+            }
+
+            const enabled = $sandboxToggle.length && $sandboxToggle.is(':checked');
+            $sandboxPathInput.prop('disabled', !enabled);
+
+            if (!enabled) {
+                $sandboxPathInput.removeClass(errorFieldClass).removeAttr('aria-invalid');
+            }
+        }
+
+        if ($form.data('bjlgSandboxBound') !== true) {
+            $form.data('bjlgSandboxBound', true);
+
+            if ($sandboxToggle.length) {
+                $sandboxToggle.on('change', syncSandboxState);
+            }
+        }
+
+        syncSandboxState();
 
         function setRestoreBusyState(isBusy) {
             const busyValue = isBusy ? 'true' : 'false';
@@ -3307,10 +3332,21 @@ jQuery(document).ready(function($) {
             $debugOutput.text('');
         }
 
+        const sandboxEnabled = $sandboxToggle.length && $sandboxToggle.is(':checked');
+        const sandboxPathValue = $sandboxPathInput.length && typeof $sandboxPathInput.val() === 'string'
+            ? $sandboxPathInput.val().trim()
+            : '';
+        const restoreEnvironment = sandboxEnabled ? 'sandbox' : 'production';
+
         const formData = new FormData();
         formData.append('action', 'bjlg_upload_restore_file');
         formData.append('nonce', bjlg_ajax.nonce);
         formData.append('restore_file', fileInput.files[0]);
+        formData.append('restore_environment', restoreEnvironment);
+
+        if (sandboxEnabled) {
+            formData.append('sandbox_path', sandboxPathValue);
+        }
 
         if ($debugOutput.length) {
             appendRestoreDebug(
@@ -3319,7 +3355,9 @@ jQuery(document).ready(function($) {
                     filename: fileInput.files[0].name,
                     size: fileInput.files[0].size,
                     type: fileInput.files[0].type || 'inconnu',
-                    create_backup_before_restore: createRestorePoint
+                    create_backup_before_restore: createRestorePoint,
+                    restore_environment: restoreEnvironment,
+                    sandbox_path: sandboxEnabled ? sandboxPathValue : ''
                 }
             );
         }
@@ -3335,7 +3373,7 @@ jQuery(document).ready(function($) {
             appendRestoreDebug('Réponse du serveur (téléversement)', response);
             if (response.success && response.data && response.data.filename) {
                 setRestoreStatusText('Fichier téléversé. Préparation de la restauration...');
-                runRestore(response.data.filename, createRestorePoint);
+                runRestore(response.data.filename, createRestorePoint, restoreEnvironment, sandboxPathValue);
             } else {
                 const payload = response && response.data ? response.data : {};
                 const message = payload && payload.message
@@ -3369,14 +3407,19 @@ jQuery(document).ready(function($) {
             $button.prop('disabled', false);
         });
 
-        function runRestore(filename, createRestorePointChecked) {
+        function runRestore(filename, createRestorePointChecked, environment, sandboxPath) {
             const requestData = {
                 action: 'bjlg_run_restore',
                 nonce: bjlg_ajax.nonce,
                 filename: filename,
                 create_backup_before_restore: createRestorePointChecked ? 1 : 0,
-                password: passwordInput ? passwordInput.value : ''
+                password: passwordInput ? passwordInput.value : '',
+                restore_environment: environment
             };
+
+            if (environment === 'sandbox') {
+                requestData.sandbox_path = sandboxPath;
+            }
 
             setRestoreBusyState(true);
             setRestoreStatusText('Initialisation de la restauration...');

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -836,6 +836,27 @@ class BJLG_Admin {
                                 </div>
                             </td>
                         </tr>
+                        <?php if (BJLG_Restore::user_can_use_sandbox()) : ?>
+                        <tr>
+                            <th scope="row">Environnement de test</th>
+                            <td>
+                                <div class="bjlg-field-control">
+                                    <label>
+                                        <input type="checkbox" name="restore_to_sandbox" value="1">
+                                        Restaurer dans un environnement de test
+                                    </label>
+                                    <p class="description">Les fichiers seront restaurés dans un dossier isolé sans impacter la production.</p>
+                                    <label for="bjlg-restore-sandbox-path" class="screen-reader-text">Chemin de la sandbox</label>
+                                    <input type="text"
+                                           id="bjlg-restore-sandbox-path"
+                                           name="sandbox_path"
+                                           class="regular-text"
+                                           placeholder="Laisser vide pour utiliser le dossier sandbox automatique"
+                                           disabled>
+                                </div>
+                            </td>
+                        </tr>
+                        <?php endif; ?>
                     </tbody>
                 </table>
                 <div id="bjlg-restore-errors" class="notice notice-error" style="display: none;" role="alert"></div>


### PR DESCRIPTION
## Summary
- extend BJLG_Restore to prepare sandbox routing, accept alternate targets, and expose cleanup/publish actions with history logging
- expose a “Restaurer dans un environnement de test” option in the admin UI/JS and propagate sandbox parameters through the async restore flow and REST endpoint
- add tests covering sandbox restores to ensure production paths are untouched

## Testing
- vendor-bjlg/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e276305f40832eaf65ab3b14f32113