### PR TITLE
Fix admin tab routing and header layout

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -51,7 +51,7 @@
 .bjlg-dashboard-overview__header {
     display: flex;
     flex-wrap: wrap;
-    align-items: baseline;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 8px;
     margin-bottom: 16px;
@@ -61,11 +61,24 @@
     margin: 0;
     border: 0;
     padding: 0;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .bjlg-dashboard-overview__timestamp {
     font-size: 0.9em;
     color: #50575e;
+    flex: 0 1 auto;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+@media (max-width: 782px) {
+    .bjlg-dashboard-overview__timestamp {
+        margin-left: 0;
+        width: 100%;
+        white-space: normal;
+    }
 }
 
 .bjlg-alerts {

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -120,9 +120,23 @@ class BJLG_Admin {
      */
     public function render_admin_page() {
         $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'backup_restore';
-        $page_url = admin_url('admin.php?page=backup-jlg');
-        
+        $page_url = add_query_arg(
+            [
+                'page' => 'backup-jlg',
+            ],
+            admin_url('admin.php')
+        );
+
         $tabs = apply_filters('bjlg_admin_tabs', []);
+        if (!is_array($tabs) || empty($tabs)) {
+            $tabs = $this->get_default_tabs([]);
+        }
+
+        if (!array_key_exists($active_tab, $tabs)) {
+            $active_tab = array_key_exists('backup_restore', $tabs)
+                ? 'backup_restore'
+                : (string) array_key_first($tabs);
+        }
         $metrics = $this->advanced_admin ? $this->advanced_admin->get_dashboard_metrics() : [];
 
         ?>
@@ -135,7 +149,7 @@ class BJLG_Admin {
 
             <nav class="nav-tab-wrapper">
                 <?php foreach ($tabs as $tab_key => $tab_label): ?>
-                    <a href="<?php echo esc_url(add_query_arg('tab', $tab_key, $page_url)); ?>" 
+                    <a href="<?php echo esc_url(add_query_arg(['tab' => $tab_key], $page_url)); ?>"
                        class="nav-tab <?php echo $active_tab == $tab_key ? 'nav-tab-active' : ''; ?>">
                         <?php echo esc_html($tab_label); ?>
                     </a>


### PR DESCRIPTION
## Summary
- ensure the admin tab router always builds stable URLs and falls back to a valid tab when an unknown slug is requested
- tweak the dashboard header flex rules so the timestamp no longer overlaps the title on wide screens and still wraps on mobile

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e4426dba98832ea804fab5f420901c