### PR TITLE
Provide coded UI presets demo and CSS tokens

### DIFF
--- a/docs/ui-presets-demo.html
+++ b/docs/ui-presets-demo.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Démo de presets UI</title>
+    <link rel="stylesheet" href="ui-presets.css" />
+    <style>
+      body {
+        background: radial-gradient(circle at top, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.95));
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Démo des presets UI</h1>
+        <p class="intro">
+          Chaque section applique un attribut <code>data-preset</code> pour charger instantanément les couleurs,
+          typographies, ombres et interactions associées. Les composants de base (boutons, formulaires,
+          cartes, modales) réagissent automatiquement aux variables des thèmes.
+        </p>
+      </header>
+
+      <section class="preset" data-preset="minimal-focus" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Minimal Focus</h2>
+          <span class="preset__subtitle">Headless UI vibes</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Action principale</button>
+              <button class="secondary">Option</button>
+              <button class="ghost">Ghost</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="mf-email">Email</label>
+              <input id="mf-email" type="email" placeholder="vous@example.com" />
+              <label for="mf-select">Type de sauvegarde</label>
+              <select id="mf-select">
+                <option>Incrémentale</option>
+                <option>Complète</option>
+                <option>Base de données seule</option>
+              </select>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Tags</h3>
+            <div class="tag-list">
+              <span class="pill">Accessibilité</span>
+              <span class="pill">Focus visible</span>
+              <span class="pill">Sans distraction</span>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Modale</h3>
+            <div class="modal">
+              <h4 class="modal__title">Confirmer la rotation</h4>
+              <p>Voulez-vous vraiment purger les sauvegardes plus anciennes que 30 jours&nbsp;?</p>
+              <div class="modal__footer">
+                <button class="secondary">Annuler</button>
+                <button class="primary">Confirmer</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="preset" data-preset="modern-contrast" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Modern Contrast</h2>
+          <span class="preset__subtitle">Shadcn UI mood</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Créer un plan</button>
+              <button class="secondary">Dupliquer</button>
+              <button class="ghost">Voir l'historique</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="mc-name">Nom du preset</label>
+              <input id="mc-name" type="text" placeholder="Plan nocturne" />
+              <label for="mc-frequency">Fréquence</label>
+              <select id="mc-frequency">
+                <option>Quotidienne</option>
+                <option>Hebdomadaire</option>
+                <option>Mensuelle</option>
+              </select>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Interactions</h3>
+            <ul>
+              <li>Hover luminescent</li>
+              <li>Gradient interne</li>
+              <li>Ombres profondes</li>
+            </ul>
+          </article>
+          <article class="preset__card">
+            <h3>Modale latérale</h3>
+            <div class="modal">
+              <h4 class="modal__title">Journal des webhooks</h4>
+              <p>3 webhooks envoyés au cours des 24 dernières heures. Aucun échec.</p>
+              <div class="modal__footer">
+                <button class="secondary">Exporter</button>
+                <button class="primary">Rejouer</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="preset" data-preset="systemic-elevation" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Systemic Elevation</h2>
+          <span class="preset__subtitle">Radix UI energy</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Tester le chiffrement</button>
+              <button class="secondary">Voir le manifeste</button>
+              <button class="ghost">Historique</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="se-email">Envoyer le rapport à</label>
+              <input id="se-email" type="email" placeholder="ops@example.com" />
+              <label for="se-status">État</label>
+              <select id="se-status">
+                <option>Succès</option>
+                <option>Avertissement</option>
+                <option>Échec</option>
+              </select>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Accessibilité</h3>
+            <div class="tag-list">
+              <span class="pill">Multi focus ring</span>
+              <span class="pill">Motion mindful</span>
+              <span class="pill">Slots ready</span>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Modale</h3>
+            <div class="modal">
+              <h4 class="modal__title">Détails de l'incident</h4>
+              <p>La synchronisation distante a pris 3 minutes supplémentaires. Aucun retry nécessaire.</p>
+              <div class="modal__footer">
+                <button class="secondary">Fermer</button>
+                <button class="primary">Notifier l'équipe</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="preset" data-preset="classy-utility" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Classy Utility</h2>
+          <span class="preset__subtitle">Bootstrap touch</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Sauvegarder</button>
+              <button class="secondary">Aperçu</button>
+              <button class="ghost">Logs</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="cu-label">Destination</label>
+              <input id="cu-label" type="text" placeholder="Google Drive" />
+              <label for="cu-mode">Mode</label>
+              <select id="cu-mode">
+                <option>Automatique</option>
+                <option>Planifié</option>
+                <option>Manuel</option>
+              </select>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Chips</h3>
+            <div class="tag-list">
+              <span class="pill">Primary</span>
+              <span class="pill">Warning</span>
+              <span class="pill">Danger</span>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Modale</h3>
+            <div class="modal">
+              <h4 class="modal__title">Rotation automatique</h4>
+              <p>Les archives supérieures à 12 versions seront supprimées.</p>
+              <div class="modal__footer">
+                <button class="secondary">Annuler</button>
+                <button class="primary">Appliquer</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="preset" data-preset="vibrant-clarity" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Vibrant Clarity</h2>
+          <span class="preset__subtitle">Semantic UI spirit</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Publier</button>
+              <button class="secondary">Prévisualiser</button>
+              <button class="ghost">Archiver</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="vc-title">Titre</label>
+              <input id="vc-title" type="text" placeholder="Audit mensuel" />
+              <label for="vc-notes">Notes</label>
+              <textarea id="vc-notes" rows="3" placeholder="Lister les tâches critiques"></textarea>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Alertes</h3>
+            <div class="tag-list">
+              <span class="pill">Positive</span>
+              <span class="pill">Warning</span>
+              <span class="pill">Negative</span>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Modale</h3>
+            <div class="modal">
+              <h4 class="modal__title">Rapport généré</h4>
+              <p>Le rapport Semantic est prêt à être partagé avec votre équipe.</p>
+              <div class="modal__footer">
+                <button class="secondary">Télécharger</button>
+                <button class="primary">Partager</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="preset" data-preset="motion-canvas" style="background: var(--color-background); color: var(--color-text);">
+        <div class="preset__header">
+          <h2 class="preset__title">Motion Canvas</h2>
+          <span class="preset__subtitle">Anime.js flair</span>
+        </div>
+        <div class="preset__grid">
+          <article class="preset__card">
+            <h3>Boutons</h3>
+            <div class="preset__btn-row">
+              <button class="primary">Lancer la démo</button>
+              <button class="secondary">Paramètres</button>
+              <button class="ghost">Mode réduit</button>
+            </div>
+          </article>
+          <article class="preset__card">
+            <h3>Formulaire</h3>
+            <form>
+              <label for="mo-scene">Scène animée</label>
+              <input id="mo-scene" type="text" placeholder="Timeline héro" />
+              <label for="mo-intensity">Intensité</label>
+              <select id="mo-intensity">
+                <option>Légère</option>
+                <option>Standard</option>
+                <option>Explosive</option>
+              </select>
+            </form>
+          </article>
+          <article class="preset__card">
+            <h3>Effets</h3>
+            <ul>
+              <li>Motion path</li>
+              <li>Stagger</li>
+              <li>Scroll trigger</li>
+            </ul>
+          </article>
+          <article class="preset__card">
+            <h3>Modale immersive</h3>
+            <div class="modal">
+              <h4 class="modal__title">Projection en cours</h4>
+              <p>Les animations Anime.js se synchronisent avec le défilement utilisateur.</p>
+              <div class="modal__footer">
+                <button class="secondary">Suspendre</button>
+                <button class="primary">Continuer</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/ui-presets.css
+++ b/docs/ui-presets.css
@@ -1,0 +1,421 @@
+/*
+ * UI preset tokens & demo styles.
+ * Each preset exposes CSS custom properties so the styles can be
+ * transplanted into a design system, Storybook, or WordPress admin page.
+ */
+:root {
+  --preset-radius-sm: 6px;
+  --preset-radius-md: 10px;
+  --preset-radius-lg: 16px;
+  --preset-spacing-xs: 0.35rem;
+  --preset-spacing-sm: 0.5rem;
+  --preset-spacing-md: 1rem;
+  --preset-spacing-lg: 1.5rem;
+  --preset-spacing-xl: 2.5rem;
+  --preset-shadow-soft: 0 12px 30px -18px rgba(15, 23, 42, 0.35);
+  color-scheme: light dark;
+  font-family: "Inter", "Sora", "Public Sans", "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+  display: grid;
+  gap: 3rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 3.5vw, 3.2rem);
+  margin-bottom: 0.5rem;
+  color: #f8fafc;
+}
+
+.intro {
+  color: rgba(248, 250, 252, 0.75);
+  margin-bottom: 2rem;
+  max-width: 70ch;
+  line-height: 1.55;
+}
+
+.preset {
+  border-radius: var(--preset-radius-lg);
+  padding: var(--preset-spacing-xl);
+  display: grid;
+  gap: var(--preset-spacing-lg);
+  transition: transform 160ms ease, box-shadow 220ms ease;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.preset:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--preset-shadow, var(--preset-shadow-soft));
+}
+
+.preset__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--preset-spacing-sm);
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.preset__title {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  margin: 0;
+  color: var(--color-text-strong);
+}
+
+.preset__subtitle {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.preset__grid {
+  display: grid;
+  gap: var(--preset-spacing-lg);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.preset__card {
+  background: color-mix(in srgb, var(--color-surface) 92%, #ffffff 8%);
+  border-radius: var(--preset-radius-md);
+  padding: var(--preset-spacing-md);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent 40%);
+  box-shadow: var(--preset-card-shadow, none);
+  color: var(--color-text);
+  display: grid;
+  gap: var(--preset-spacing-sm);
+}
+
+.preset__card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-family: var(--font-heading);
+  color: var(--color-text-strong);
+}
+
+.preset__card p,
+.preset__card li,
+.preset__card label {
+  margin: 0;
+  font-family: var(--font-body);
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
+.preset__card ul {
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.preset__btn-row {
+  display: flex;
+  gap: var(--preset-spacing-sm);
+  flex-wrap: wrap;
+}
+
+button,
+.pill {
+  font-family: var(--font-body);
+  font-weight: 600;
+  border-radius: var(--preset-radius-sm);
+  border: 1px solid transparent;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 180ms ease, background 150ms ease, border 150ms ease;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-focus) 80%, rgba(255, 255, 255, 0.15) 20%);
+}
+
+button.primary {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  box-shadow: var(--preset-btn-shadow, none);
+}
+
+button.secondary {
+  background: var(--color-surface);
+  color: var(--color-text-strong);
+  border-color: color-mix(in srgb, var(--color-border) 70%, transparent 30%);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 40%, transparent 60%);
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--preset-btn-shadow-hover, var(--preset-shadow-soft));
+}
+
+form {
+  display: grid;
+  gap: var(--preset-spacing-sm);
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+input,
+select,
+textarea {
+  border-radius: var(--preset-radius-sm);
+  padding: 0.65rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent 25%);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  transition: border 120ms ease, box-shadow 120ms ease, background 150ms ease;
+}
+
+input::placeholder {
+  color: color-mix(in srgb, var(--color-text) 60%, #ffffff 40%);
+}
+
+.tag-list {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.pill {
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent 80%);
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 35%, transparent 65%);
+}
+
+.modal {
+  padding: var(--preset-spacing-md);
+  border-radius: var(--preset-radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent 40%);
+  background: color-mix(in srgb, var(--color-surface) 94%, #ffffff 6%);
+  display: grid;
+  gap: var(--preset-spacing-sm);
+  box-shadow: var(--preset-modal-shadow, 0 18px 60px -30px rgba(15, 23, 42, 0.4));
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-family: var(--font-heading);
+  color: var(--color-text-strong);
+}
+
+.modal__footer {
+  display: flex;
+  gap: var(--preset-spacing-sm);
+  justify-content: flex-end;
+}
+
+/* --- Preset variations -------------------------------------------------- */
+
+[data-preset="minimal-focus"] {
+  --font-heading: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --color-background: #f9fafb;
+  --color-surface: #ffffff;
+  --color-text: #374151;
+  --color-text-strong: #111827;
+  --color-accent: #2563eb;
+  --color-on-accent: #ffffff;
+  --color-border: #e5e7eb;
+  --color-input-bg: #ffffff;
+  --color-focus: rgba(37, 99, 235, 0.35);
+  --preset-shadow: 0 12px 30px -20px rgba(17, 24, 39, 0.35);
+  --preset-btn-shadow: none;
+  --preset-btn-shadow-hover: 0 8px 18px -12px rgba(37, 99, 235, 0.5);
+}
+
+[data-preset="minimal-focus"] button.ghost {
+  border-color: rgba(37, 99, 235, 0.3);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+[data-preset="modern-contrast"] {
+  --font-heading: "Sora", "Sora Variable", sans-serif;
+  --font-body: "Neue Haas Grotesk", "Inter", sans-serif;
+  --color-background: #0f172a;
+  --color-surface: #1e293b;
+  --color-text: rgba(248, 250, 252, 0.82);
+  --color-text-strong: #f8fafc;
+  --color-accent: #a855f7;
+  --color-on-accent: #0f172a;
+  --color-border: rgba(148, 163, 184, 0.28);
+  --color-input-bg: rgba(15, 23, 42, 0.85);
+  --color-focus: rgba(168, 85, 247, 0.55);
+  --preset-shadow: 0 22px 60px -30px rgba(88, 28, 135, 0.65);
+  --preset-btn-shadow: 0 12px 30px -16px rgba(168, 85, 247, 0.65);
+  --preset-btn-shadow-hover: 0 16px 40px -12px rgba(56, 189, 248, 0.55);
+  --preset-card-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.2);
+  --preset-modal-shadow: 0 24px 80px -24px rgba(14, 165, 233, 0.35);
+}
+
+[data-preset="modern-contrast"] .preset__card {
+  background: linear-gradient(160deg, rgba(168, 85, 247, 0.12), rgba(14, 165, 233, 0.08));
+}
+
+[data-preset="modern-contrast"] button.secondary {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.75);
+}
+
+[data-preset="systemic-elevation"] {
+  --font-heading: "IBM Plex Sans", "Inter", sans-serif;
+  --font-body: "Work Sans", system-ui, sans-serif;
+  --color-background: #ffffff;
+  --color-surface: #f1f5f9;
+  --color-text: #1f2937;
+  --color-text-strong: #0f172a;
+  --color-accent: #0ea5e9;
+  --color-on-accent: #f8fafc;
+  --color-border: rgba(15, 23, 42, 0.12);
+  --color-input-bg: #ffffff;
+  --color-focus: linear-gradient(115deg, rgba(14, 165, 233, 0.5), rgba(16, 185, 129, 0.45));
+  --preset-shadow: 0 20px 50px -28px rgba(15, 23, 42, 0.4);
+  --preset-btn-shadow: 0 10px 24px -16px rgba(14, 165, 233, 0.4);
+  --preset-btn-shadow-hover: 0 16px 36px -20px rgba(16, 185, 129, 0.4);
+  --preset-card-shadow: 0 10px 30px -12px rgba(15, 23, 42, 0.2);
+}
+
+[data-preset="systemic-elevation"] button.secondary {
+  border-color: rgba(14, 165, 233, 0.45);
+  color: #0ea5e9;
+  background: rgba(14, 165, 233, 0.12);
+}
+
+[data-preset="systemic-elevation"] .pill {
+  background: rgba(16, 185, 129, 0.16);
+  color: #0f766e;
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+[data-preset="classy-utility"] {
+  --font-heading: "Public Sans", system-ui, sans-serif;
+  --font-body: "Public Sans", system-ui, sans-serif;
+  --color-background: #f8f9fa;
+  --color-surface: #ffffff;
+  --color-text: #212529;
+  --color-text-strong: #0b1320;
+  --color-accent: #0d6efd;
+  --color-on-accent: #ffffff;
+  --color-border: rgba(33, 37, 41, 0.12);
+  --color-input-bg: #ffffff;
+  --color-focus: rgba(13, 110, 253, 0.35);
+  --preset-shadow: 0 18px 45px -26px rgba(13, 110, 253, 0.45);
+  --preset-btn-shadow: 0 10px 24px -16px rgba(13, 110, 253, 0.35);
+  --preset-btn-shadow-hover: 0 14px 32px -16px rgba(13, 110, 253, 0.45);
+}
+
+[data-preset="classy-utility"] .modal {
+  border-top: 4px solid var(--color-accent);
+}
+
+[data-preset="classy-utility"] .tag-list {
+  gap: 0.25rem;
+}
+
+[data-preset="vibrant-clarity"] {
+  --font-heading: "Lato", "Lato Black", sans-serif;
+  --font-body: "Lato", sans-serif;
+  --color-background: #f7f9fb;
+  --color-surface: #ffffff;
+  --color-text: #1b1c1d;
+  --color-text-strong: #111;
+  --color-accent: #2185d0;
+  --color-on-accent: #ffffff;
+  --color-border: rgba(27, 28, 29, 0.15);
+  --color-input-bg: #ffffff;
+  --color-focus: rgba(33, 133, 208, 0.35);
+  --preset-shadow: 0 20px 48px -30px rgba(27, 28, 29, 0.5);
+  --preset-btn-shadow: 0 12px 26px -18px rgba(33, 133, 208, 0.5);
+  --preset-btn-shadow-hover: 0 18px 36px -20px rgba(100, 53, 201, 0.45);
+}
+
+[data-preset="vibrant-clarity"] .pill {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+}
+
+[data-preset="motion-canvas"] {
+  --font-heading: "Space Grotesk", "Space Grotesk Variable", sans-serif;
+  --font-body: "Manrope", system-ui, sans-serif;
+  --color-background: #0b0d17;
+  --color-surface: #111324;
+  --color-text: rgba(237, 242, 247, 0.85);
+  --color-text-strong: #f7fafc;
+  --color-accent: linear-gradient(120deg, #ff6b6b 0%, #f7b801 80%);
+  --color-on-accent: #0b0d17;
+  --color-border: rgba(99, 102, 241, 0.25);
+  --color-input-bg: rgba(11, 13, 23, 0.85);
+  --color-focus: rgba(247, 184, 1, 0.55);
+  --preset-shadow: 0 28px 80px -26px rgba(255, 107, 107, 0.55);
+  --preset-btn-shadow: 0 16px 36px -18px rgba(247, 184, 1, 0.45);
+  --preset-btn-shadow-hover: 0 20px 44px -16px rgba(95, 173, 86, 0.55);
+  --preset-modal-shadow: 0 30px 90px -20px rgba(255, 107, 107, 0.6);
+  background-image: radial-gradient(circle at 10% 20%, rgba(255, 107, 107, 0.16), transparent 60%),
+    radial-gradient(circle at 70% 20%, rgba(247, 184, 1, 0.12), transparent 55%),
+    radial-gradient(circle at 50% 70%, rgba(95, 173, 86, 0.12), transparent 65%);
+}
+
+[data-preset="motion-canvas"] button.primary {
+  background: linear-gradient(120deg, #ff6b6b, #f7b801 70%);
+  color: #0b0d17;
+}
+
+[data-preset="motion-canvas"] button.secondary {
+  border-color: rgba(95, 173, 86, 0.55);
+  color: rgba(237, 242, 247, 0.88);
+  background: rgba(17, 19, 36, 0.65);
+}
+
+[data-preset="motion-canvas"] .pill {
+  border-radius: 999px;
+  background: rgba(95, 173, 86, 0.22);
+  color: #f7fafc;
+  border-color: rgba(95, 173, 86, 0.55);
+}
+
+/* Reduced motion --------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .preset:hover,
+  button:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}

--- a/docs/ui-presets.md
+++ b/docs/ui-presets.md
@@ -1,0 +1,139 @@
+# Presets graphiques inspirés de bibliothèques populaires
+
+Ce document rassemble plusieurs propositions de presets (combinaisons de couleurs, de typos et d'effets d'interaction) inspirés d'écosystèmes UI répandus tels que Headless UI, Shadcn UI, Radix UI, Bootstrap, Semantic UI et Anime.js. Chaque preset comprend :
+
+- **Palette** : couleurs principales, secondaires et d'accent.
+- **Typographie** : familles et usages recommandés.
+- **Composants clés** : orientations pour buttons, cartes, formulaires, modales.
+- **Interactions** : principes d'animations, micro-interactions et transitions.
+
+👉 **Nouveau : un prototype HTML/CSS accompagnant ces presets est disponible dans [`docs/ui-presets-demo.html`](./ui-presets-demo.html)
+et la feuille de style associée [`docs/ui-presets.css`](./ui-presets.css).**
+
+Les variables CSS sont structurées autour de l’attribut `data-preset` pour faciliter l’intégration dans Storybook, WordPress ou
+des design systems basés sur les custom properties. Les composants du prototype (boutons, cartes, formulaires, modales) se
+stylisent automatiquement via ces tokens.
+
+## 1. Preset « Minimal Focus » (inspiration Headless UI)
+
+- **Palette**
+  - Fond : `#F9FAFB`
+  - Texte primaire : `#111827`
+  - Accent : `#2563EB`
+  - Neutres : `#D1D5DB`, `#6B7280`
+- **Typographie**
+  - Titres : Inter SemiBold, capitalisation minimaliste.
+  - Corps : Inter Regular, 16 px avec leading généreux (1.6).
+- **Composants clés**
+  - Boutons : apparence ghost par défaut, remplissage léger sur hover.
+  - Cartes : bordure 1 px `#E5E7EB`, coins légèrement arrondis (6 px).
+  - Formulaires : champs à fond blanc, focus state très visible (`ring-2` accent).
+  - Modales : centrées, large padding, header discret.
+- **Interactions**
+  - Transitions en `ease-in-out` 150 ms.
+  - Apparition des overlays en fade/scale très léger (1.02).
+
+## 2. Preset « Modern Contrast » (inspiration Shadcn UI)
+
+- **Palette**
+  - Fond : `#0F172A`
+  - Surface secondaire : `#1E293B`
+  - Accent : `#A855F7`
+  - Texte primaire : `#F8FAFC`
+- **Typographie**
+  - Titres : Sora Bold, espacements de lettres resserrés.
+  - Corps : Neue Haas Grotesk Regular, 15 px.
+- **Composants clés**
+  - Boutons : versions solides avec shadow douce + variantes outline contrastées.
+  - Cartes : gradient subtil (`rgba(168,85,247,0.12)` à `rgba(14,165,233,0.08)`).
+  - Formulaires : champs à bordure fluorescente, label flottant.
+  - Modales : navigation latérale avec header collant.
+- **Interactions**
+  - Hover states luminescents (drop shadow colorée).
+  - Reveal animations en slide-up 250 ms, overshoot léger (`cubic-bezier(0.16, 1, 0.3, 1)`).
+
+## 3. Preset « Systemic Elevation » (inspiration Radix UI)
+
+- **Palette**
+  - Fond : `#FFFFFF`
+  - Accent principal : `#0EA5E9`
+  - Accent secondaire : `#10B981`
+  - Fond contrasté : `#F1F5F9`
+- **Typographie**
+  - Titres : IBM Plex Sans Medium.
+  - Corps : Work Sans Regular, 16 px.
+- **Composants clés**
+  - Boutons : focus rings multi-couleurs (bleu + vert) pour l'accessibilité.
+  - Cartes : composables, structure en slots, elevation par shadow `0 10px 30px -12px rgba(15, 23, 42, 0.2)`.
+  - Formulaires : emphasise sur états (error = rouge `#F87171`, success = accent secondaire).
+  - Modales : segmentation claire entre header, body, footer.
+- **Interactions**
+  - Animations orientées accessibilité : transitions de 100 à 200 ms maximum.
+  - Utilisation d'animations discrètes en `transform` plutôt que `opacity` pure.
+
+## 4. Preset « Classy Utility » (inspiration Bootstrap)
+
+- **Palette**
+  - Primaire : `#0D6EFD`
+  - Secondaire : `#6C757D`
+  - Success : `#198754`
+  - Warning : `#FFC107`
+  - Danger : `#DC3545`
+- **Typographie**
+  - Titres : Public Sans SemiBold.
+  - Corps : Public Sans Regular, 1 rem.
+- **Composants clés**
+  - Boutons : déclinables en 6 variantes chromatiques, radius 4 px.
+  - Cartes : header accentué, corps à fond blanc, footer optionnel.
+  - Formulaires : labels alignés, helper text pour validation.
+  - Modales : top header coloré selon contexte (primary, warning, etc.).
+- **Interactions**
+  - Transitions standard 200 ms en `ease`.
+  - Accordion, tabs et tooltips inspirés des patterns bootstrap.
+
+## 5. Preset « Vibrant Clarity » (inspiration Semantic UI)
+
+- **Palette**
+  - Primaire : `#2185D0`
+  - Secondary : `#1B1C1D`
+  - Accent : `#6435C9`
+  - Positive : `#21BA45`
+  - Negative : `#DB2828`
+- **Typographie**
+  - Titres : Lato Black.
+  - Corps : Lato Regular, 15-16 px.
+- **Composants clés**
+  - Boutons : large padding, uppercase optionnel.
+  - Cartes : segments modulables, header avec dividing line.
+  - Formulaires : inline validation, messages colorés.
+  - Modales : slide-down depuis le top avec fond semi-transparent.
+- **Interactions**
+  - Transitions fluides `ease-in-out` 300 ms.
+  - Menus déroulants avec `fade + slide`.
+
+## 6. Preset « Motion Canvas » (inspiration Anime.js)
+
+- **Palette**
+  - Fond : `#0B0D17`
+  - Accent dynamique : `#FF6B6B`
+  - Accent secondaire : `#5FAD56`
+  - Highlights : `#F7B801`
+- **Typographie**
+  - Titres : Space Grotesk Bold, tailles XXL pour hero/landing.
+  - Corps : Manrope Regular, 16 px.
+- **Composants clés**
+  - Boutons : grands CTA avec gradient animé.
+  - Cartes : mise en avant par animations vectorielles (lignes, particules).
+  - Formulaires : transitions progressives champ par champ.
+  - Modales : plein écran, background animé en boucle lente.
+- **Interactions**
+  - Effets `motion path`, `stagger` et `spring` (Anime.js) sur les listes.
+  - Scroll-triggered animations : parallax léger sur sections.
+  - Prévoir un mode réduit (réduction des animations pour accessibilité).
+
+## Recommandations générales d'implémentation
+
+1. **Systèmes de tokens** : centraliser les couleurs, typographies et radii dans un fichier de variables (CSS custom properties ou design tokens JSON) pour permettre la dérivation rapide de chaque preset.
+2. **Thématisation** : adopter une architecture CSS modulable (CSS-in-JS, Tailwind config, ou design tokens + utilitaires) afin de basculer d'un preset à l'autre en surchargeant les variables.
+3. **Accessibilité** : vérifier les contrastes (WCAG AA minimum), prévoir des focus visibles et des options pour réduire les animations.
+4. **Documentation** : fournir pour chaque preset un Storybook ou une page de démonstration avec exemples de composants clefs et instructions d'intégration.


### PR DESCRIPTION
## Summary
- add reusable CSS variables for six UI presets covering colors, typography, elevation, and focus states
- create an HTML prototype that showcases buttons, forms, tags, and modals themed via `data-preset`
- update the documentation to point to the new demo and explain how to integrate the presets

## Testing
- not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68e62fd6c28c832eaa57cb112303f16b