### PR TITLE
Add hidden username field to restore form

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -906,6 +906,40 @@
     display: block;
 }
 
+.bjlg-screen-reader-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+.bjlg-screen-reader-only:focus,
+.bjlg-screen-reader-only:active,
+.bjlg-screen-reader-only:focus-within {
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+    margin: 0 !important;
+    overflow: visible !important;
+    clip: auto !important;
+    white-space: normal !important;
+}
+
+.bjlg-screen-reader-only:focus-within .bjlg-screen-reader-only {
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+    margin: 0 !important;
+    overflow: visible !important;
+    clip: auto !important;
+    white-space: normal !important;
+}
+
 .bjlg-backup-toolbar {
     display: flex;
     justify-content: space-between;

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -840,6 +840,15 @@ class BJLG_Admin {
             <h2>Restaurer depuis un fichier</h2>
             <p>Si vous avez un fichier de sauvegarde sur votre ordinateur, vous pouvez le téléverser ici pour lancer une restauration.</p>
             <form id="bjlg-restore-form" method="post" enctype="multipart/form-data">
+                <div class="bjlg-restore-username-field bjlg-screen-reader-only">
+                    <label class="bjlg-screen-reader-only" for="bjlg-restore-username">Nom d'utilisateur</label>
+                    <input type="text"
+                           id="bjlg-restore-username"
+                           name="username"
+                           class="regular-text bjlg-screen-reader-only"
+                           autocomplete="username"
+                           aria-label="Nom d'utilisateur">
+                </div>
                 <table class="form-table">
                     <tbody>
                         <tr>


### PR DESCRIPTION
## Summary
- add a visually-hidden username input to the restore form so password fields have an associated username for accessibility
- introduce reusable helper styles to visually hide elements while keeping them available to assistive technologies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43fa3c0e4832eb9f6fdd5dfddcf71