### PR TITLE
Fix duplicate Dropbox and OneDrive connection handlers

### DIFF
--- a/backup-jlg/includes/destinations/class-bjlg-dropbox.php
+++ b/backup-jlg/includes/destinations/class-bjlg-dropbox.php
@@ -114,25 +114,15 @@ class BJLG_Dropbox implements BJLG_Destination_Interface {
     public function test_connection(?array $settings = null) {
         $settings = $settings ? array_merge($this->get_default_settings(), $settings) : $this->get_settings();
 
-        if (empty($settings['access_token'])) {
-            throw new Exception("Token d'accès Dropbox manquant.");
-        }
-
-        $path = $this->normalize_folder($settings['folder']);
-        $this->api_json('https://api.dropboxapi.com/2/files/list_folder', [
-            'path' => $path === '' ? '' : $path,
-            'recursive' => false,
-            'include_media_info' => false,
-            'include_deleted' => false,
-        ], $settings);
+        $result = $this->run_test_connection($settings);
 
         $this->store_status([
             'last_result' => 'success',
-            'tested_at' => $this->get_time(),
-            'message' => 'Connexion Dropbox vérifiée avec succès.',
+            'tested_at' => $result['tested_at'],
+            'message' => $result['message'],
         ]);
 
-        return true;
+        return $result;
     }
 
     public function handle_test_connection() {
@@ -149,37 +139,44 @@ class BJLG_Dropbox implements BJLG_Destination_Interface {
         ];
 
         try {
-            $this->test_connection($settings);
-            wp_send_json_success(['message' => 'Connexion Dropbox réussie.']);
+            $result = $this->test_connection($settings);
+
+            wp_send_json_success([
+                'message' => $result['message'],
+                'status_message' => $result['message'],
+                'tested_at' => $result['tested_at'],
+                'tested_at_formatted' => gmdate('d/m/Y H:i:s', $result['tested_at']),
+            ]);
         } catch (Exception $exception) {
+            $tested_at = $this->get_time();
             $this->store_status([
                 'last_result' => 'error',
-                'tested_at' => $this->get_time(),
+                'tested_at' => $tested_at,
                 'message' => $exception->getMessage(),
             ]);
 
-            wp_send_json_error(['message' => $exception->getMessage()]);
+            wp_send_json_error([
+                'message' => $exception->getMessage(),
+                'status_message' => $exception->getMessage(),
+                'tested_at' => $tested_at,
+                'tested_at_formatted' => gmdate('d/m/Y H:i:s', $tested_at),
+            ], 400);
         }
     }
 
     public function handle_disconnect_request() {
         if (!\bjlg_can_manage_plugin()) {
-            return;
+            wp_die('Permission refusée.');
         }
 
-        if (isset($_POST['bjlg_dropbox_nonce'])) {
-            $nonce = wp_unslash($_POST['bjlg_dropbox_nonce']);
-            if (function_exists('wp_verify_nonce') && !wp_verify_nonce($nonce, 'bjlg_dropbox_disconnect')) {
-                return;
-            }
-        }
+        $nonce_field = isset($_POST['_wpnonce']) ? '_wpnonce' : 'bjlg_dropbox_nonce';
+        check_admin_referer('bjlg_dropbox_disconnect', $nonce_field);
 
         $this->disconnect();
 
-        if (function_exists('wp_safe_redirect')) {
-            wp_safe_redirect(admin_url('admin.php?page=backup-jlg&tab=settings'));
-            exit;
-        }
+        $redirect = isset($_REQUEST['_wp_http_referer']) ? esc_url_raw(wp_unslash($_REQUEST['_wp_http_referer'])) : admin_url('admin.php?page=backup-jlg&tab=settings');
+        wp_safe_redirect(add_query_arg('bjlg_dropbox_disconnected', '1', $redirect));
+        exit;
     }
 
     public function upload_file($filepath, $task_id) {
@@ -512,65 +509,7 @@ class BJLG_Dropbox implements BJLG_Destination_Interface {
         return (int) call_user_func($this->time_provider);
     }
 
-    public function handle_test_connection() {
-        if (!\bjlg_can_manage_plugin()) {
-            wp_send_json_error(['message' => 'Permission refusée.'], 403);
-        }
-
-        check_ajax_referer('bjlg_nonce', 'nonce');
-
-        $settings = [
-            'access_token' => isset($_POST['dropbox_access_token']) ? sanitize_text_field(wp_unslash($_POST['dropbox_access_token'])) : '',
-            'folder' => isset($_POST['dropbox_folder']) ? sanitize_text_field(wp_unslash($_POST['dropbox_folder'])) : '',
-            'enabled' => true,
-        ];
-
-        try {
-            $result = $this->test_connection($settings);
-            $this->store_status([
-                'last_result' => 'success',
-                'tested_at' => $result['tested_at'],
-                'message' => $result['message'],
-            ]);
-
-            wp_send_json_success([
-                'message' => $result['message'],
-                'status_message' => $result['message'],
-                'tested_at' => $result['tested_at'],
-                'tested_at_formatted' => gmdate('d/m/Y H:i:s', $result['tested_at']),
-            ]);
-        } catch (Exception $exception) {
-            $tested_at = $this->get_time();
-            $this->store_status([
-                'last_result' => 'error',
-                'tested_at' => $tested_at,
-                'message' => $exception->getMessage(),
-            ]);
-
-            wp_send_json_error([
-                'message' => $exception->getMessage(),
-                'status_message' => $exception->getMessage(),
-                'tested_at' => $tested_at,
-                'tested_at_formatted' => gmdate('d/m/Y H:i:s', $tested_at),
-            ], 400);
-        }
-    }
-
-    public function handle_disconnect_request() {
-        if (!\bjlg_can_manage_plugin()) {
-            wp_die('Permission refusée.');
-        }
-
-        check_admin_referer('bjlg_dropbox_disconnect');
-
-        $this->disconnect();
-
-        $redirect = isset($_REQUEST['_wp_http_referer']) ? esc_url_raw(wp_unslash($_REQUEST['_wp_http_referer'])) : admin_url('admin.php?page=backup-jlg&tab=settings');
-        wp_safe_redirect(add_query_arg('bjlg_dropbox_disconnected', '1', $redirect));
-        exit;
-    }
-
-    private function test_connection(array $settings) {
+    private function run_test_connection(array $settings) {
         if ($settings['access_token'] === '') {
             throw new Exception('Fournissez un token d\'accès Dropbox.');
         }


### PR DESCRIPTION
## Summary
- remove the duplicate Dropbox and OneDrive AJAX handlers that caused fatal redeclaration errors
- reuse a single test_connection implementation that returns status metadata for the admin UI
- update disconnect handlers to validate either nonce field used by existing forms before redirecting

## Testing
- composer test *(fails: phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dddaf450832ea1054675fe776db2