### PR TITLE
Fix admin pattern normalization regex

### DIFF
--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -1172,16 +1172,14 @@ jQuery(document).ready(function($) {
             if (typeof value !== 'string') {
                 return [];
             }
-            return value.split(/[
-,]+/).map(function(entry) {
+            return value.split(/[\r\n,]+/).map(function(entry) {
                 return entry.trim();
             }).filter(Boolean);
         }
 
         function patternsToTextarea(value) {
             if (Array.isArray(value)) {
-                return value.join('
-');
+                return value.join('\n');
             }
             if (typeof value === 'string') {
                 return value;


### PR DESCRIPTION
## Summary
- fix the admin pattern normalizer to split on commas and newlines without syntax errors
- ensure textarea serialization rejoins patterns using newline characters

## Testing
- vendor/bin/phpunit *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e300e23ae8832eb4693632a181ff47