### PR TITLE
feat: trigger automatic pre-update backups

### DIFF
--- a/backup-jlg/backup-jlg.php
+++ b/backup-jlg/backup-jlg.php
@@ -195,6 +195,7 @@ final class BJLG_Plugin {
             'class-bjlg-cleanup.php', 'class-bjlg-encryption.php', 'class-bjlg-health-check.php',
             'class-bjlg-diagnostics.php', 'class-bjlg-webhooks.php', 'class-bjlg-incremental.php',
             'class-bjlg-notification-transport.php', 'class-bjlg-notification-queue.php', 'class-bjlg-notifications.php', 'class-bjlg-destination-factory.php', 'class-bjlg-remote-purge-worker.php',
+            'class-bjlg-update-guard.php',
             'class-bjlg-performance.php', 'class-bjlg-rate-limiter.php', 'class-bjlg-rest-api.php',
             'class-bjlg-api-keys.php', 'class-bjlg-admin-advanced.php', 'class-bjlg-admin.php', 'class-bjlg-actions.php',
             'destinations/interface-bjlg-destination.php', 'destinations/abstract-class-bjlg-s3-compatible.php',
@@ -232,6 +233,7 @@ final class BJLG_Plugin {
         new BJLG\BJLG_Settings();
         new BJLG\BJLG_API_Keys();
         new BJLG\BJLG_Remote_Purge_Worker();
+        new BJLG\BJLG_Update_Guard();
     }
 
     public function enqueue_admin_assets($hook) {

--- a/backup-jlg/includes/class-bjlg-update-guard.php
+++ b/backup-jlg/includes/class-bjlg-update-guard.php
@@ -1,0 +1,311 @@
+<?php
+namespace BJLG;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Déclenche automatiquement une sauvegarde avant toute mise à jour de plugin/thème.
+ */
+class BJLG_Update_Guard {
+    /** @var array<string, bool> */
+    private $processed_signatures = [];
+
+    /** @var BJLG_Backup|null */
+    private $backup_service = null;
+
+    public function __construct($backup_service = null) {
+        if ($backup_service instanceof BJLG_Backup) {
+            $this->backup_service = $backup_service;
+        }
+
+        \add_filter('upgrader_pre_install', [$this, 'handle_pre_install'], 9, 3);
+    }
+
+    /**
+     * Intercepte les mises à jour pour lancer une sauvegarde préventive.
+     *
+     * @param mixed                $response  Réponse actuelle du hook.
+     * @param array<string,mixed>  $hook_extra Contexte de la mise à jour.
+     * @param mixed                $upgrader  Instance de l'upgrader courant.
+     *
+     * @return mixed
+     */
+    public function handle_pre_install($response, $hook_extra, $upgrader) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+        try {
+            $this->maybe_trigger_pre_update_backup($hook_extra);
+        } catch (\Throwable $exception) {
+            BJLG_Debug::log('Sauvegarde pré-update non déclenchée : ' . $exception->getMessage());
+        }
+
+        return $response;
+    }
+
+    /**
+     * Lance une sauvegarde avant mise à jour si le contexte le justifie.
+     *
+     * @param mixed $hook_extra
+     *
+     * @return string|null Identifiant de la tâche créée ou null si aucune sauvegarde n'a été lancée.
+     */
+    public function maybe_trigger_pre_update_backup($hook_extra) {
+        $context = $this->normalize_context($hook_extra);
+        if (!$context) {
+            return null;
+        }
+
+        $enabled = \apply_filters('bjlg_pre_update_backup_enabled', true, $context, $hook_extra);
+        if (!$enabled) {
+            return null;
+        }
+
+        $signature = $context['signature'];
+        if (isset($this->processed_signatures[$signature])) {
+            return null;
+        }
+        $this->processed_signatures[$signature] = true;
+
+        if (BJLG_Backup::is_task_locked()) {
+            BJLG_Debug::log('Sauvegarde pré-update ignorée : une autre sauvegarde est déjà en cours.');
+            return null;
+        }
+
+        $blueprint = $this->resolve_blueprint($context, $hook_extra);
+        if (empty($blueprint['components'])) {
+            BJLG_Debug::log('Sauvegarde pré-update ignorée : aucun composant à sauvegarder.');
+            return null;
+        }
+
+        $task_id = 'bjlg_backup_' . md5(uniqid('preupdate', true));
+        $task_data = [
+            'progress' => 5,
+            'status' => 'pending',
+            'status_text' => sprintf('Snapshot avant %s…', $context['label']),
+            'components' => $blueprint['components'],
+            'encrypt' => (bool) $blueprint['encrypt'],
+            'incremental' => (bool) $blueprint['incremental'],
+            'source' => 'pre_update',
+            'start_time' => time(),
+            'include_patterns' => $blueprint['include_patterns'],
+            'exclude_patterns' => $blueprint['exclude_patterns'],
+            'post_checks' => $blueprint['post_checks'],
+            'secondary_destinations' => $blueprint['secondary_destinations'],
+            'secondary_destination_batches' => $blueprint['secondary_destination_batches'],
+            'update_context' => $context,
+        ];
+
+        $task_data = \apply_filters('bjlg_pre_update_backup_task', $task_data, $context, $hook_extra);
+        if (!is_array($task_data)) {
+            BJLG_Debug::log('Sauvegarde pré-update annulée par filtre : payload invalide.');
+            return null;
+        }
+
+        $saved = \set_transient($task_id, $task_data, BJLG_Backup::get_task_ttl());
+        if (!$saved) {
+            BJLG_Debug::log("Impossible d'initialiser la tâche de sauvegarde pré-update $task_id.");
+            return null;
+        }
+
+        BJLG_History::log(
+            'pre_update_backup',
+            'info',
+            sprintf(
+                'Sauvegarde pré-update lancée avant %s : %s.',
+                $context['label'],
+                $context['items_label']
+            )
+        );
+
+        \do_action('bjlg_pre_update_backup_launched', $task_id, $task_data, $context, $hook_extra);
+
+        try {
+            $this->get_backup_service()->run_backup_task($task_id);
+        } catch (\Throwable $exception) {
+            BJLG_Debug::log('Erreur lors de la sauvegarde pré-update : ' . $exception->getMessage());
+        }
+
+        return $task_id;
+    }
+
+    /**
+     * Normalise le contexte reçu depuis WordPress.
+     *
+     * @param mixed $hook_extra
+     *
+     * @return array<string,mixed>|null
+     */
+    private function normalize_context($hook_extra) {
+        if (!is_array($hook_extra)) {
+            return null;
+        }
+
+        $action = isset($hook_extra['action']) ? sanitize_key((string) $hook_extra['action']) : '';
+        if ($action !== 'update') {
+            return null;
+        }
+
+        $type = isset($hook_extra['type']) ? sanitize_key((string) $hook_extra['type']) : '';
+        if (!in_array($type, ['plugin', 'theme', 'core'], true)) {
+            return null;
+        }
+
+        $items = $this->extract_items_from_context($hook_extra, $type);
+        $items_label = !empty($items) ? implode(', ', $items) : __('site complet', 'backup-jlg');
+
+        $label = $this->describe_target($type, count($items));
+        $context = [
+            'type' => $type,
+            'action' => $action,
+            'items' => $items,
+            'items_label' => $items_label,
+            'label' => $label,
+            'signature' => $type . '|' . md5($items_label . '|' . $label),
+        ];
+
+        $context = \apply_filters('bjlg_pre_update_backup_context', $context, $hook_extra);
+        if (!is_array($context) || empty($context['signature'])) {
+            return null;
+        }
+
+        return $context;
+    }
+
+    /**
+     * Sélectionne les composants à sauvegarder en se basant sur la planification existante.
+     *
+     * @param array<string,mixed> $context
+     * @param mixed               $hook_extra
+     *
+     * @return array<string,mixed>
+     */
+    private function resolve_blueprint(array $context, $hook_extra) {
+        $collection = \get_option('bjlg_schedule_settings', []);
+        $sanitized_collection = BJLG_Settings::sanitize_schedule_collection($collection);
+        $schedules = isset($sanitized_collection['schedules']) && is_array($sanitized_collection['schedules'])
+            ? $sanitized_collection['schedules']
+            : [];
+
+        if (!empty($schedules)) {
+            $primary = $this->select_primary_schedule($schedules);
+        } else {
+            $primary = BJLG_Settings::get_default_schedule_entry();
+        }
+
+        $blueprint = [
+            'components' => $primary['components'],
+            'encrypt' => $primary['encrypt'],
+            'incremental' => $primary['incremental'],
+            'include_patterns' => $primary['include_patterns'],
+            'exclude_patterns' => $primary['exclude_patterns'],
+            'post_checks' => $primary['post_checks'],
+            'secondary_destinations' => $primary['secondary_destinations'],
+            'secondary_destination_batches' => $primary['secondary_destination_batches'] ?? [],
+        ];
+
+        return \apply_filters('bjlg_pre_update_backup_blueprint', $blueprint, $context, $hook_extra);
+    }
+
+    /**
+     * Retourne le planning prioritaire (actif si disponible, sinon le premier).
+     *
+     * @param array<int,array<string,mixed>> $schedules
+     *
+     * @return array<string,mixed>
+     */
+    private function select_primary_schedule(array $schedules) {
+        foreach ($schedules as $schedule) {
+            if (!is_array($schedule)) {
+                continue;
+            }
+
+            if (($schedule['recurrence'] ?? 'disabled') !== 'disabled') {
+                return $schedule;
+            }
+        }
+
+        return $schedules[0];
+    }
+
+    /**
+     * Extrait la liste des éléments concernés par la mise à jour.
+     *
+     * @param array<string,mixed> $hook_extra
+     * @param string              $type
+     *
+     * @return string[]
+     */
+    private function extract_items_from_context(array $hook_extra, $type) {
+        $items = [];
+        $keys = ['plugin', 'plugins', 'theme', 'themes', 'item', 'items'];
+
+        foreach ($keys as $key) {
+            if (!isset($hook_extra[$key])) {
+                continue;
+            }
+
+            $value = $hook_extra[$key];
+            if (is_array($value)) {
+                foreach ($value as $entry) {
+                    if (is_scalar($entry)) {
+                        $items[] = $this->format_item((string) $entry);
+                    }
+                }
+            } elseif (is_scalar($value)) {
+                $items[] = $this->format_item((string) $value);
+            }
+        }
+
+        if ($type === 'core' && empty($items)) {
+            $items[] = 'wordpress-core';
+        }
+
+        $items = array_values(array_unique(array_filter($items)));
+
+        return $items;
+    }
+
+    /**
+     * Formate proprement l'identifiant d'un élément.
+     */
+    private function format_item($item) {
+        $trimmed = trim($item);
+
+        if ($trimmed === '') {
+            return '';
+        }
+
+        return sanitize_text_field($trimmed);
+    }
+
+    /**
+     * Fournit un libellé humain selon le type d'élément.
+     */
+    private function describe_target($type, $count) {
+        switch ($type) {
+            case 'plugin':
+                return $count > 1
+                    ? __('la mise à jour des extensions', 'backup-jlg')
+                    : __('la mise à jour de l\'extension', 'backup-jlg');
+            case 'theme':
+                return $count > 1
+                    ? __('la mise à jour des thèmes', 'backup-jlg')
+                    : __('la mise à jour du thème', 'backup-jlg');
+            case 'core':
+                return __('la mise à jour du cœur WordPress', 'backup-jlg');
+            default:
+                return __('la mise à jour', 'backup-jlg');
+        }
+    }
+
+    /**
+     * Retourne (ou crée) le service de sauvegarde.
+     */
+    private function get_backup_service() {
+        if (!$this->backup_service instanceof BJLG_Backup) {
+            $this->backup_service = new BJLG_Backup();
+        }
+
+        return $this->backup_service;
+    }
+}

--- a/backup-jlg/tests/BJLG_UpdateGuardTest.php
+++ b/backup-jlg/tests/BJLG_UpdateGuardTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-bjlg-debug.php';
+require_once __DIR__ . '/../includes/class-bjlg-settings.php';
+require_once __DIR__ . '/../includes/class-bjlg-backup.php';
+require_once __DIR__ . '/../includes/class-bjlg-update-guard.php';
+
+if (!class_exists('BJLG_Test_BackupStub')) {
+    class BJLG_Test_BackupStub extends BJLG\BJLG_Backup
+    {
+        /** @var array<int, string> */
+        public $task_ids = [];
+
+        public function __construct()
+        {
+            // Ne pas exécuter le constructeur parent pour éviter l'enregistrement de hooks.
+        }
+
+        public function run_backup_task($task_id)
+        {
+            $this->task_ids[] = (string) $task_id;
+        }
+    }
+}
+
+final class BJLG_UpdateGuardTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['bjlg_test_transients'] = [];
+        $GLOBALS['bjlg_test_options'] = [];
+        $GLOBALS['bjlg_test_filters'] = [];
+    }
+
+    public function test_launches_backup_before_plugin_update(): void
+    {
+        $backup_stub = new BJLG_Test_BackupStub();
+        $guard = new BJLG\BJLG_Update_Guard($backup_stub);
+
+        $captured_history = [];
+        add_action(
+            'bjlg_history_logged',
+            static function ($action, $status, $details) use (&$captured_history): void {
+                $captured_history[] = [$action, $status, $details];
+            },
+            10,
+            3
+        );
+
+        $hook_extra = [
+            'type' => 'plugin',
+            'action' => 'update',
+            'plugins' => ['hello/hello.php'],
+        ];
+
+        $task_id = $guard->maybe_trigger_pre_update_backup($hook_extra);
+
+        $this->assertNotNull($task_id);
+        $this->assertSame([$task_id], $backup_stub->task_ids);
+        $this->assertArrayHasKey($task_id, $GLOBALS['bjlg_test_transients']);
+
+        $task_data = $GLOBALS['bjlg_test_transients'][$task_id];
+        $this->assertSame('pre_update', $task_data['source']);
+        $this->assertSame(['hello/hello.php'], $task_data['update_context']['items']);
+        $this->assertSame('la mise à jour de l\'extension', $task_data['update_context']['label']);
+
+        $this->assertNotEmpty($captured_history);
+        $this->assertSame('pre_update_backup', $captured_history[0][0]);
+        $this->assertSame('info', $captured_history[0][1]);
+    }
+
+    public function test_skips_duplicate_contexts(): void
+    {
+        $backup_stub = new BJLG_Test_BackupStub();
+        $guard = new BJLG\BJLG_Update_Guard($backup_stub);
+
+        $hook_extra = [
+            'type' => 'plugin',
+            'action' => 'update',
+            'plugins' => ['classic-editor/classic-editor.php'],
+        ];
+
+        $first = $guard->maybe_trigger_pre_update_backup($hook_extra);
+        $second = $guard->maybe_trigger_pre_update_backup($hook_extra);
+
+        $this->assertNotNull($first);
+        $this->assertNull($second);
+        $this->assertCount(1, $backup_stub->task_ids);
+    }
+
+    public function test_ignores_non_update_actions(): void
+    {
+        $backup_stub = new BJLG_Test_BackupStub();
+        $guard = new BJLG\BJLG_Update_Guard($backup_stub);
+
+        $hook_extra = [
+            'type' => 'plugin',
+            'action' => 'install',
+            'plugin' => 'new-plugin/new-plugin.php',
+        ];
+
+        $task_id = $guard->maybe_trigger_pre_update_backup($hook_extra);
+
+        $this->assertNull($task_id);
+        $this->assertEmpty($backup_stub->task_ids);
+        $this->assertEmpty($GLOBALS['bjlg_test_transients']);
+    }
+}

