### PR TITLE
docs: étendre les recommandations UX/UI avancées

### DIFF
--- a/docs/ui-ux-audit.md
+++ b/docs/ui-ux-audit.md
@@ -47,6 +47,21 @@ Ce document synthétise les écarts d'expérience entre l'interface d'administra
 - **Autoriser la personnalisation du bloc** via les presets `supports.color` et `supports.typography` de `block.json`, puis remplacer les valeurs fixes par des variables CSS héritées du thème, afin de garantir un rendu aligné côté front et éditeur.【F:backup-jlg/assets/css/block-status.css†L1-L44】
 - **Afficher des états de chargement accessibles** (skeleton `components.Skeleton`, `Spinner`) dans `block-status.js` pour informer l’éditeur lors des requêtes `apiFetch` et proposer une action de rechargement en cas d’erreur.【F:backup-jlg/assets/js/block-status.js†L60-L122】
 
+### 3.7 Observabilité & reporting
+- **Enrichir la timeline de planification** avec des vues cumulatives (heatmap hebdo, histogramme des succès/échecs) et des filtres par destination ou type de contenu ; aujourd’hui elle se limite à deux vues (semaine/mois) rendues côté jQuery, sans drill-down ni regroupement multi-sites.【F:backup-jlg/includes/class-bjlg-admin.php†L780-L808】【F:backup-jlg/assets/js/admin.js†L502-L516】
+- **Transformer le « bilan de santé » texte en tableau de bord partageable** (widgets graphiques, export PDF/CSV, envoi programmé par e-mail) afin d’aligner la visibilité sur l’état des sauvegardes avec ce que proposent BlogVault ou ManageWP, qui combinent tendances et alerting automatique.【F:backup-jlg/includes/class-bjlg-health-check.php†L512-L532】
+- **Structurer l’historique des actions en vues filtrables et exports prêts à l’audit** (recherche par utilisateur, statut, plage temporelle) plutôt qu’une simple liste plate ; tirer parti du catalogue d’actions déjà typé pour générer des timelines et rapports conformes aux exigences clients/ITSM.【F:backup-jlg/includes/class-bjlg-history.php†L445-L459】
+
+### 3.8 Collaboration & gouvernance
+- **Introduire des rôles granularisés** (Technicien, Observateur, Client final) et une gestion des accès par site ou groupe, au-delà de la capacité globale `manage_options` actuellement requise, pour refléter les modèles multi-équipes des agences et MSP.【F:backup-jlg/backup-jlg.php†L25-L80】
+- **Ajouter des mentions d’auteur et d’approbateur sur les actions sensibles** (restauration, suppression de sauvegarde) avec validation en deux étapes ou commentaires, afin de capitaliser sur l’historique existant pour offrir une traçabilité comparable aux consoles pros.【F:backup-jlg/includes/class-bjlg-history.php†L445-L459】
+- **Prévoir un mode « centre de services »** : vue consolidée des tickets/notifications pour plusieurs clients, délégation temporaire d’accès et intégration SSO (Google/Microsoft) afin de fluidifier le support managé et les handovers d’équipes.【F:backup-jlg/backup-jlg.php†L25-L80】
+
+### 3.9 Automatisation & remédiation proactive
+- **Standardiser des « playbooks » de reprise** (planification auto d’une sauvegarde à la détection d’un échec, rerun automatique après incident) plutôt que s’appuyer sur les seuls boutons « Exécuter »/« Mettre en pause » présents dans les cartes de planification.【F:backup-jlg/includes/class-bjlg-admin.php†L725-L760】
+- **Mettre en place des recommandations dynamiques** dans l’UI (ex. proposer l’activation du chiffrement si non coché, suggérer une destination secondaire) via des encadrés guidés plutôt que des notices statiques générées par `renderScheduleFeedback()`.【F:backup-jlg/assets/js/admin.js†L550-L579】
+- **Coupler les webhooks et l’API REST existants à des workflows prêts à l’emploi** (ex. intégrations Slack, Teams, ServiceNow) pour lancer automatiquement diagnostics, sauvegardes d’urgence ou notifications clients dès qu’un événement critique est loggé.【F:backup-jlg/includes/class-bjlg-rest-api.php†L301-L318】【F:backup-jlg/includes/class-bjlg-webhooks.php†L321-L354】
+
 ## 4. Prochaines étapes suggérées
 
 1. Prioriser la refonte navigation + design system pour rapprocher l'expérience de BlogVault/ManageWP (impact adoption + accessibilité).


### PR DESCRIPTION
## Summary
- enrich the UX/UI audit with new observability and reporting recommendations aligned with pro backup suites
- document collaboration and governance expectations for agency-grade usage
- suggest automation and remediation playbooks leveraging existing REST and webhook capabilities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d26c1144832eb2bbc5386dcdb281