### PR TITLE
Refactor database export batching

### DIFF
--- a/backup-jlg/tests/stubs/class-bjlg-incremental-stub.php
+++ b/backup-jlg/tests/stubs/class-bjlg-incremental-stub.php
@@ -1,0 +1,39 @@
+<?php
+namespace BJLG {
+    if (!class_exists(__NAMESPACE__ . '\\BJLG_Incremental', false)) {
+        class BJLG_Incremental
+        {
+            /** @var self|null */
+            public static $latestInstance = null;
+
+            /** @var array<string, bool> */
+            public static $changedTables = [];
+
+            /** @var array<int, string> */
+            public static $checkedTables = [];
+
+            public function __construct()
+            {
+                self::$latestInstance = $this;
+            }
+
+            public static function get_latest_instance()
+            {
+                return self::$latestInstance;
+            }
+
+            public function table_has_changed($table_name)
+            {
+                self::$checkedTables[] = $table_name;
+
+                return self::$changedTables[$table_name] ?? false;
+            }
+        }
+    }
+}
+
+namespace {
+    if (!class_exists('BJLG_Incremental', false)) {
+        class_alias('BJLG\\BJLG_Incremental', 'BJLG_Incremental');
+    }
+}


### PR DESCRIPTION
## Summary
- switch database export batching to primary-key pagination with a streaming fallback
- harden identifier handling when emitting SQL dumps
- extend backup database tests with new scenarios and an incremental stub

## Testing
- `vendor-bjlg/bin/phpunit --configuration phpunit.xml tests/BJLG_BackupDatabaseTest.php` *(fails: Fatal error: Cannot redeclare BJLG\\BJLG_Dropbox::handle_test_connection())*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6c26bc4832ea2481789a6b274e8