### PR TITLE
Implement notification queue retries and accessibility fixes

### DIFF
--- a/backup-jlg/assets/css/admin.css
+++ b/backup-jlg/assets/css/admin.css
@@ -1066,6 +1066,22 @@
     display: block;
 }
 
+.bjlg-checkbox-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.bjlg-checkbox-list li + li {
+    margin-top: 0.5rem;
+}
+
+.bjlg-checkbox-list label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .bjlg-screen-reader-only {
     position: absolute !important;
     width: 1px !important;

--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -194,7 +194,7 @@ final class BJLG_Plugin {
             'class-bjlg-backup.php', 'class-bjlg-restore.php', 'class-bjlg-scheduler.php',
             'class-bjlg-cleanup.php', 'class-bjlg-encryption.php', 'class-bjlg-health-check.php',
             'class-bjlg-diagnostics.php', 'class-bjlg-webhooks.php', 'class-bjlg-incremental.php',
-            'class-bjlg-notifications.php', 'class-bjlg-destination-factory.php', 'class-bjlg-remote-purge-worker.php',
+            'class-bjlg-notification-transport.php', 'class-bjlg-notification-queue.php', 'class-bjlg-notifications.php', 'class-bjlg-destination-factory.php', 'class-bjlg-remote-purge-worker.php',
             'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php', 'class-bjlg-blocks.php',
             'class-bjlg-api-keys.php', 'class-bjlg-admin-advanced.php', 'class-bjlg-admin.php', 'class-bjlg-actions.php',
             'destinations/interface-bjlg-destination.php', 'destinations/abstract-class-bjlg-s3-compatible.php',
@@ -226,6 +226,7 @@ final class BJLG_Plugin {
         new BJLG\BJLG_Diagnostics();
         new BJLG\BJLG_Webhooks();
         new BJLG\BJLG_Incremental();
+        new BJLG\BJLG_Notification_Queue();
         new BJLG\BJLG_Notifications();
         new BJLG\BJLG_REST_API();
         new BJLG\BJLG_Settings();

--- a/backup-jlg/includes/class-bjlg-admin.php
+++ b/backup-jlg/includes/class-bjlg-admin.php
@@ -1519,13 +1519,36 @@ class BJLG_Admin {
                         <th scope="row">Événements surveillés</th>
                         <td>
                             <div class="bjlg-field-control">
-                                <fieldset>
-                                    <label><input type="checkbox" name="notify_backup_complete" <?php checked(!empty($notification_settings['events']['backup_complete'])); ?>> Sauvegarde terminée</label><br>
-                                    <label><input type="checkbox" name="notify_backup_failed" <?php checked(!empty($notification_settings['events']['backup_failed'])); ?>> Échec de sauvegarde</label><br>
-                                    <label><input type="checkbox" name="notify_cleanup_complete" <?php checked(!empty($notification_settings['events']['cleanup_complete'])); ?>> Nettoyage finalisé</label><br>
-                                    <label><input type="checkbox" name="notify_storage_warning" <?php checked(!empty($notification_settings['events']['storage_warning'])); ?>> Alerte de stockage</label>
+                                <fieldset aria-describedby="bjlg-notifications-events-description">
+                                    <legend class="screen-reader-text"><?php esc_html_e('Événements surveillés', 'backup-jlg'); ?></legend>
+                                    <ul class="bjlg-checkbox-list" role="list">
+                                        <li>
+                                            <label for="bjlg-notify-backup-complete">
+                                                <input type="checkbox" id="bjlg-notify-backup-complete" name="notify_backup_complete" <?php checked(!empty($notification_settings['events']['backup_complete'])); ?>>
+                                                <span><?php esc_html_e('Sauvegarde terminée', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                        <li>
+                                            <label for="bjlg-notify-backup-failed">
+                                                <input type="checkbox" id="bjlg-notify-backup-failed" name="notify_backup_failed" <?php checked(!empty($notification_settings['events']['backup_failed'])); ?>>
+                                                <span><?php esc_html_e('Échec de sauvegarde', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                        <li>
+                                            <label for="bjlg-notify-cleanup-complete">
+                                                <input type="checkbox" id="bjlg-notify-cleanup-complete" name="notify_cleanup_complete" <?php checked(!empty($notification_settings['events']['cleanup_complete'])); ?>>
+                                                <span><?php esc_html_e('Nettoyage finalisé', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                        <li>
+                                            <label for="bjlg-notify-storage-warning">
+                                                <input type="checkbox" id="bjlg-notify-storage-warning" name="notify_storage_warning" <?php checked(!empty($notification_settings['events']['storage_warning'])); ?>>
+                                                <span><?php esc_html_e('Alerte de stockage', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                    </ul>
                                 </fieldset>
-                                <p class="description">Choisissez quels événements déclenchent un envoi de notification.</p>
+                                <p id="bjlg-notifications-events-description" class="description"><?php esc_html_e('Choisissez quels événements déclenchent un envoi de notification.', 'backup-jlg'); ?></p>
                             </div>
                         </td>
                     </tr>
@@ -1541,12 +1564,30 @@ class BJLG_Admin {
                         <th scope="row">Canaux disponibles</th>
                         <td>
                             <div class="bjlg-field-control">
-                                <fieldset>
-                                    <label><input type="checkbox" name="channel_email" <?php checked(!empty($notification_settings['channels']['email']['enabled'])); ?>> E-mail</label><br>
-                                    <label><input type="checkbox" name="channel_slack" <?php checked(!empty($notification_settings['channels']['slack']['enabled'])); ?>> Slack</label><br>
-                                    <label><input type="checkbox" name="channel_discord" <?php checked(!empty($notification_settings['channels']['discord']['enabled'])); ?>> Discord</label>
+                                <fieldset aria-describedby="bjlg-notifications-channels-description">
+                                    <legend class="screen-reader-text"><?php esc_html_e('Canaux de notification actifs', 'backup-jlg'); ?></legend>
+                                    <ul class="bjlg-checkbox-list" role="list">
+                                        <li>
+                                            <label for="bjlg-channel-email">
+                                                <input type="checkbox" id="bjlg-channel-email" name="channel_email" <?php checked(!empty($notification_settings['channels']['email']['enabled'])); ?>>
+                                                <span><?php esc_html_e('E-mail', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                        <li>
+                                            <label for="bjlg-channel-slack">
+                                                <input type="checkbox" id="bjlg-channel-slack" name="channel_slack" <?php checked(!empty($notification_settings['channels']['slack']['enabled'])); ?>>
+                                                <span><?php esc_html_e('Slack', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                        <li>
+                                            <label for="bjlg-channel-discord">
+                                                <input type="checkbox" id="bjlg-channel-discord" name="channel_discord" <?php checked(!empty($notification_settings['channels']['discord']['enabled'])); ?>>
+                                                <span><?php esc_html_e('Discord', 'backup-jlg'); ?></span>
+                                            </label>
+                                        </li>
+                                    </ul>
                                 </fieldset>
-                                <p class="description">Activez les canaux qui doivent recevoir vos notifications.</p>
+                                <p id="bjlg-notifications-channels-description" class="description"><?php esc_html_e('Activez les canaux qui doivent recevoir vos notifications.', 'backup-jlg'); ?></p>
                             </div>
                         </td>
                     </tr>

--- a/backup-jlg/includes/class-bjlg-notification-queue.php
+++ b/backup-jlg/includes/class-bjlg-notification-queue.php
@@ -1,0 +1,516 @@
+<?php
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Manages the notification queue and retry logic for asynchronous delivery.
+ */
+class BJLG_Notification_Queue {
+
+    private const OPTION = 'bjlg_notification_queue';
+    private const HOOK = 'bjlg_process_notification_queue';
+    private const LOCK_TRANSIENT = 'bjlg_notification_queue_lock';
+    private const LOCK_DURATION = 45; // seconds
+    private const MAX_ATTEMPTS = 5;
+    private const MAX_ENTRIES_PER_RUN = 5;
+
+    public function __construct() {
+        add_action('init', [$this, 'ensure_schedule']);
+        add_action(self::HOOK, [$this, 'process_queue']);
+    }
+
+    /**
+     * Ensures a recurring schedule exists so that stuck notifications are retried.
+     */
+    public function ensure_schedule() {
+        if (!wp_next_scheduled(self::HOOK)) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'every_five_minutes', self::HOOK);
+        }
+    }
+
+    /**
+     * Adds an entry to the notification queue.
+     *
+     * @param array<string,mixed> $entry
+     */
+    public static function enqueue(array $entry) {
+        $normalized = self::normalize_entry($entry);
+        if (empty($normalized)) {
+            return;
+        }
+
+        $queue = self::get_queue();
+        $queue[] = $normalized;
+        self::save_queue($queue);
+
+        if (!wp_next_scheduled(self::HOOK)) {
+            wp_schedule_single_event(time() + 15, self::HOOK);
+        }
+
+        do_action('bjlg_notification_queued', $normalized);
+    }
+
+    /**
+     * Processes the queued notifications when triggered by WP-Cron.
+     */
+    public function process_queue() {
+        if ($this->is_locked()) {
+            return;
+        }
+
+        $this->lock();
+
+        try {
+            $queue = self::get_queue();
+            if (empty($queue)) {
+                return;
+            }
+
+            $now = time();
+            $updated_queue = [];
+            $processed = 0;
+
+            foreach ($queue as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+
+                if ($processed >= self::MAX_ENTRIES_PER_RUN) {
+                    $updated_queue[] = $entry;
+                    continue;
+                }
+
+                $next_attempt_at = isset($entry['next_attempt_at']) ? (int) $entry['next_attempt_at'] : 0;
+                if ($next_attempt_at > $now) {
+                    $updated_queue[] = $entry;
+                    continue;
+                }
+
+                $result = $this->handle_entry($entry, $now);
+
+                if ($result['completed']) {
+                    $this->log_entry_completion($result['entry']);
+                    continue;
+                }
+
+                $updated_queue[] = $result['entry'];
+
+                if ($result['attempted']) {
+                    $processed++;
+                }
+            }
+
+            self::save_queue($updated_queue);
+        } finally {
+            $this->unlock();
+        }
+
+        $remaining = self::get_queue();
+        if (!empty($remaining)) {
+            $delay = $this->get_next_delay($remaining);
+            wp_schedule_single_event(time() + $delay, self::HOOK);
+        }
+    }
+
+    /**
+     * Handles the delivery of a single queue entry.
+     *
+     * @param array<string,mixed> $entry
+     *
+     * @return array{entry:array<string,mixed>,completed:bool,attempted:bool}
+     */
+    private function handle_entry(array $entry, $now) {
+        $attempted = false;
+        $channels = isset($entry['channels']) && is_array($entry['channels']) ? $entry['channels'] : [];
+        $all_terminal = true;
+        $next_attempt_at = null;
+
+        foreach ($channels as $channel_key => &$channel) {
+            $channel = $this->normalize_channel($channel);
+
+            if (empty($channel['enabled'])) {
+                $channel['status'] = 'disabled';
+                continue;
+            }
+
+            $status = $channel['status'];
+            if (in_array($status, ['completed', 'failed'], true)) {
+                continue;
+            }
+
+            $ready_at = isset($channel['next_attempt_at']) ? (int) $channel['next_attempt_at'] : $now;
+            if ($ready_at > $now) {
+                $all_terminal = false;
+                $next_attempt_at = $this->min_time($next_attempt_at, $ready_at);
+                continue;
+            }
+
+            $attempted = true;
+            $result = $this->send_channel($channel_key, $entry, $channel);
+
+            if (!is_array($result)) {
+                $result = ['success' => false, 'message' => __('Erreur inconnue lors de l\'envoi.', 'backup-jlg')];
+            }
+
+            if (!empty($result['success'])) {
+                $channel['status'] = 'completed';
+                $channel['completed_at'] = $now;
+                $channel['last_error'] = '';
+                $this->log_channel_success($channel_key, $entry);
+            } else {
+                $channel['attempts']++;
+                $channel['last_error'] = isset($result['message']) ? trim((string) $result['message']) : '';
+                $channel['last_error_at'] = $now;
+
+                if ($channel['attempts'] >= self::MAX_ATTEMPTS) {
+                    $channel['status'] = 'failed';
+                    $channel['failed_at'] = $now;
+                    $this->log_channel_failure($channel_key, $entry, $channel['last_error']);
+                } else {
+                    $channel['status'] = 'retry';
+                    $channel['next_attempt_at'] = $now + $this->compute_backoff($channel['attempts']);
+                    $all_terminal = false;
+                    $next_attempt_at = $this->min_time($next_attempt_at, $channel['next_attempt_at']);
+                    $this->log_channel_retry($channel_key, $entry, $channel['last_error'], $channel['attempts']);
+                }
+            }
+        }
+        unset($channel);
+
+        $entry['channels'] = $channels;
+        $entry['last_attempt_at'] = $attempted ? $now : ($entry['last_attempt_at'] ?? 0);
+
+        if ($next_attempt_at !== null) {
+            $entry['next_attempt_at'] = $next_attempt_at;
+        } else {
+            $entry['next_attempt_at'] = $all_terminal ? $now : ($now + $this->compute_backoff(1));
+        }
+
+        $entry['updated_at'] = $now;
+
+        return [
+            'entry' => $entry,
+            'completed' => $this->all_channels_terminal($channels),
+            'attempted' => $attempted,
+        ];
+    }
+
+    /**
+     * Sends the notification via a given channel.
+     *
+     * @param array<string,mixed> $entry
+     * @param array<string,mixed> $channel
+     *
+     * @return array{success:bool,message?:string}
+     */
+    private function send_channel($channel_key, array $entry, array $channel) {
+        $title = isset($entry['title']) ? (string) $entry['title'] : '';
+        $lines = isset($entry['lines']) && is_array($entry['lines']) ? $entry['lines'] : [];
+        $subject = isset($entry['subject']) ? (string) $entry['subject'] : $title;
+        $body = isset($entry['body']) ? (string) $entry['body'] : implode("\n", $lines);
+
+        switch ($channel_key) {
+            case 'email':
+                $recipients = isset($channel['recipients']) && is_array($channel['recipients']) ? $channel['recipients'] : [];
+                return BJLG_Notification_Transport::send_email($recipients, $subject, $body);
+            case 'slack':
+                $webhook = isset($channel['webhook_url']) ? (string) $channel['webhook_url'] : '';
+                return BJLG_Notification_Transport::send_slack($webhook, $title, $lines);
+            case 'discord':
+                $webhook = isset($channel['webhook_url']) ? (string) $channel['webhook_url'] : '';
+                return BJLG_Notification_Transport::send_discord($webhook, $title, $lines);
+        }
+
+        return [
+            'success' => false,
+            'message' => sprintf(__('Canal inconnu : %s', 'backup-jlg'), $channel_key),
+        ];
+    }
+
+    /**
+     * Computes the delay before retrying a failed delivery.
+     */
+    private function compute_backoff($attempts) {
+        $attempts = max(1, (int) $attempts);
+        $base = 60; // seconds
+        $max = 15 * MINUTE_IN_SECONDS;
+        $delay = $base * (2 ** ($attempts - 1));
+
+        return (int) min($delay, $max);
+    }
+
+    /**
+     * Determines the delay before the next scheduled run based on pending channels.
+     *
+     * @param array<int,array<string,mixed>> $queue
+     */
+    private function get_next_delay(array $queue) {
+        $now = time();
+        $next = null;
+
+        foreach ($queue as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $candidate = isset($entry['next_attempt_at']) ? (int) $entry['next_attempt_at'] : 0;
+            if ($candidate > $now) {
+                $next = $this->min_time($next, $candidate);
+            }
+        }
+
+        if ($next === null) {
+            return MINUTE_IN_SECONDS;
+        }
+
+        return max(15, $next - $now);
+    }
+
+    /**
+     * Returns the smallest positive timestamp between the provided value and the candidate.
+     *
+     * @param int|null $current
+     * @param int      $candidate
+     *
+     * @return int|null
+     */
+    private function min_time($current, $candidate) {
+        if ($candidate <= 0) {
+            return $current;
+        }
+
+        if ($current === null) {
+            return $candidate;
+        }
+
+        return min($current, $candidate);
+    }
+
+    /**
+     * Checks whether all channels are in a terminal state.
+     *
+     * @param array<string,array<string,mixed>> $channels
+     */
+    private function all_channels_terminal(array $channels) {
+        foreach ($channels as $channel) {
+            if (empty($channel['enabled'])) {
+                continue;
+            }
+
+            $status = isset($channel['status']) ? (string) $channel['status'] : 'pending';
+            if (!in_array($status, ['completed', 'failed', 'disabled'], true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Normalizes the structure of a channel entry.
+     *
+     * @param array<string,mixed> $channel
+     *
+     * @return array<string,mixed>
+     */
+    private function normalize_channel($channel) {
+        if (!is_array($channel)) {
+            $channel = [];
+        }
+
+        $channel['enabled'] = !empty($channel['enabled']);
+        $channel['status'] = isset($channel['status']) ? (string) $channel['status'] : 'pending';
+        $channel['attempts'] = isset($channel['attempts']) ? (int) $channel['attempts'] : 0;
+
+        return $channel;
+    }
+
+    /**
+     * Logs a successful delivery in the plugin history.
+     */
+    private function log_channel_success($channel_key, array $entry) {
+        if (!class_exists(BJLG_History::class)) {
+            return;
+        }
+
+        $message = sprintf(
+            __('Notification « %s » envoyée via %s.', 'backup-jlg'),
+            isset($entry['event']) ? (string) $entry['event'] : 'event',
+            $channel_key
+        );
+
+        BJLG_History::log('notification', 'success', $message);
+    }
+
+    /**
+     * Logs a retry in the plugin history.
+     */
+    private function log_channel_retry($channel_key, array $entry, $error_message, $attempts) {
+        if (!class_exists(BJLG_History::class)) {
+            return;
+        }
+
+        $message = sprintf(
+            __('Nouvelle tentative pour la notification « %s » via %s (#%d) : %s', 'backup-jlg'),
+            isset($entry['event']) ? (string) $entry['event'] : 'event',
+            $channel_key,
+            $attempts,
+            $error_message !== '' ? $error_message : __('erreur inconnue', 'backup-jlg')
+        );
+
+        BJLG_History::log('notification', 'warning', $message);
+    }
+
+    /**
+     * Logs a definitive failure in the plugin history.
+     */
+    private function log_channel_failure($channel_key, array $entry, $error_message) {
+        if (!class_exists(BJLG_History::class)) {
+            return;
+        }
+
+        $message = sprintf(
+            __('Notification « %s » abandonnée via %s : %s', 'backup-jlg'),
+            isset($entry['event']) ? (string) $entry['event'] : 'event',
+            $channel_key,
+            $error_message !== '' ? $error_message : __('erreur inconnue', 'backup-jlg')
+        );
+
+        BJLG_History::log('notification', 'failure', $message);
+    }
+
+    /**
+     * Logs the completion of a queue entry (all channels processed).
+     *
+     * @param array<string,mixed> $entry
+     */
+    private function log_entry_completion(array $entry) {
+        if (!class_exists(BJLG_History::class)) {
+            return;
+        }
+
+        $channels = isset($entry['channels']) && is_array($entry['channels']) ? $entry['channels'] : [];
+        $states = [];
+        foreach ($channels as $key => $channel) {
+            if (empty($channel['enabled'])) {
+                continue;
+            }
+            $status = isset($channel['status']) ? (string) $channel['status'] : 'pending';
+            $states[] = sprintf('%s:%s', $key, $status);
+        }
+
+        if (empty($states)) {
+            return;
+        }
+
+        $message = sprintf(
+            __('Notification « %s » clôturée (%s).', 'backup-jlg'),
+            isset($entry['event']) ? (string) $entry['event'] : 'event',
+            implode(', ', $states)
+        );
+
+        BJLG_History::log('notification', 'info', $message);
+    }
+
+    /**
+     * Retrieves the queue from the options table.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private static function get_queue() {
+        $queue = get_option(self::OPTION, []);
+
+        if (!is_array($queue)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($queue as $entry) {
+            if (is_array($entry)) {
+                $normalized[] = $entry;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Persists the queue in the options table.
+     *
+     * @param array<int,array<string,mixed>> $queue
+     */
+    private static function save_queue(array $queue) {
+        update_option(self::OPTION, array_values($queue), false);
+    }
+
+    /**
+     * Normalizes the structure of an entry to avoid missing keys.
+     *
+     * @param array<string,mixed> $entry
+     *
+     * @return array<string,mixed>
+     */
+    private static function normalize_entry(array $entry) {
+        if (empty($entry['channels']) || !is_array($entry['channels'])) {
+            return [];
+        }
+
+        $now = time();
+        $normalized = [
+            'id' => isset($entry['id']) ? (string) $entry['id'] : uniqid('bjlg_notif_', true),
+            'event' => isset($entry['event']) ? (string) $entry['event'] : 'event',
+            'title' => isset($entry['title']) ? (string) $entry['title'] : '',
+            'subject' => isset($entry['subject']) ? (string) $entry['subject'] : '',
+            'lines' => isset($entry['lines']) && is_array($entry['lines']) ? array_values($entry['lines']) : [],
+            'body' => isset($entry['body']) ? (string) $entry['body'] : '',
+            'context' => isset($entry['context']) && is_array($entry['context']) ? $entry['context'] : [],
+            'created_at' => isset($entry['created_at']) ? (int) $entry['created_at'] : $now,
+            'next_attempt_at' => isset($entry['next_attempt_at']) ? (int) $entry['next_attempt_at'] : $now,
+            'channels' => [],
+        ];
+
+        foreach ($entry['channels'] as $key => $channel) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            $normalized['channels'][$key] = [
+                'enabled' => !empty($channel['enabled']),
+                'status' => isset($channel['status']) ? (string) $channel['status'] : 'pending',
+                'attempts' => isset($channel['attempts']) ? (int) $channel['attempts'] : 0,
+            ];
+
+            if (isset($channel['recipients']) && is_array($channel['recipients'])) {
+                $normalized['channels'][$key]['recipients'] = array_values($channel['recipients']);
+            }
+
+            if (isset($channel['webhook_url'])) {
+                $normalized['channels'][$key]['webhook_url'] = (string) $channel['webhook_url'];
+            }
+
+            if (isset($channel['next_attempt_at'])) {
+                $normalized['channels'][$key]['next_attempt_at'] = (int) $channel['next_attempt_at'];
+            }
+        }
+
+        if (empty($normalized['channels'])) {
+            return [];
+        }
+
+        return $normalized;
+    }
+
+    private function is_locked() {
+        return (bool) get_transient(self::LOCK_TRANSIENT);
+    }
+
+    private function lock() {
+        set_transient(self::LOCK_TRANSIENT, 1, self::LOCK_DURATION);
+    }
+
+    private function unlock() {
+        delete_transient(self::LOCK_TRANSIENT);
+    }
+}

--- a/backup-jlg/includes/class-bjlg-notification-transport.php
+++ b/backup-jlg/includes/class-bjlg-notification-transport.php
@@ -1,0 +1,171 @@
+<?php
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Provides transport helpers for multi-channel notifications.
+ */
+class BJLG_Notification_Transport {
+
+    /**
+     * Normalizes a raw list of email recipients into a unique array of addresses.
+     *
+     * @param mixed $raw
+     *
+     * @return string[]
+     */
+    public static function normalize_email_recipients($raw) {
+        if (!is_string($raw)) {
+            return [];
+        }
+
+        $parts = preg_split('/[,\n]+/', $raw);
+        if (!$parts) {
+            return [];
+        }
+
+        $valid = [];
+        foreach ($parts as $part) {
+            $email = sanitize_email(trim((string) $part));
+            if ($email !== '' && is_email($email)) {
+                $valid[] = $email;
+            }
+        }
+
+        return array_values(array_unique($valid));
+    }
+
+    /**
+     * Sends a notification email.
+     *
+     * @param string[] $recipients
+     * @param string   $subject
+     * @param string   $body
+     *
+     * @return array{success:bool,message?:string}
+     */
+    public static function send_email(array $recipients, $subject, $body) {
+        if (empty($recipients)) {
+            return [
+                'success' => false,
+                'message' => __('Aucun destinataire e-mail valide.', 'backup-jlg'),
+            ];
+        }
+
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+        $sent = wp_mail($recipients, $subject, $body, $headers);
+
+        if ($sent) {
+            return ['success' => true];
+        }
+
+        return [
+            'success' => false,
+            'message' => __('Échec de l\'envoi de la notification e-mail.', 'backup-jlg'),
+        ];
+    }
+
+    /**
+     * Sends a message to the configured Slack webhook.
+     *
+     * @param string   $webhook_url
+     * @param string   $title
+     * @param string[] $lines
+     *
+     * @return array{success:bool,message?:string}
+     */
+    public static function send_slack($webhook_url, $title, array $lines) {
+        if (!self::is_valid_url($webhook_url)) {
+            return [
+                'success' => false,
+                'message' => __('URL Slack invalide.', 'backup-jlg'),
+            ];
+        }
+
+        $message = sprintf('*%s*\n%s', $title, implode("\n", $lines));
+
+        $response = wp_remote_post($webhook_url, [
+            'headers' => ['Content-Type' => 'application/json; charset=utf-8'],
+            'body' => wp_json_encode(['text' => $message]),
+            'timeout' => 15,
+        ]);
+
+        if (is_wp_error($response)) {
+            return [
+                'success' => false,
+                'message' => $response->get_error_message(),
+            ];
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code >= 200 && $code < 300) {
+            return ['success' => true];
+        }
+
+        return [
+            'success' => false,
+            'message' => sprintf(__('Réponse inattendue de Slack : %s', 'backup-jlg'), $code),
+        ];
+    }
+
+    /**
+     * Sends a message to the configured Discord webhook.
+     *
+     * @param string   $webhook_url
+     * @param string   $title
+     * @param string[] $lines
+     *
+     * @return array{success:bool,message?:string}
+     */
+    public static function send_discord($webhook_url, $title, array $lines) {
+        if (!self::is_valid_url($webhook_url)) {
+            return [
+                'success' => false,
+                'message' => __('URL Discord invalide.', 'backup-jlg'),
+            ];
+        }
+
+        $content = sprintf('**%s**\n%s', $title, implode("\n", $lines));
+
+        $response = wp_remote_post($webhook_url, [
+            'headers' => ['Content-Type' => 'application/json; charset=utf-8'],
+            'body' => wp_json_encode(['content' => $content]),
+            'timeout' => 15,
+        ]);
+
+        if (is_wp_error($response)) {
+            return [
+                'success' => false,
+                'message' => $response->get_error_message(),
+            ];
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code >= 200 && $code < 300) {
+            return ['success' => true];
+        }
+
+        return [
+            'success' => false,
+            'message' => sprintf(__('Réponse inattendue de Discord : %s', 'backup-jlg'), $code),
+        ];
+    }
+
+    /**
+     * Validates an URL before calling wp_remote_post.
+     *
+     * @param mixed $url
+     */
+    public static function is_valid_url($url) {
+        if (!is_string($url) || trim($url) === '') {
+            return false;
+        }
+
+        $validated = wp_http_validate_url($url);
+
+        return $validated !== false && filter_var($validated, FILTER_VALIDATE_URL);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated transport helpers and a cron-driven notification queue with retry and logging support
- update multi-channel notifications to enqueue payloads for asynchronous delivery via the queue
- improve notification settings accessibility with legends, labelled controls, and list styling

## Testing
- php -l backup-jlg/includes/class-bjlg-notification-transport.php
- php -l backup-jlg/includes/class-bjlg-notification-queue.php
- php -l backup-jlg/includes/class-bjlg-notifications.php
- php -l backup-jlg/includes/class-bjlg-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68e578eee014832e9b4ad8dc90feed45