### PR TITLE
Improve admin dashboard announcements and block theming

### DIFF
--- a/backup-jlg/assets/css/block-status.css
+++ b/backup-jlg/assets/css/block-status.css
@@ -1,10 +1,27 @@
 .bjlg-block-status {
-    background: #ffffff;
-    border: 1px solid #dcdcde;
+    --bjlg-surface: var(--wp--preset--color--background, #ffffff);
+    --bjlg-surface-muted: var(--wp--preset--color--surface, #f6f7f7);
+    --bjlg-border: var(--wp-admin-border-color, #dcdcde);
+    --bjlg-text: var(--wp--preset--color--foreground, #1d2327);
+    --bjlg-text-muted: var(--wp--preset--color--muted, #50575e);
+    --bjlg-text-subtle: var(--wp--preset--color--muted, #646970);
+    --bjlg-accent: var(--wp-admin-theme-color, #2271b1);
+    --bjlg-accent-contrast: var(--wp-admin-theme-color--text, #ffffff);
+    --bjlg-accent-hover: var(--wp-admin-theme-color-darker-10, #135e96);
+    --bjlg-alert-info-bg: rgba(var(--wp-admin-theme-color--rgb, 34, 113, 177), 0.12);
+    --bjlg-alert-info-border: rgba(var(--wp-admin-theme-color--rgb, 34, 113, 177), 0.4);
+    --bjlg-alert-warning-bg: rgba(251, 191, 36, 0.18);
+    --bjlg-alert-warning-border: rgba(251, 191, 36, 0.5);
+    --bjlg-alert-error-bg: rgba(214, 54, 56, 0.15);
+    --bjlg-alert-error-border: rgba(214, 54, 56, 0.45);
+    --bjlg-alert-success-bg: rgba(34, 197, 94, 0.18);
+    --bjlg-alert-success-border: rgba(34, 197, 94, 0.45);
+    background: var(--bjlg-surface);
+    border: 1px solid var(--bjlg-border);
     border-radius: 8px;
     padding: 24px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-    color: #1d2327;
+    color: var(--bjlg-text);
     font-family: inherit;
 }
 
@@ -28,7 +45,7 @@
 
 .bjlg-block-status__timestamp {
     font-size: 0.875rem;
-    color: #50575e;
+    color: var(--bjlg-text-subtle);
 }
 
 .bjlg-block-status__summary {
@@ -39,7 +56,7 @@
 }
 
 .bjlg-block-status__stat {
-    background: #f6f7f7;
+    background: var(--bjlg-surface-muted);
     border-radius: 6px;
     padding: 16px;
     display: flex;
@@ -49,7 +66,7 @@
 
 .bjlg-block-status__stat-label {
     font-size: 0.875rem;
-    color: #50575e;
+    color: var(--bjlg-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.03em;
 }
@@ -57,12 +74,12 @@
 .bjlg-block-status__stat-value {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #1d2327;
+    color: var(--bjlg-text);
 }
 
 .bjlg-block-status__stat-meta {
     font-size: 0.875rem;
-    color: #646970;
+    color: var(--bjlg-text-subtle);
 }
 
 .bjlg-block-status__actions {
@@ -79,25 +96,27 @@
     padding: 10px 18px;
     border-radius: 4px;
     font-weight: 600;
-    background: #2271b1;
-    color: #ffffff;
+    background: var(--bjlg-accent);
+    color: var(--bjlg-accent-contrast);
     text-decoration: none;
+    border: 1px solid transparent;
 }
 
 .bjlg-block-status__button:hover,
 .bjlg-block-status__button:focus {
-    background: #135e96;
-    color: #ffffff;
+    background: var(--bjlg-accent-hover);
+    color: var(--bjlg-accent-contrast);
 }
 
 .bjlg-block-status__button--secondary {
-    background: #f3f4f5;
-    color: #1d2327;
+    background: var(--bjlg-surface-muted);
+    color: var(--bjlg-text);
+    border-color: var(--bjlg-border);
 }
 
 .bjlg-block-status__button--secondary:hover,
 .bjlg-block-status__button--secondary:focus {
-    background: #e2e4e7;
+    background: var(--bjlg-surface);
 }
 
 .bjlg-block-status__alerts {
@@ -117,23 +136,23 @@
 }
 
 .bjlg-block-status__alert--info {
-    background: #f0f6fc;
-    border: 1px solid #8fbdf0;
+    background: var(--bjlg-alert-info-bg);
+    border: 1px solid var(--bjlg-alert-info-border);
 }
 
 .bjlg-block-status__alert--warning {
-    background: #fff4e5;
-    border: 1px solid #f0c88b;
+    background: var(--bjlg-alert-warning-bg);
+    border: 1px solid var(--bjlg-alert-warning-border);
 }
 
 .bjlg-block-status__alert--error {
-    background: #fdecea;
-    border: 1px solid #f18f81;
+    background: var(--bjlg-alert-error-bg);
+    border: 1px solid var(--bjlg-alert-error-border);
 }
 
 .bjlg-block-status__alert--success {
-    background: #edf7ed;
-    border: 1px solid #9fd89f;
+    background: var(--bjlg-alert-success-bg);
+    border: 1px solid var(--bjlg-alert-success-border);
 }
 
 .bjlg-block-status__alert-body {
@@ -148,13 +167,14 @@
 
 .bjlg-block-status__alert-link {
     font-weight: 600;
-    color: #1d2327;
+    color: var(--bjlg-accent);
     text-decoration: none;
 }
 
 .bjlg-block-status__alert-link:hover,
 .bjlg-block-status__alert-link:focus {
     text-decoration: underline;
+    color: var(--bjlg-accent-hover);
 }
 
 .bjlg-block-status__recent {
@@ -177,7 +197,7 @@
 .bjlg-block-status__backup-item {
     display: flex;
     flex-direction: column;
-    background: #f6f7f7;
+    background: var(--bjlg-surface-muted);
     border-radius: 6px;
     padding: 12px 16px;
 }
@@ -188,7 +208,7 @@
 
 .bjlg-block-status__backup-meta {
     font-size: 0.875rem;
-    color: #646970;
+    color: var(--bjlg-text-subtle);
 }
 
 .bjlg-block-status__placeholder,
@@ -196,7 +216,7 @@
 .bjlg-block-status__notice,
 .bjlg-block-status__empty {
     text-align: center;
-    color: #50575e;
+    color: var(--bjlg-text-muted);
 }
 
 .bjlg-block-status__placeholder {
@@ -214,7 +234,7 @@
 }
 
 .bjlg-block-status__notice {
-    background: #f6f7f7;
+    background: var(--bjlg-surface-muted);
     border-radius: 6px;
     padding: 16px;
 }

--- a/backup-jlg/assets/js/block-status.js
+++ b/backup-jlg/assets/js/block-status.js
@@ -85,7 +85,12 @@
             return null;
         }
 
-        return wp.element.createElement('div', { className: 'bjlg-block-status__alerts' },
+        return wp.element.createElement('div', {
+            className: 'bjlg-block-status__alerts',
+            role: 'status',
+            'aria-live': 'polite',
+            'aria-atomic': 'true'
+        },
             alerts.map((alert, index) => wp.element.createElement('div', {
                 key: alert.id || index,
                 className: 'bjlg-block-status__alert bjlg-block-status__alert--' + formatAlertType(alert.type),
@@ -176,7 +181,12 @@
                     wp.i18n.sprintf(__('Actualisé le %s', 'backup-jlg'), data.generated_at)
                 ) : null
             ),
-            wp.element.createElement('div', { className: 'bjlg-block-status__summary' },
+            wp.element.createElement('div', {
+                className: 'bjlg-block-status__summary',
+                role: 'status',
+                'aria-live': 'polite',
+                'aria-atomic': 'true'
+            },
                 wp.element.createElement(SummaryStat, {
                     label: __('Dernière sauvegarde', 'backup-jlg'),
                     value: summary.history_last_backup,

--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -240,7 +240,10 @@ final class BJLG_Plugin {
         wp_enqueue_style('bjlg-admin', BJLG_PLUGIN_URL . 'assets/css/admin.css', [], BJLG_VERSION);
         wp_enqueue_style('bjlg-admin-advanced', BJLG_PLUGIN_URL . 'assets/css/admin-advanced.css', [], BJLG_VERSION);
         wp_enqueue_script('bjlg-chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js', [], '4.4.4', true);
-        wp_enqueue_script('bjlg-admin', BJLG_PLUGIN_URL . 'assets/js/admin.js', ['jquery', 'bjlg-chartjs'], BJLG_VERSION, true);
+        wp_enqueue_script('bjlg-admin', BJLG_PLUGIN_URL . 'assets/js/admin.js', ['jquery', 'bjlg-chartjs', 'wp-a11y', 'wp-i18n'], BJLG_VERSION, true);
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations('bjlg-admin', 'backup-jlg', BJLG_PLUGIN_DIR . 'languages');
+        }
         wp_localize_script('bjlg-admin', 'bjlg_ajax', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce'    => wp_create_nonce('bjlg_nonce'),

--- a/backup-jlg/block.json
+++ b/backup-jlg/block.json
@@ -13,6 +13,15 @@
         "spacing": {
             "margin": true,
             "padding": true
+        },
+        "color": {
+            "background": true,
+            "text": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true
         }
     },
     "attributes": {

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -219,7 +219,9 @@ class BJLG_Admin {
                 <?php endif; ?>
             </header>
 
-            <div class="bjlg-dashboard-actions" data-role="actions">
+            <div id="bjlg-dashboard-live-region" class="screen-reader-text" role="status" aria-live="polite" aria-atomic="true"></div>
+
+            <div class="bjlg-dashboard-actions" data-role="actions" role="region" aria-live="polite" aria-atomic="true">
                 <article class="bjlg-action-card" data-action="backup">
                     <div class="bjlg-action-card__content">
                         <h3 class="bjlg-action-card__title"><?php esc_html_e('Lancer une sauvegarde', 'backup-jlg'); ?></h3>
@@ -254,7 +256,7 @@ class BJLG_Admin {
                 </article>
             </div>
 
-            <div class="bjlg-alerts" data-role="alerts">
+            <div class="bjlg-alerts" data-role="alerts" role="status" aria-live="polite" aria-atomic="true">
                 <?php foreach ($alerts as $alert): ?>
                     <div class="bjlg-alert bjlg-alert--<?php echo esc_attr($alert['type'] ?? 'info'); ?>">
                         <div class="bjlg-alert__content">
@@ -316,7 +318,7 @@ class BJLG_Admin {
                 </article>
             </div>
 
-            <div class="bjlg-onboarding" data-role="onboarding">
+            <div class="bjlg-onboarding" data-role="onboarding" role="region" aria-live="polite" aria-atomic="true">
                 <h3 class="bjlg-onboarding__title"><?php esc_html_e('Bien démarrer', 'backup-jlg'); ?></h3>
                 <ul class="bjlg-onboarding__list">
                     <?php foreach ($onboarding as $resource): ?>

--- a/backup-jlg/includes/class-bjlg-blocks.php
+++ b/backup-jlg/includes/class-bjlg-blocks.php
@@ -122,7 +122,7 @@ class BJLG_Blocks {
                 <?php endif; ?>
             </header>
 
-            <div class="bjlg-block-status__summary">
+            <div class="bjlg-block-status__summary" role="status" aria-live="polite" aria-atomic="true">
                 <div class="bjlg-block-status__stat">
                     <span class="bjlg-block-status__stat-label"><?php esc_html_e('Dernière sauvegarde', 'backup-jlg'); ?></span>
                     <span class="bjlg-block-status__stat-value"><?php echo esc_html($snapshot['summary']['history_last_backup'] ?? __('N/A', 'backup-jlg')); ?></span>
@@ -160,7 +160,7 @@ class BJLG_Blocks {
             <?php endif; ?>
 
             <?php if (!empty($attributes['showAlerts']) && !empty($snapshot['alerts'])): ?>
-                <div class="bjlg-block-status__alerts">
+                <div class="bjlg-block-status__alerts" role="status" aria-live="polite" aria-atomic="true">
                     <?php foreach ($snapshot['alerts'] as $alert): ?>
                         <div class="bjlg-block-status__alert bjlg-block-status__alert--<?php echo esc_attr($alert['type'] ?? 'info'); ?>">
                             <div class="bjlg-block-status__alert-body">


### PR DESCRIPTION
## Summary
- add accessible live regions and announcements for the admin dashboard so async updates are surfaced to assistive tech
- expose new block color/typography supports and refresh block styles to rely on WordPress design tokens
- update block markup/scripts to add aria-live regions and align alerts with the new styling utilities

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68e551eb2618832e87dd2ee838c8ff8a