### PR TITLE
Improve backup progress debug logging and remote destination feedback

### DIFF
--- a/backup-jlg/includes/class-bjlg-settings.php
+++ b/backup-jlg/includes/class-bjlg-settings.php
@@ -1844,6 +1844,46 @@ class BJLG_Settings {
     }
 
     /**
+     * Retourne un libellé lisible pour une destination donnée.
+     */
+    public static function get_destination_label($destination_id) {
+        if (!is_scalar($destination_id)) {
+            return '';
+        }
+
+        $slug = sanitize_key((string) $destination_id);
+        if ($slug === '') {
+            return '';
+        }
+
+        $default_labels = [
+            'google_drive' => 'Google Drive',
+            'aws_s3' => 'Amazon S3',
+            'dropbox' => 'Dropbox',
+            'onedrive' => 'Microsoft OneDrive',
+            'pcloud' => 'pCloud',
+            'sftp' => 'Serveur SFTP',
+            'wasabi' => 'Wasabi',
+            'azure_blob' => 'Azure Blob Storage',
+            'backblaze_b2' => 'Backblaze B2',
+        ];
+
+        $label = isset($default_labels[$slug]) ? $default_labels[$slug] : '';
+
+        /** @var string|false $filtered */
+        $filtered = apply_filters('bjlg_destination_label', $label, $slug);
+        if (is_string($filtered) && $filtered !== '') {
+            return $filtered;
+        }
+
+        if ($label !== '') {
+            return $label;
+        }
+
+        return ucwords(str_replace(['_', '-'], ' ', $slug));
+    }
+
+    /**
      * Convertit une valeur en booléen normalisé.
      *
      * @param mixed $value


### PR DESCRIPTION
## Summary
- add structured debug logging to each backup progress update to make troubleshooting easier when BJLG_DEBUG is enabled
- expose a helper to resolve human-readable destination labels and reuse it to build user-facing failure summaries
- surface detailed warnings when remote destination uploads fail so users know unconnected services must be configured

## Testing
- `composer test` *(fails: phpunit not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e443192ff4832e8228d2c353af1a92