--- a/docs/comparaison-pro.md
+++ b/docs/comparaison-pro.md
@@ -10,12 +10,12 @@ Ce document positionne Backup JLG face aux offres haut de gamme (UpdraftPlus Pr
 - **Sécurité d’accès** : rate limiting, gestion de clés API et webhooks signés se rapprochent des contrôles d’accès « agency-grade » de ManageWP ou BlogVault.【F:backup-jlg/includes/class-bjlg-rate-limiter.php†L18-L62】【F:backup-jlg/includes/class-bjlg-api-keys.php†L13-L172】【F:backup-jlg/includes/class-bjlg-webhooks.php†L18-L328】
 - **Restauration production/sandbox orchestrée** : la possibilité de préparer, nettoyer et promouvoir des sandboxes permet de tester les archives avant promotion, une approche voisine des workflows de restauration sécurisés proposés par BlogVault Staging.【F:backup-jlg/includes/class-bjlg-restore.php†L44-L207】【F:backup-jlg/includes/class-bjlg-restore.php†L503-L616】
 - **Distribution sécurisée des exports** : tokens de téléchargement temporaires, contrôles d’accès et journalisation détaillée renforcent la conformité et la traçabilité attendues sur les offres managées.【F:backup-jlg/includes/class-bjlg-actions.php†L16-L200】【F:backup-jlg/includes/class-bjlg-history.php†L8-L158】
+- **Snapshots pré-mise à jour** : un gardien dédié déclenche automatiquement une sauvegarde complète avant chaque update de plugin ou de thème via `upgrader_pre_install`, limitant les régressions comme le proposent Jetpack Backup ou BlogVault.【F:backup-jlg/includes/class-bjlg-update-guard.php†L10-L166】
 
 ## Écarts observés face aux offres pro
 
 - **Notifications multi-canales incomplètes** : l’interface propose email/Slack/Discord mais seul le webhook interne est implémenté, là où les solutions commerciales poussent des alertes temps réel sur plusieurs canaux.【F:backup-jlg/includes/class-bjlg-settings.php†L41-L54】【F:backup-jlg/includes/class-bjlg-webhooks.php†L24-L29】
 - **Nettoyage distant** : la rotation incrémentale enregistre les suppressions à propager mais aucun worker natif ne consomme la file d’attente, à la différence des solutions SaaS qui purgent automatiquement les copies distantes.【F:backup-jlg/includes/class-bjlg-incremental.php†L279-L347】
-- **Pilotage avant mise à jour** : il n’existe pas encore de déclencheur automatique avant une mise à jour de plugin/thème, une fonctionnalité courante des offres professionnelles pour éviter les régressions.
 - **Couverture multisite et gestion centralisée** : le plugin reste officiellement mono-site tandis que les suites pro gèrent la supervision multi-projets depuis une même console (ManageWP, BlogVault Agency).【F:README.md†L111-L116】
 - **Stockage isolé managé** : Backup JLG délègue la résilience au stockage choisi par l’utilisateur ; les solutions SaaS haut de gamme répliquent automatiquement les archives sur une infrastructure managée avec redondance géographique, fonctionnalité encore absente nativement.
 
@@ -36,7 +36,7 @@ Ce document positionne Backup JLG face aux offres haut de gamme (UpdraftPlus Pr
 
 1. **Implémenter l’envoi réel des notifications** (emails, Slack/Discord) en s’appuyant sur les réglages existants et sur les hooks `bjlg_backup_complete`/`bjlg_backup_failed`, afin d’égaler les alertes omnicanales des solutions gérées.【F:backup-jlg/includes/class-bjlg-settings.php†L41-L54】【F:backup-jlg/includes/class-bjlg-webhooks.php†L24-L29】
 2. **Créer un orchestrateur de purge distante** qui consomme l’action `bjlg_incremental_remote_purge` et déclenche les API des stockages concernés, assurant une rotation complète sans intervention manuelle.【F:backup-jlg/includes/class-bjlg-incremental.php†L279-L347】
-3. **Ajouter un déclencheur de sauvegarde pré-mise à jour** (hook `upgrader_pre_install` ou équivalent) pour automatiser les snapshots avant chaque update, comme le proposent UpdraftPlus Premium ou Jetpack Backup.
+3. **Rendre le snapshot pré-update configurable côté interface** (activation, composants dédiés, rappel) pour s’aligner totalement sur les offres qui laissent aux administrateurs la main sur ce déclencheur automatique.【F:backup-jlg/includes/class-bjlg-update-guard.php†L27-L166】
 4. **Étendre la prise en charge multisite** : support natif de WordPress multisite et mutualisation des historiques/API pour piloter plusieurs environnements depuis une seule instance, indispensable pour rivaliser avec les consoles agence.【F:README.md†L111-L116】【F:backup-jlg/includes/class-bjlg-rest-api.php†L54-L319】
 5. **Renforcer la supervision proactive** : compléter le bilan de santé et l’audit SQL existants par des métriques d’usage (quota distant, temps moyen de restauration) exposées via API/webhooks afin de fournir les garanties de service attendues sur les offres premium.【F:backup-jlg/includes/class-bjlg-health-check.php†L17-L152】【F:backup-jlg/includes/class-bjlg-history.php†L8-L158】
 
@@ -53,7 +53,7 @@ Ce document positionne Backup JLG face aux offres haut de gamme (UpdraftPlus Pr
 
 - **Parcours admin modulaires** : éclater la mono-page actuelle en sous-pages dédiées (monitoring, restauration, automatisation) et migrer progressivement vers `@wordpress/components` pour gagner en accessibilité native et en cohérence mobile.【F:backup-jlg/includes/class-bjlg-admin.php†L121-L170】【F:backup-jlg/assets/css/admin.css†L741-L980】
 - **Onboarding piloté** : transformer la liste statique actuelle en checklist interactive avec suivi d’étapes, rappelant les assistants guidés des suites pro.【F:backup-jlg/assets/js/admin.js†L90-L199】
-- **Pré-sauvegarde avant mises à jour** : brancher un déclencheur automatique sur `upgrader_pre_install`/`automatic_updates_complete` pour créer un snapshot avant toute mise à jour de plugin ou de thème, fonctionnalité différenciante dans les offres managées.【F:backup-jlg/includes/class-bjlg-admin.php†L121-L170】
+- **Snapshot pré-update opérationnel** : le gardien dédié déclenche désormais la sauvegarde juste avant chaque mise à jour grâce au hook `upgrader_pre_install`, reproduisant les garde-fous observés sur les suites pro.【F:backup-jlg/includes/class-bjlg-update-guard.php†L27-L166】
 
 ### Paris long terme (>6 mois)
 
@@ -68,7 +68,7 @@ Ce document positionne Backup JLG face aux offres haut de gamme (UpdraftPlus Pr
 - **Cadence de sauvegarde étendue mais perfectible** : le planificateur propose désormais des fréquences de 5 à 15 minutes en plus des intervalles horaires à mensuels, mais un champ Cron personnalisé permettrait d’adresser les scénarios d’orchestration avancés.【F:backup-jlg/includes/class-bjlg-settings.php†L18-L72】【F:backup-jlg/includes/class-bjlg-scheduler.php†L47-L119】
 - **Canaux d’alerte à finaliser** : seuls les formulaires d’email, Slack et Discord existent côté réglages, sans SMS, Teams ou webhook sortant réellement câblés. Étendre les destinations et brancher l’envoi réel rapprocherait l’expérience des offres omnicanales.【F:backup-jlg/includes/class-bjlg-settings.php†L41-L55】【F:backup-jlg/includes/class-bjlg-webhooks.php†L24-L29】
 - **Connecteurs cloud élargis** : Azure Blob et Backblaze B2 rejoignent Drive, S3, Wasabi, Dropbox, OneDrive, pCloud et SFTP dans les onglets d’administration, confirmant l’alignement du catalogue avec les offres pro.【F:backup-jlg/includes/class-bjlg-admin.php†L62-L78】【F:backup-jlg/includes/class-bjlg-admin.php†L373-L540】【F:backup-jlg/includes/destinations/class-bjlg-azure-blob.php†L71-L118】【F:backup-jlg/includes/destinations/class-bjlg-backblaze-b2.php†L76-L154】
-- **Absence d’automatisation pré-update** : la page d’administration ne déclare aucun hook dédié aux mises à jour de plugins/thèmes, ce qui empêche de proposer une option « sauvegarde avant update » pourtant standard en pro.【F:backup-jlg/includes/class-bjlg-admin.php†L146-L170】
+- **Gardien pré-update intégré** : la logique embarquée dans `BJLG_Update_Guard` déclenche automatiquement la sauvegarde avant chaque mise à jour, sans intervention manuelle, comblant l’un des manques pointés lors du benchmark pro.【F:backup-jlg/includes/class-bjlg-update-guard.php†L27-L166】
 
 ### Expérience UX/UI dans l’admin
 


### PR DESCRIPTION
## Summary
- add the BJLG_Update_Guard service that snapshots the site before plugin and theme updates, with filters/actions for integrators
- register the guard in the plugin bootstrap and document the new capability in the professional comparison guide
- cover the new workflow with PHPUnit tests to ensure a single backup is queued per update context

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e59b72c914832ebdac832c1d0ad6a5