### PR TITLE
Improve webhook secret visibility and mobile destination UX

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -858,6 +858,44 @@
     align-items: center;
 }
 
+.bjlg-secret-field {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.bjlg-secret-field .regular-text {
+    max-width: 100%;
+}
+
+.bjlg-toggle-secret {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    padding: 0 6px;
+}
+
+.bjlg-toggle-secret .dashicons {
+    margin: 0;
+}
+
+.bjlg-destination-option-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bjlg-destination-option {
+    display: block;
+}
+
+.bjlg-destination-unavailable {
+    margin: 0;
+    color: #d63638;
+}
+
 .bjlg-form-field-unit {
     display: inline-flex;
     align-items: center;
@@ -1049,6 +1087,12 @@
     }
 
     .bjlg-field-control {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .bjlg-field-control fieldset {
         display: flex;
         flex-direction: column;
         gap: 12px;

--- a/backup-jlg/assets/js/admin.js
+++ b/backup-jlg/assets/js/admin.js
@@ -4233,6 +4233,48 @@ jQuery(document).ready(function($) {
         });
     });
 
+    // --- AFFICHER / MASQUER LES SECRETS ---
+    $('body').on('click', '.bjlg-toggle-secret', function(e) {
+        e.preventDefault();
+
+        const $button = $(this);
+        const targetSelector = $button.data('target');
+        if (!targetSelector) {
+            return;
+        }
+
+        const $input = $(targetSelector);
+        if (!$input.length) {
+            return;
+        }
+
+        const currentType = ($input.attr('type') || '').toLowerCase();
+        const isHidden = currentType !== 'text';
+        $input.attr('type', isHidden ? 'text' : 'password');
+
+        const showLabel = $button.data('labelShow');
+        const hideLabel = $button.data('labelHide');
+        const nextLabel = isHidden ? hideLabel : showLabel;
+        if (typeof nextLabel === 'string' && nextLabel.length) {
+            $button.attr('aria-label', nextLabel);
+            const $srOnly = $button.find('.screen-reader-text');
+            if ($srOnly.length) {
+                $srOnly.text(nextLabel);
+            }
+        }
+
+        const $icon = $button.find('.dashicons');
+        if ($icon.length) {
+            if (isHidden) {
+                $icon.removeClass('dashicons-visibility').addClass('dashicons-hidden');
+            } else {
+                $icon.removeClass('dashicons-hidden').addClass('dashicons-visibility');
+            }
+        }
+
+        $button.attr('aria-pressed', isHidden ? 'true' : 'false');
+    });
+
     // --- COPIE RAPIDE POUR LES CHAMPS WEBHOOK ---
     $('body').on('click', '.bjlg-copy-field', function(e) {
         e.preventDefault();

--- a/backup-jlg/includes/destinations/class-bjlg-google-drive.php
+++ b/backup-jlg/includes/destinations/class-bjlg-google-drive.php
@@ -94,6 +94,10 @@ class BJLG_Google_Drive implements BJLG_Destination_Interface {
         return 'Google Drive';
     }
 
+    public function is_sdk_available() {
+        return (bool) $this->sdk_available;
+    }
+
     public function is_connected() {
         $token = $this->get_stored_token();
 


### PR DESCRIPTION
## Summary
- add a toggle button so the webhook secret stays hidden by default while keeping copy/regenerate controls
- surface a warning for Google Drive destinations when the SDK is missing and space out checkbox lists on mobile
- expose the Google Drive SDK availability flag and add supporting JS/CSS for the new behaviours

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e301c4c9a0832eb0a3f19923c126cd